### PR TITLE
Increase sink max parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ can also be used by the serializer if needed (for instance, the AvroToProtoSeria
 * Flink cannot automatically serialize avro's GenericRecord, hence users must explicitly specify type information 
 when using the AvroToProtoSerializer. Check Flink's [blog on non-trivial serialization](https://nightlies.apache.org/flink/flink-docs-release-1.17/api/java/org/apache/flink/connector/base/DeliveryGuarantee.html#AT_LEAST_ONCE). 
 Note that the avro schema needed here can be obtained from BigQuerySchemaProvider.
-* The maximum parallelism of BigQuery sinks has been capped at 100. This is to respect BigQuery storage 
+* The maximum parallelism of BigQuery sinks has been capped at 128. This is to respect BigQuery storage 
 [write quotas](https://cloud.google.com/bigquery/quotas#write-api-limits) while adhering to 
 [best usage practices](https://cloud.google.com/bigquery/docs/write-api-best-practices). Users should either set 
 [sink level parallelism](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/datastream/execution/parallel/#operator-level) 
-explicitly, or ensure that default job level parallelism is under 100.
+explicitly, or ensure that default job level parallelism is under 128.
 * Users are recommended to choose their application's [restart strategy](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/ops/state/task_failure_recovery/) 
 wisely, so as to avoid incessant retries which can potentially disrupt the BigQuery Storage API backend. Regardless of which 
 strategy is adopted, the restarts must be finite and graciously spaced.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -32,10 +32,11 @@ abstract class BigQueryBaseSink implements Sink {
     // BigQuery write streams can offer over 10 MBps throughput, and per project throughput quotas
     // are in the order of single digit GBps. With each sink writer maintaining a single and unique
     // write connection to BigQuery, maximum parallelism for sink is intentionally restricted to
-    // 100 for initial releases of this connector.
+    // 128 for initial releases of this connector. This is also the default max parallelism of
+    // Flink applications.
     // Based on performance observations and user feedback, this number can be increased in the
     // future.
-    public static final int MAX_SINK_PARALLELISM = 100;
+    public static final int MAX_SINK_PARALLELISM = 128;
 
     final BigQueryConnectOptions connectOptions;
     final BigQuerySchemaProvider schemaProvider;

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
@@ -107,7 +107,7 @@ public class BigQueryDefaultSinkTest {
     public void testCreateMoreWritersThanAllowed() throws IOException {
         InitContext mockedContext = Mockito.mock(InitContext.class);
         Mockito.when(mockedContext.getSubtaskId()).thenReturn(1);
-        Mockito.when(mockedContext.getNumberOfParallelSubtasks()).thenReturn(101);
+        Mockito.when(mockedContext.getNumberOfParallelSubtasks()).thenReturn(129);
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
                         .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))


### PR DESCRIPTION
Accept Flink's default maximum parallelism of 128.