### PR TITLE
Included an unshaded guava specifically for BigQuery usage.

### DIFF
--- a/flink-connector-bigquery-common/pom.xml
+++ b/flink-connector-bigquery-common/pom.xml
@@ -55,6 +55,13 @@ under the License.
             <artifactId>google-cloud-bigquery</artifactId>
         </dependency>
 
+        <!-- Not directly consumed, kept for shading -->
+        <!-- This will be a different version of guava than the one used by Flink -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <!-- org.apache.avro - used by SchemaTransform -->
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@ under the License.
     <properties>
         <revision>0.4-SNAPSHOT</revision>
         <flink.version>1.17.1</flink.version>
+        <bigquery.guava.version>32.1.3-jre</bigquery.guava.version>
         <google-lib-bom.version>26.33.0</google-lib-bom.version>
 
         <junit5.version>5.9.3</junit5.version>
@@ -173,6 +174,13 @@ under the License.
                 <version>${google-lib-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- The guava version used by BigQuery, not Flink -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${bigquery.guava.version}</version>
             </dependency>
 
             <!-- Utilities -->
@@ -347,32 +355,49 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.guava:guava:*</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>flatten-maven-plugin</artifactId>
-				<version>1.5.0</version>
-				<configuration>
-					<updatePomFile>true</updatePomFile>
-					<flattenMode>resolveCiFriendliesOnly</flattenMode>
-				</configuration>
-				<executions>
-					<execution>
-						<id>flatten</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>flatten</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>flatten.clean</id>
-						<phase>clean</phase>
-						<goals>
-							<goal>clean</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>


### PR DESCRIPTION
Note that the guava versions used by Flink and BigQuery can be incompatible with each other. The final uber jar of a consumer should include both shaded versions so that Flink and BigQuery connectors can function correctly with their own guava dependency. Without this, Maven will resolve to a single version of guava randomly picked from some transitive dependency and may result in runtime exceptions of a Flink job.

Minor: expanded tabs to whitespaces for the touched poms.

Before the change, guava is a transitive dep (introduced by BigQuery storage) of this project (common jar):
<img width="814" alt="Screenshot 2024-10-28 at 11 09 11 AM" src="https://github.com/user-attachments/assets/e376257c-44af-4def-adf7-202bdd105a9e">

After the change, guava is a direct dep (introduced by the common jar of this project):
<img width="820" alt="Screenshot 2024-10-28 at 1 51 12 PM" src="https://github.com/user-attachments/assets/80005038-ad4a-4d51-98c5-19c30a543666">

The build process (top-right), new jar structure (bot-left) and the old jar structure (bot-right):
<img width="2495" alt="Screenshot 2024-10-28 at 4 08 39 PM" src="https://github.com/user-attachments/assets/2b329871-a5c5-4e8f-9c18-fb6649122f8d">

You can see that the only addition is the guava jar, which looks like this:
<img width="306" alt="Screenshot 2024-10-28 at 4 09 57 PM" src="https://github.com/user-attachments/assets/38d1acfd-97fa-434b-a658-e524ab2cd890">

