### PR TITLE
remove dropwizard dependency from bq source

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-examples/pom.xml
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-examples/pom.xml
@@ -86,7 +86,6 @@ under the License.
                                 <includes>
                                     <include>org.apache.flink:flink-connector-bigquery</include>
                                     <include>org.apache.flink:flink-avro</include>
-                                    <include>org.apache.flink:flink-metrics-dropwizard</include>
                                     <include>com.google.*:*</include>
                                     <include>commons-codec:commons-codec</include>    
                                     <include>dev.failsafe:*</include>                                
@@ -97,7 +96,6 @@ under the License.
                                     <include>com.fasterxml.jackson.*:*</include>
                                     <include>org.threeten:*</include>
                                     <include>org.checkerframework:*</include>
-                                    <include>io.dropwizard.metrics:*</include>
                                     <include>io.grpc:*</include>
                                     <include>io.opencensus:*</include>
                                     <include>io.perfmark:*</include>

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-table-api-examples/pom.xml
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-table-api-examples/pom.xml
@@ -91,7 +91,6 @@ under the License.
                                 <includes>
                                     <include>org.apache.flink:flink-connector-bigquery</include>
                                     <include>org.apache.flink:flink-avro</include>
-                                    <include>org.apache.flink:flink-metrics-dropwizard</include>
                                     <include>com.google.*:*</include>
                                     <include>commons-codec:commons-codec</include>    
                                     <include>dev.failsafe:*</include>                                
@@ -102,7 +101,6 @@ under the License.
                                     <include>com.fasterxml.jackson.*:*</include>
                                     <include>org.threeten:*</include>
                                     <include>org.checkerframework:*</include>
-                                    <include>io.dropwizard.metrics:*</include>
                                     <include>io.grpc:*</include>
                                     <include>io.opencensus:*</include>
                                     <include>io.perfmark:*</include>

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -82,11 +82,6 @@ under the License.
             <artifactId>flink-avro</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-metrics-dropwizard</artifactId>
-        </dependency>
-
         <!-- Table ecosystem -->
         <!-- Projects depending on this project won't depend on flink-table-*. -->
         <dependency>

--- a/flink-1.17-connector-bigquery/pom.xml
+++ b/flink-1.17-connector-bigquery/pom.xml
@@ -107,12 +107,6 @@ under the License.
 
             <dependency>
                 <groupId>org.apache.flink</groupId>
-                <artifactId>flink-metrics-dropwizard</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.flink</groupId>
                 <artifactId>flink-shaded-force-shading</artifactId>
                 <version>${flink.shaded.version}</version>
             </dependency>


### PR DESCRIPTION
For context on why we want to remove this dep:  #185 

This means that we will no longer record the `readSplitTime` histogram metric. We believe this is a reasonable tradeoff since read split times are still logged and read times can be monitored on the service side.