### PR TITLE
Local build generate non consumable pom files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.flattened-pom.xml
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>flatten</id>
-						<phase>process-resources</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>flatten</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,31 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
             </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.1.0</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@ under the License.
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
-				<version>1.1.0</version>
+				<version>1.5.0</version>
 				<configuration>
 					<updatePomFile>true</updatePomFile>
 					<flattenMode>resolveCiFriendliesOnly</flattenMode>
@@ -331,7 +331,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>flatten</id>
-						<phase>package</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>flatten</goal>
 						</goals>


### PR DESCRIPTION
Current main branch build generate having POM containing ${revision} has version. 

![Screenshot 2024-04-30 at 5 26 57 PM](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/assets/3120359/95b75c54-8814-489c-a12c-45875b68e287)


This is neatly explained in the official maven documentation: https://maven.apache.org/maven-ci-friendly.html#install-deploy I updated main pom with official suggestion. Currently it works on my machine.