### PR TITLE
fix: BQ partition utils intervals

### DIFF
--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/BigQueryPartitionUtils.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/BigQueryPartitionUtils.java
@@ -180,7 +180,7 @@ public class BigQueryPartitionUtils {
 
     static String dateRestrictionFromPartitionType(
             PartitionType partitionType, String columnName, String valueFromSQL) {
-        String temporalFormat = "%s BETWEEN '%s' AND '%s'";
+        String temporalFormat = "%s >= '%s' AND %s < '%s'";
         try {
             switch (partitionType) {
                 case DAY:
@@ -192,6 +192,7 @@ public class BigQueryPartitionUtils {
                                 temporalFormat,
                                 columnName,
                                 SQL_DAY_FORMAT.format(day),
+                                columnName,
                                 SQL_DAY_FORMAT.format(
                                         Date.from(day.toInstant().plusSeconds(DAY_SECONDS))));
                     }
@@ -204,6 +205,7 @@ public class BigQueryPartitionUtils {
                                 temporalFormat,
                                 columnName,
                                 SQL_MONTH_FORMAT.format(day),
+                                columnName,
                                 DateTimeFormatter.ofPattern(SQL_DAY_FORMAT_STRING)
                                         .withZone(UTC_ZONE)
                                         .format(
@@ -223,6 +225,7 @@ public class BigQueryPartitionUtils {
                                 temporalFormat,
                                 columnName,
                                 SQL_YEAR_FORMAT.format(day),
+                                columnName,
                                 DateTimeFormatter.ofPattern(SQL_YEAR_FORMAT_STRING)
                                         .withZone(UTC_ZONE)
                                         .format(
@@ -254,7 +257,7 @@ public class BigQueryPartitionUtils {
                                 DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
                                         .withZone(UTC_ZONE))
                         .atZone(UTC_ZONE);
-        String temporalFormat = "%s BETWEEN '%s' AND '%s'";
+        String temporalFormat = "%s >= '%s' AND %s < '%s'";
         switch (partitionType) {
             case HOUR:
                 {
@@ -266,6 +269,7 @@ public class BigQueryPartitionUtils {
                             temporalFormat,
                             columnName,
                             parsedDateTime.format(hourFormatter),
+                            columnName,
                             parsedDateTime.plusHours(1).format(hourFormatter));
                 }
             case DAY:
@@ -278,6 +282,7 @@ public class BigQueryPartitionUtils {
                             temporalFormat,
                             columnName,
                             parsedDateTime.format(dayFormatter),
+                            columnName,
                             parsedDateTime.plusDays(1).format(dayFormatter));
                 }
             case MONTH:
@@ -290,6 +295,7 @@ public class BigQueryPartitionUtils {
                             temporalFormat,
                             columnName,
                             parsedDateTime.format(monthFormatter),
+                            columnName,
                             parsedDateTime.plusMonths(1).format(monthFormatter));
                 }
             case YEAR:
@@ -302,6 +308,7 @@ public class BigQueryPartitionUtils {
                             temporalFormat,
                             columnName,
                             parsedDateTime.format(yearFormatter),
+                            columnName,
                             parsedDateTime.plusYears(1).format(yearFormatter));
                 }
             default:

--- a/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/common/utils/BigQueryPartitionUtilsTest.java
+++ b/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/common/utils/BigQueryPartitionUtilsTest.java
@@ -449,7 +449,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoDateDay() {
-        String expected = "dragon BETWEEN '2023-01-02' AND '2023-01-03'";
+        String expected = "dragon >= '2023-01-02' AND dragon < '2023-01-03'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -466,7 +466,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoDateMonth() {
-        String expected = "dragon BETWEEN '2023-01-01' AND '2023-02-01'";
+        String expected = "dragon >= '2023-01-01' AND dragon < '2023-02-01'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -483,7 +483,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoDateYear() {
-        String expected = "dragon BETWEEN '2023-01-01' AND '2024-01-01'";
+        String expected = "dragon >= '2023-01-01' AND dragon < '2024-01-01'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -500,7 +500,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoTimestampHour() {
-        String expected = "dragon BETWEEN '2023-01-01 03:00:00' AND '2023-01-01 04:00:00'";
+        String expected = "dragon >= '2023-01-01 03:00:00' AND dragon < '2023-01-01 04:00:00'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -517,7 +517,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoTimestampDay() {
-        String expected = "dragon BETWEEN '2023-01-01 00:00:00' AND '2023-01-02 00:00:00'";
+        String expected = "dragon >= '2023-01-01 00:00:00' AND dragon < '2023-01-02 00:00:00'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -534,7 +534,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoTimestampMonth() {
-        String expected = "dragon BETWEEN '2023-01-01 00:00:00' AND '2023-02-01 00:00:00'";
+        String expected = "dragon >= '2023-01-01 00:00:00' AND dragon < '2023-02-01 00:00:00'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(
@@ -551,7 +551,7 @@ public class BigQueryPartitionUtilsTest {
 
     @Test
     public void testFormatPartitionRestrictionBasedOnInfoTimestampYear() {
-        String expected = "dragon BETWEEN '2023-01-01 00:00:00' AND '2024-01-01 00:00:00'";
+        String expected = "dragon >= '2023-01-01 00:00:00' AND dragon < '2024-01-01 00:00:00'";
         String actual =
                 BigQueryPartitionUtils.formatPartitionRestrictionBasedOnInfo(
                         Optional.of(


### PR DESCRIPTION
👋 been having an issue with the query restriction generated by the connector when running in unbounded mode.

The BETWEEN operator is inclusive: begin and end values are included.  this causes the source connector to read some of the data twice.

This change should fix that, let me know if there's any test I may have missed !