### PR TITLE
Add signatures for exactly once sink

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Base class for developing a BigQuery sink. */
-abstract class BigQueryBaseSink implements Sink {
+abstract class BigQueryBaseSink<IN> implements Sink<IN> {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -23,10 +23,10 @@ import com.google.cloud.flink.bigquery.sink.writer.BigQueryDefaultWriter;
 /**
  * Sink to write data into a BigQuery table using {@link BigQueryDefaultWriter}.
  *
- * <p>Depending on the checkpointing mode, this sink will offer at-least-once consistency guarantee.
+ * <p>Depending on the checkpointing mode, this sink offers following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: at-least-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
- * <li>Checkpointing disabled: no consistency guarantee.
+ * <li>Checkpointing disabled (NOT RECOMMENDED!): no consistency guarantee.
  */
 class BigQueryDefaultSink extends BigQueryBaseSink {
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -23,7 +23,7 @@ import com.google.cloud.flink.bigquery.sink.writer.BigQueryDefaultWriter;
 /**
  * Sink to write data into a BigQuery table using {@link BigQueryDefaultWriter}.
  *
- * <p>Depending on the checkpointing mode, this sink offers following consistency guarantees:
+ * <p>Depending on the checkpointing mode, this sink offers the following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: at-least-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
  * <li>Checkpointing disabled (NOT RECOMMENDED!): no consistency guarantee.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 /**
  * Sink to write data into a BigQuery table using {@link BigQueryBufferedWriter}.
  *
- * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
+ * <p>Depending on the checkpointing mode, this writer offers the following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: exactly-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
  * <li>Checkpointing disabled: no consistency guarantee.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import com.google.cloud.flink.bigquery.sink.committer.BigQueryCommittable;
+import com.google.cloud.flink.bigquery.sink.writer.BigQueryWriterState;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Sink to write data into a BigQuery table using {@link BigQueryBufferedWriter}.
+ *
+ * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
+ * <li>{@link CheckpointingMode#EXACTLY_ONCE}: exactly-once write consistency.
+ * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
+ * <li>Checkpointing disabled: no consistency guarantee.
+ *
+ * @param <IN> Type of records written to BigQuery
+ */
+public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
+        implements TwoPhaseCommittingStatefulSink<IN, BigQueryWriterState, BigQueryCommittable> {
+
+    BigQueryExactlyOnceSink(BigQuerySinkConfig sinkConfig) {
+        super(sinkConfig);
+    }
+
+    @Override
+    public PrecommittingStatefulSinkWriter<IN, BigQueryWriterState, BigQueryCommittable>
+            createWriter(InitContext context) throws IOException {
+        throw new UnsupportedOperationException("createWriter not implemented");
+    }
+
+    @Override
+    public PrecommittingStatefulSinkWriter<IN, BigQueryWriterState, BigQueryCommittable>
+            restoreWriter(InitContext context, Collection<BigQueryWriterState> recoveredState)
+                    throws IOException {
+        throw new UnsupportedOperationException("restoreWriter not implemented");
+    }
+
+    @Override
+    public Committer<BigQueryCommittable> createCommitter() throws IOException {
+        throw new UnsupportedOperationException("createCommitter not implemented");
+    }
+
+    @Override
+    public SimpleVersionedSerializer<BigQueryCommittable> getCommittableSerializer() {
+        throw new UnsupportedOperationException("getCommittableSerializer not implemented");
+    }
+
+    @Override
+    public SimpleVersionedSerializer<BigQueryWriterState> getWriterStateSerializer() {
+        throw new UnsupportedOperationException("getWriterStateSerializer not implemented");
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -29,12 +29,13 @@ import org.slf4j.LoggerFactory;
  * <p>With {@link DeliveryGuarantee#AT_LEAST_ONCE}, the Sink added to Flink job will be {@link
  * BigQueryDefaultSink}.
  *
- * <p>Eventual data consistency at destination is also dependent on checkpointing mode. With {@link
- * CheckpointingMode#AT_LEAST_ONCE} or {@link CheckpointingMode#EXACTLY_ONCE}, the {@link
- * BigQueryDefaultSink} will offer at-least-once consistency. We recommend enabling checkpointing to
- * avoid any unexpected behavior.
+ * <p>With {@link DeliveryGuarantee#EXACTLY_ONCE}, the Sink added to Flink job will be {@link
+ * BigQueryExactlyOnceSink}.
  *
- * <p>Support for exactly-once consistency in BigQuerySink will be offered soon!
+ * <p>Eventual data consistency at destination is also dependent on checkpointing mode. Look at
+ * {@link BigQueryDefaultSink} and {@link BigQueryExactlyOnceSink} for write consistencies offered
+ * across combinations of {@link CheckpointingMode} and sink's {@link DeliveryGuarantee}. It is
+ * recommended that checkpointing is enabled to avoid unexpected behavior.
  */
 public class BigQuerySink {
 
@@ -44,8 +45,11 @@ public class BigQuerySink {
         if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.AT_LEAST_ONCE) {
             return new BigQueryDefaultSink(sinkConfig);
         }
+        if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.EXACTLY_ONCE) {
+            return new BigQueryExactlyOnceSink(sinkConfig);
+        }
         LOG.error(
-                "Only at-least-once write consistency is supported in BigQuery sink. Found {}",
+                "BigQuery sink does not support {} delivery guarantee. Use AT_LEAST_ONCE or EXACTLY_ONCE.",
                 sinkConfig.getDeliveryGuarantee());
         throw new UnsupportedOperationException(
                 String.format("%s is not supported", sinkConfig.getDeliveryGuarantee()));

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/TwoPhaseCommittingStatefulSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/TwoPhaseCommittingStatefulSink.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * A combination of {@link TwoPhaseCommittingSink} and {@link StatefulSink}.
+ *
+ * <p>Interface for a sink that supports TPC protocol and statefulness.
+ *
+ * @param <IN> Type of the sink's input.
+ * @param <WriterStateT> Type of the sink writer's state.
+ * @param <CommittableT> Type of the committables.
+ */
+@Internal
+public interface TwoPhaseCommittingStatefulSink<IN, WriterStateT, CommittableT>
+        extends TwoPhaseCommittingSink<IN, CommittableT>, StatefulSink<IN, WriterStateT> {
+
+    @Override
+    PrecommittingStatefulSinkWriter<IN, WriterStateT, CommittableT> createWriter(
+            Sink.InitContext context) throws IOException;
+
+    @Override
+    PrecommittingStatefulSinkWriter<IN, WriterStateT, CommittableT> restoreWriter(
+            Sink.InitContext context, Collection<WriterStateT> recoveredState) throws IOException;
+
+    /**
+     * A combination of {@link PrecommittingSinkWriter} and {@link StatefulSinkWriter}.
+     *
+     * <p>Interface for a writer that supports TPC protocol and statefulness.
+     *
+     * @param <IN> Type of the sink's input.
+     * @param <WriterStateT> Type of the sink writer's state.
+     * @param <CommittableT> Type of the committables.
+     */
+    interface PrecommittingStatefulSinkWriter<IN, WriterStateT, CommittableT>
+            extends TwoPhaseCommittingSink.PrecommittingSinkWriter<IN, CommittableT>,
+                    StatefulSink.StatefulSinkWriter<IN, WriterStateT> {}
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittable.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.committer;
+
+import com.google.cloud.flink.bigquery.sink.state.BigQueryStreamState;
+
+/**
+ * Information required for a commit operation, passed from {@link BigQueryBufferedWriter} to {@link
+ * BigQueryCommitter}.
+ */
+public class BigQueryCommittable extends BigQueryStreamState {
+
+    private final long producerId;
+
+    public BigQueryCommittable(long producerId, String streamName, long streamOffset) {
+        super(streamName, streamOffset);
+        this.producerId = producerId;
+    }
+
+    public long getProducerId() {
+        return producerId;
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittableSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittableSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.committer;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/** Serializer and deserializer for {@link BigQueryCommittable}. */
+public class BigQueryCommittableSerializer
+        implements SimpleVersionedSerializer<BigQueryCommittable> {
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public byte[] serialize(BigQueryCommittable committable) throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeLong(committable.getProducerId());
+            out.writeUTF(committable.getStreamName());
+            out.writeLong(committable.getStreamOffset());
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public BigQueryCommittable deserialize(int version, byte[] serialized) throws IOException {
+        try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                final DataInputStream in = new DataInputStream(bais)) {
+            final Long producerId = in.readLong();
+            final String streamName = in.readUTF();
+            final long streamOffset = in.readLong();
+            BigQueryCommittable committable =
+                    new BigQueryCommittable(producerId, streamName, streamOffset);
+            return committable;
+        }
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommitter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommitter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.committer;
+
+import org.apache.flink.api.connector.sink2.Committer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Committer implementation for {@link BigQueryExactlyOnceSink}.
+ *
+ * <p>The committer is responsible for committing records buffered in BigQuery write stream to
+ * BigQuery table.
+ */
+public class BigQueryCommitter implements Committer<BigQueryCommittable>, Closeable {
+
+    @Override
+    public void commit(Collection<CommitRequest<BigQueryCommittable>> commitRequests)
+            throws IOException, InterruptedException {}
+
+    @Override
+    public void close() {}
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/state/BigQueryStreamState.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/state/BigQueryStreamState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.state;
+
+/** State representation of a BigQuery write stream. */
+public abstract class BigQueryStreamState {
+
+    protected final String streamName;
+    protected final long streamOffset;
+
+    public BigQueryStreamState(String streamName, long streamOffset) {
+        this.streamName = streamName;
+        this.streamOffset = streamOffset;
+    }
+
+    public String getStreamName() {
+        return streamName;
+    }
+
+    public long getStreamOffset() {
+        return streamOffset;
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/Throttler.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/Throttler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.throttle;
+
+/** Limits the rate at which an operation can be performed. */
+public interface Throttler {
+
+    /** Limits the rate by waiting if necessary. */
+    void throttle();
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -42,7 +42,7 @@ import java.util.List;
  *
  * <p>Records are grouped to maximally utilize the BigQuery append request's payload.
  *
- * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
+ * <p>Depending on the checkpointing mode, this writer offers the following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: exactly-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
  * <li>{Checkpointing disabled}: no write consistency.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.writer;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ProtoRows;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.sink.TwoPhaseCommittingStatefulSink;
+import com.google.cloud.flink.bigquery.sink.committer.BigQueryCommittable;
+import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
+import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Writer implementation for {@link BigQueryBufferedSink}.
+ *
+ * <p>This writer appends records to the BigQuery table's buffered write stream. This means that
+ * records are buffered in the stream until flushed (BigQuery write API, different from sink
+ * writer's flush). Records will be written to the destination table after the BigQuery flush API is
+ * invoked by {@link BigQueryCommitter}, at which point it will be available for querying.
+ *
+ * <p>In case of stream replay upon failure recovery, previously buffered data will be discarded and
+ * records will be buffered again from the latest checkpoint.
+ *
+ * <p>Records are grouped to maximally utilize the BigQuery append request's payload.
+ *
+ * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
+ * <li>{@link CheckpointingMode#EXACTLY_ONCE}: exactly-once write consistency.
+ * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
+ * <li>{Checkpointing disabled}: no write consistency.
+ *
+ * @param <IN> Type of records to be written to BigQuery.
+ */
+public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
+        implements TwoPhaseCommittingStatefulSink.PrecommittingStatefulSinkWriter<
+                IN, BigQueryWriterState, BigQueryCommittable> {
+
+    public BigQueryBufferedWriter(
+            int subtaskId,
+            BigQueryConnectOptions connectOptions,
+            BigQuerySchemaProvider schemaProvider,
+            BigQueryProtoSerializer serializer) {
+        super(subtaskId, connectOptions, schemaProvider, serializer);
+    }
+
+    @Override
+    public void write(IN element, Context context) throws IOException, InterruptedException {
+        throw new UnsupportedOperationException("write not implemented");
+    }
+
+    @Override
+    ApiFuture sendAppendRequest(ProtoRows protoRows) {
+        throw new UnsupportedOperationException("sendAppendRequest not implemented");
+    }
+
+    @Override
+    void validateAppendResponse(ApiFuture<AppendRowsResponse> appendResponseFuture) {
+        throw new UnsupportedOperationException("validateAppendResponse not implemented");
+    }
+
+    @Override
+    public Collection<BigQueryCommittable> prepareCommit()
+            throws IOException, InterruptedException {
+        throw new UnsupportedOperationException("prepareCommit not implemented");
+    }
+
+    @Override
+    public List<BigQueryWriterState> snapshotState(long checkpointId) throws IOException {
+        throw new UnsupportedOperationException("snapshotState not implemented");
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -40,8 +40,7 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Records are grouped to maximally utilize the BigQuery append request's payload.
  *
- * <p>Depending on the checkpointing mode, this writer offers either at-least-once or at-most-once
- * consistency guarantee.
+ * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: at-least-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
  * <li>{Checkpointing disabled}: no write consistency.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Records are grouped to maximally utilize the BigQuery append request's payload.
  *
- * <p>Depending on the checkpointing mode, this writer offers following consistency guarantees:
+ * <p>Depending on the checkpointing mode, this writer offers the following consistency guarantees:
  * <li>{@link CheckpointingMode#EXACTLY_ONCE}: at-least-once write consistency.
  * <li>{@link CheckpointingMode#AT_LEAST_ONCE}: at-least-once write consistency.
  * <li>{Checkpointing disabled}: no write consistency.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterState.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterState.java
@@ -22,11 +22,18 @@ import com.google.cloud.flink.bigquery.sink.state.BigQueryStreamState;
 public class BigQueryWriterState extends BigQueryStreamState {
 
     // Used for Flink metrics.
+    private long totalRecordsSeen;
     private long totalRecordsWritten;
 
-    public BigQueryWriterState(String streamName, long streamOffset, long totalRecordsWritten) {
+    public BigQueryWriterState(
+            String streamName, long streamOffset, long totalRecordsSeen, long totalRecordsWritten) {
         super(streamName, streamOffset);
+        this.totalRecordsSeen = totalRecordsSeen;
         this.totalRecordsWritten = totalRecordsWritten;
+    }
+
+    public long getTotalRecordsSeen() {
+        return totalRecordsSeen;
     }
 
     public long getTotalRecordsWritten() {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterState.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterState.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.writer;
+
+import com.google.cloud.flink.bigquery.sink.state.BigQueryStreamState;
+
+/** State representation of a {@link BigQueryBufferedWriter}. */
+public class BigQueryWriterState extends BigQueryStreamState {
+
+    // Used for Flink metrics.
+    private long totalRecordsWritten;
+
+    public BigQueryWriterState(String streamName, long streamOffset, long totalRecordsWritten) {
+        super(streamName, streamOffset);
+        this.totalRecordsWritten = totalRecordsWritten;
+    }
+
+    public long getTotalRecordsWritten() {
+        return totalRecordsWritten;
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializer.java
@@ -39,6 +39,7 @@ public class BigQueryWriterStateSerializer
                 final DataOutputStream out = new DataOutputStream(baos)) {
             out.writeUTF(state.getStreamName());
             out.writeLong(state.getStreamOffset());
+            out.writeLong(state.getTotalRecordsSeen());
             out.writeLong(state.getTotalRecordsWritten());
             out.flush();
             return baos.toByteArray();
@@ -51,8 +52,10 @@ public class BigQueryWriterStateSerializer
                 final DataInputStream in = new DataInputStream(bais)) {
             final String streamName = in.readUTF();
             final long streamOffset = in.readLong();
+            final long totalRecordsSeen = in.readLong();
             final long totalRecordsWritten = in.readLong();
-            return new BigQueryWriterState(streamName, streamOffset, totalRecordsWritten);
+            return new BigQueryWriterState(
+                    streamName, streamOffset, totalRecordsSeen, totalRecordsWritten);
         }
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.writer;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/** Serializer and deserializer for {@link BigQueryWriterState}. */
+public class BigQueryWriterStateSerializer
+        implements SimpleVersionedSerializer<BigQueryWriterState> {
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public byte[] serialize(BigQueryWriterState state) throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeUTF(state.getStreamName());
+            out.writeLong(state.getStreamOffset());
+            out.writeLong(state.getTotalRecordsWritten());
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public BigQueryWriterState deserialize(int version, byte[] serialized) throws IOException {
+        try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                final DataInputStream in = new DataInputStream(bais)) {
+            final String streamName = in.readUTF();
+            final long streamOffset = in.readLong();
+            final long totalRecordsWritten = in.readLong();
+            return new BigQueryWriterState(streamName, streamOffset, totalRecordsWritten);
+        }
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
@@ -55,7 +55,6 @@ public class BigQuerySinkTest {
         assertNotNull(BigQuerySink.get(sinkConfig, null));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
     public void testExactlyOnceNotSupported() throws IOException {
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittableSerializerTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/committer/BigQueryCommittableSerializerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.committer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link BigQueryCommittableSerializer}. */
+public class BigQueryCommittableSerializerTest {
+
+    private static final BigQueryCommittableSerializer INSTANCE =
+            new BigQueryCommittableSerializer();
+    private static final BigQueryCommittable COMMITTABLE = new BigQueryCommittable(12, "foo", 1996);
+
+    @Test
+    public void testSerde() throws IOException {
+        byte[] ser = INSTANCE.serialize(COMMITTABLE);
+        BigQueryCommittable de = INSTANCE.deserialize(INSTANCE.getVersion(), ser);
+        assertEquals(12, de.getProducerId());
+        assertEquals("foo", de.getStreamName());
+        assertEquals(1996, de.getStreamOffset());
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializerTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializerTest.java
@@ -27,7 +27,8 @@ public class BigQueryWriterStateSerializerTest {
 
     private static final BigQueryWriterStateSerializer INSTANCE =
             new BigQueryWriterStateSerializer();
-    private static final BigQueryWriterState STATE = new BigQueryWriterState("foo", 1996, 23456);
+    private static final BigQueryWriterState STATE =
+            new BigQueryWriterState("foo", 1996, 24000, 23000);
 
     @Test
     public void testSerde() throws IOException {
@@ -35,6 +36,7 @@ public class BigQueryWriterStateSerializerTest {
         BigQueryWriterState de = INSTANCE.deserialize(INSTANCE.getVersion(), ser);
         assertEquals("foo", de.getStreamName());
         assertEquals(1996, de.getStreamOffset());
-        assertEquals(23456, de.getTotalRecordsWritten());
+        assertEquals(24000, de.getTotalRecordsSeen());
+        assertEquals(23000, de.getTotalRecordsWritten());
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializerTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryWriterStateSerializerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.writer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link BigQueryWriterStateSerializer}. */
+public class BigQueryWriterStateSerializerTest {
+
+    private static final BigQueryWriterStateSerializer INSTANCE =
+            new BigQueryWriterStateSerializer();
+    private static final BigQueryWriterState STATE = new BigQueryWriterState("foo", 1996, 23456);
+
+    @Test
+    public void testSerde() throws IOException {
+        byte[] ser = INSTANCE.serialize(STATE);
+        BigQueryWriterState de = INSTANCE.deserialize(INSTANCE.getVersion(), ser);
+        assertEquals("foo", de.getStreamName());
+        assertEquals(1996, de.getStreamOffset());
+        assertEquals(23456, de.getTotalRecordsWritten());
+    }
+}


### PR DESCRIPTION
Interfaces and classes that define the structure of exactly-once sink feature.

/gcbrun