### PR TITLE
Created Avro Schema to BigQuerySchema Convertor

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
@@ -107,6 +107,7 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
         Schema recordSchema = element.getSchema();
         DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
         // Get a record's field schema and find the field descriptor for each field one by one.
+        // TODO: Allow Avro schema to be of other named types apart from RECORD: ENUM and FIXED
         for (Schema.Field field : recordSchema.getFields()) {
             // In case no field descriptor exists for the field, throw an error as we have
             // incompatible schemas.

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/AvroToBigQuerySchemaTransform.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/AvroToBigQuerySchemaTransform.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.common.utils;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import org.apache.avro.LogicalTypes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for transforming Avro {@link org.apache.avro.Schema} to BigQuery {@link Schema}.
+ */
+public class AvroToBigQuerySchemaTransform {
+    /**
+     * Maximum nesting level for BigQuery schemas (15 levels). See <a
+     * href="https://cloud.google.com/bigquery/docs/nested-repeated#limitations">BigQuery nested and
+     * repeated field limitations</a>.
+     */
+    private static final int MAX_NESTED_LEVEL = 15;
+
+    /**
+     * A list of Avro schema TYPES that have a "name" property. We can only create BigQuery Fields
+     * for these
+     */
+    private static final List<org.apache.avro.Schema.Type> AVRO_TYPES_WITH_NAME =
+            new ArrayList<>(
+                    Arrays.asList(
+                            org.apache.avro.Schema.Type.RECORD,
+                            org.apache.avro.Schema.Type.ENUM,
+                            org.apache.avro.Schema.Type.FIXED));
+
+    /**
+     * Converts an Avro schema to a BigQuery schema.
+     *
+     * <p>This method transforms an Avro {@link org.apache.avro.Schema} into a BigQuery {@link
+     * Schema}. It iterates through the fields of the Avro schema, converts each field to its
+     * BigQuery equivalent, and constructs a BigQuery schema with the resulting fields.
+     *
+     * <p>For each Avro field, the method extracts the field's name, documentation (if available),
+     * and default value (if available), and uses this information to build the corresponding
+     * BigQuery field.
+     *
+     * <p>The Avro schema **must** define a name along with the datatype to be converted to a
+     * BigQuery schema
+     *
+     * @param avroSchema The Avro schema to convert.
+     * @return The converted BigQuery {@link Schema}.
+     */
+    public static Schema getBigQuerySchema(org.apache.avro.Schema avroSchema) {
+
+        org.apache.avro.Schema avroSchemaWithFields = avroSchema;
+        if (!AVRO_TYPES_WITH_NAME.contains(avroSchema.getType())) {
+            throw new IllegalArgumentException(
+                    "The Avro Schema must have named fields to convert to BigQuery columns. Found Schema: "
+                            + avroSchema);
+        }
+
+        // Wrap the named schema without fields in a field as fields are iterated to generate BQ
+        // Schema
+        if (avroSchema.getType() != org.apache.avro.Schema.Type.RECORD) {
+            List<org.apache.avro.Schema.Field> avroFields = new ArrayList<>();
+            org.apache.avro.Schema avroSchemaWithWrappedNamedField =
+                    org.apache.avro.Schema.createRecord(
+                            "fieldContainingGenericRecordAvroSchema",
+                            avroSchema.getDoc(),
+                            avroSchema.getNamespace(),
+                            false);
+            avroFields.add(
+                    new org.apache.avro.Schema.Field(
+                            avroSchema.getName(), avroSchema, avroSchema.getDoc(), null));
+            avroSchemaWithWrappedNamedField.setFields(avroFields);
+            avroSchemaWithFields = avroSchemaWithWrappedNamedField;
+        }
+
+        List<Field> fields =
+                avroSchemaWithFields.getFields().stream()
+                        .map(
+                                avroField -> {
+                                    Field.Builder bigQueryFieldBuilder =
+                                            convertAvroFieldToBigQueryField(
+                                                            avroField.schema(), avroField.name(), 0)
+                                                    .toBuilder();
+                                    if (avroField.doc() != null) {
+                                        bigQueryFieldBuilder.setDescription(avroField.doc());
+                                    }
+                                    if (avroField.hasDefaultValue()) {
+                                        bigQueryFieldBuilder.setDefaultValueExpression(
+                                                avroField.defaultVal().toString());
+                                    }
+                                    return bigQueryFieldBuilder.build();
+                                })
+                        .collect(Collectors.toList());
+        return Schema.of(fields);
+    }
+
+    private static Field convertAvroFieldToBigQueryField(
+            org.apache.avro.Schema avroSchema, String name, int nestedLevel) {
+        org.apache.avro.Schema.Type type = avroSchema.getType();
+        switch (type) {
+            case ARRAY:
+                return convertAvroRepeatedFieldToBigQueryField(
+                        avroSchema.getElementType(), name, nestedLevel);
+            case UNION:
+                return convertAvroNullableFieldToBigQueryField(avroSchema, name, nestedLevel);
+            case MAP:
+                throw new UnsupportedOperationException(getErrorMessage(type.toString(), name));
+            default:
+                return convertAvroRequiredFieldToBigQueryField(avroSchema, name, nestedLevel);
+        }
+    }
+
+    /**
+     * Handles Avro UNION schema types for BigQuery compatibility.
+     *
+     * <p>BigQuery supports nullable fields but not unions with multiple non-null types. This method
+     * validates the Avro UNION schema to ensure it conforms to BigQuery's requirements.
+     *
+     * <p>Valid UNION schemas are:
+     *
+     * <ul>
+     *   <li>["null", datatype] - Represents a nullable field.
+     *   <li>[datatype] - Represents a non-nullable field.
+     * </ul>
+     *
+     * <p>Invalid UNION schemas include:
+     *
+     * <ul>
+     *   <li>["null"] - Only null type is not supported.
+     *   <li>[datatype1, datatype2, ...] - Unions without a null type are not supported.
+     * </ul>
+     *
+     * <p>If the UNION schema is valid, this method returns a BigQuery field with the schema of the
+     * non-null datatype. Otherwise, it throws an {@link UnsupportedOperationException}.
+     *
+     * @param avroSchema The Avro UNION schema to process.
+     * @return The BigQuery field corresponding to the non-null type in the UNION.
+     * @throws UnsupportedOperationException if the UNION schema is invalid for BigQuery.
+     */
+    private static Field convertAvroNullableFieldToBigQueryField(
+            org.apache.avro.Schema avroSchema, String name, int nestedLevel)
+            throws UnsupportedOperationException {
+        List<org.apache.avro.Schema> unionTypes = avroSchema.getTypes();
+
+        // Case, when there is only a single type in UNION.
+        // Can be ['null'] - ERROR
+        // [Valid-Datatype] - Not Nullable, element type
+        // Then it is essentially the same as not having a UNION.
+        if (unionTypes.size() == 1
+                && unionTypes.get(0).getType() != org.apache.avro.Schema.Type.NULL) {
+            return convertAvroFieldToBigQueryField(unionTypes.get(0), name, nestedLevel);
+        }
+
+        if (unionTypes.size() == 2) {
+            // Extract all the nonNull Datatypes.
+            // ['datatype, 'null'] and ['null', datatype] are only valid cases.
+            org.apache.avro.Schema actualSchema = null;
+            if (unionTypes.get(0).getType() != org.apache.avro.Schema.Type.NULL
+                    && unionTypes.get(1).getType() == org.apache.avro.Schema.Type.NULL) {
+                actualSchema = unionTypes.get(0);
+            } else if (unionTypes.get(0).getType() == org.apache.avro.Schema.Type.NULL
+                    && unionTypes.get(1).getType() != org.apache.avro.Schema.Type.NULL) {
+                actualSchema = unionTypes.get(1);
+            }
+
+            if (actualSchema != null
+                    && actualSchema.getType() == org.apache.avro.Schema.Type.ARRAY) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unsupported Nullable Avro Field: %s of type ARRAY. BigQuery does not support ARRAY of Nullable type.",
+                                name));
+            }
+
+            if (actualSchema != null) {
+                return convertAvroFieldToBigQueryField(actualSchema, name, nestedLevel)
+                        .toBuilder()
+                        .setMode(Field.Mode.NULLABLE)
+                        .build();
+            }
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Unsupported Avro Field: %s of type UNION. Only supported types are \"['datatype'] or ['null', 'datatype']\"",
+                        name));
+    }
+
+    /**
+     * Converts an Avro ARRAY field to a BigQuery REPEATED field.
+     *
+     * <p>This method handles the conversion of an Avro schema representing a repeated field to a
+     * corresponding BigQuery {@link Field}. It enforces the following restrictions imposed by
+     * BigQuery's schema definition:
+     *
+     * <ul>
+     *   <li>Arrays of arrays are not supported.
+     *   <li>Repeated fields cannot have nullable elements.
+     *   <li>Repeated fields cannot be unions (i.e., have multiple data types).
+     * </ul>
+     *
+     * <p>If any of these restrictions are violated, an {@link UnsupportedOperationException} is
+     * thrown.
+     *
+     * @param avroSchema The Avro schema of the repeated field.
+     * @param name The name of the field.
+     * @param nestedLevel The nesting level of the field.
+     * @return The converted BigQuery {@link Field} with mode set to {@link Field.Mode#REPEATED}.
+     * @throws UnsupportedOperationException if the Avro schema violates any of the restrictions for
+     *     BigQuery repeated fields.
+     */
+    private static Field convertAvroRepeatedFieldToBigQueryField(
+            org.apache.avro.Schema avroSchema, String name, int nestedLevel) {
+        if (avroSchema.getType() == org.apache.avro.Schema.Type.ARRAY) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "BigQuery ARRAY cannot have recursive ARRAY fields. Found recursive Array field: %s",
+                            name));
+        }
+        return convertAvroFieldToBigQueryField(avroSchema, name, nestedLevel)
+                .toBuilder()
+                .setMode(Field.Mode.REPEATED)
+                .build();
+    }
+
+    private static Field convertAvroRequiredFieldToBigQueryField(
+            org.apache.avro.Schema avroSchema, String name, int nestedLevel)
+            throws UnsupportedOperationException, IllegalArgumentException {
+        if (nestedLevel > MAX_NESTED_LEVEL) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "BigQuery RECORD type can only be nested 15 times. Found nesting level of: %s",
+                            nestedLevel));
+        }
+        StandardSQLTypeName dataType;
+        org.apache.avro.Schema.Type type = avroSchema.getType();
+
+        // handle logical type
+        if (avroSchema.getProp(org.apache.avro.LogicalType.LOGICAL_TYPE_PROP) != null) {
+            dataType = convertAvroLogicalTypeToBigQueryType(avroSchema, name);
+            Field logicalBigQueryField =
+                    Field.newBuilder(name, dataType).setMode(Field.Mode.REQUIRED).build();
+            // Add precision to the "decimal" type data
+            if (dataType == StandardSQLTypeName.NUMERIC
+                    || dataType == StandardSQLTypeName.BIGNUMERIC) {
+                long precision =
+                        ((LogicalTypes.Decimal) avroSchema.getLogicalType()).getPrecision();
+                return logicalBigQueryField.toBuilder().setPrecision(precision).build();
+            }
+            return logicalBigQueryField;
+        }
+
+        // handle  record type
+        if (Objects.requireNonNull(type) == org.apache.avro.Schema.Type.RECORD) {
+            List<Field> fields = new ArrayList<>();
+            for (int i = 0; i < avroSchema.getFields().size(); i++) {
+                org.apache.avro.Schema nestedAvroSchema =
+                        avroSchema.getField(avroSchema.getFields().get(i).name()).schema();
+                fields.add(
+                        convertAvroFieldToBigQueryField(
+                                nestedAvroSchema,
+                                avroSchema.getFields().get(i).name(),
+                                nestedLevel + 1));
+            }
+            FieldList nestedBigQueryFields = FieldList.of(fields);
+            return Field.newBuilder(name, LegacySQLTypeName.RECORD, nestedBigQueryFields)
+                    .setDescription((avroSchema.getDoc() != null) ? avroSchema.getDoc() : null)
+                    .setMode(Field.Mode.REQUIRED)
+                    .build();
+        } else {
+            dataType = convertAvroTypeToBigQueryType(type, name);
+        }
+
+        return Field.newBuilder(name, dataType).setMode(Field.Mode.REQUIRED).build();
+    }
+
+    private static StandardSQLTypeName convertAvroTypeToBigQueryType(
+            org.apache.avro.Schema.Type type, String name) throws UnsupportedOperationException {
+        switch (type) {
+            case STRING:
+            case ENUM:
+                return StandardSQLTypeName.STRING;
+            case BOOLEAN:
+                return StandardSQLTypeName.BOOL;
+            case INT:
+            case LONG:
+                return StandardSQLTypeName.INT64;
+            case FLOAT:
+            case DOUBLE:
+                return StandardSQLTypeName.FLOAT64;
+            case BYTES:
+            case FIXED:
+                return StandardSQLTypeName.BYTES;
+            default:
+                throw new UnsupportedOperationException(getErrorMessage(type.toString(), name));
+        }
+    }
+
+    private static StandardSQLTypeName convertAvroLogicalTypeToBigQueryType(
+            org.apache.avro.Schema schema, String name) {
+        String logicalTypeString = schema.getProp(org.apache.avro.LogicalType.LOGICAL_TYPE_PROP);
+        switch (logicalTypeString) {
+            case "date":
+                return StandardSQLTypeName.DATE;
+            case "time-millis":
+            case "time-micros":
+                return StandardSQLTypeName.TIME;
+            case "timestamp-millis":
+            case "timestamp-micros":
+                return StandardSQLTypeName.TIMESTAMP;
+            case "local-timestamp-millis":
+            case "local-timestamp-micros":
+                return StandardSQLTypeName.DATETIME;
+            case "duration":
+                return StandardSQLTypeName.BYTES;
+            case "decimal":
+                long precision = validatePrecisionAndScale(schema, name);
+                if (precision > 0 && precision <= 38) {
+                    return StandardSQLTypeName.NUMERIC;
+                } else if (precision > 38 && precision <= 77) {
+                    return StandardSQLTypeName.BIGNUMERIC;
+                }
+                return StandardSQLTypeName.STRING;
+            case "geography_wkt":
+                return StandardSQLTypeName.GEOGRAPHY;
+            case "uuid":
+                return StandardSQLTypeName.STRING;
+            case "Json":
+                return StandardSQLTypeName.JSON;
+            default:
+                throw new UnsupportedOperationException(getErrorMessage(logicalTypeString, name));
+        }
+    }
+
+    private static long validatePrecisionAndScale(org.apache.avro.Schema schema, String name) {
+        long precision = ((LogicalTypes.Decimal) schema.getLogicalType()).getPrecision();
+        long scale = ((LogicalTypes.Decimal) schema.getLogicalType()).getScale();
+        if (precision <= 0) {
+            throw new IllegalArgumentException(
+                    "Precision of decimal field"
+                            + name
+                            + "must be non-negative. Saw: "
+                            + precision);
+        }
+        if (scale < 0) {
+            throw new IllegalArgumentException(
+                    "Scale of decimal field" + name + "must be non-negative. Saw: " + scale);
+        }
+        if (precision < scale) {
+            throw new IllegalArgumentException(
+                    "Scale of the field "
+                            + name
+                            + "cannot exceed precision. Saw scale: "
+                            + scale
+                            + ", precision: "
+                            + precision);
+        }
+        return precision;
+    }
+
+    private static String getErrorMessage(String unsupportedAvroType, String fieldName) {
+        return String.format(
+                "The avro type: %s of field: %s is not supported by BigQuery",
+                unsupportedAvroType, fieldName);
+    }
+}

--- a/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/common/utils/AvroToBigQuerySchemaTransformTest.java
+++ b/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/common/utils/AvroToBigQuerySchemaTransformTest.java
@@ -1,0 +1,666 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.common.utils;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.SchemaBuilder;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+/** Unit tests for {@link AvroToBigQuerySchemaTransform}. */
+public class AvroToBigQuerySchemaTransformTest {
+
+    /** Tests Avro Schema with all Primitive Data Types */
+    @Test
+    public void testAllTypesSchemaSuccessful() {
+        org.apache.avro.Schema allTypesSchema =
+                org.apache.avro.Schema.createRecord("allTypes", "", "", false);
+
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "string_field", org.apache.avro.Schema.create(Type.STRING), "", null));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "bytes_field", org.apache.avro.Schema.create(Type.BYTES), "", null));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "integer_field", org.apache.avro.Schema.create(Type.LONG), "", null));
+
+        org.apache.avro.Schema arrayFieldSchema =
+                org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(Type.DOUBLE));
+        fields.add(new org.apache.avro.Schema.Field("array_field", arrayFieldSchema, "", null));
+
+        org.apache.avro.Schema numericFieldSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(Type.NULL),
+                        LogicalTypes.decimal(38, 9)
+                                .addToSchema(org.apache.avro.Schema.create(Type.BYTES)));
+        fields.add(new org.apache.avro.Schema.Field("numeric_field", numericFieldSchema, "", null));
+
+        org.apache.avro.Schema bignumericFieldSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(Type.NULL),
+                        LogicalTypes.decimal(77, 38)
+                                .addToSchema(org.apache.avro.Schema.create(Type.BYTES)));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "bignumeric_field", bignumericFieldSchema, "", null));
+
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "boolean_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL),
+                                org.apache.avro.Schema.create(Type.BOOLEAN)),
+                        "",
+                        null));
+
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "ts_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL),
+                                LogicalTypes.timestampMicros()
+                                        .addToSchema(org.apache.avro.Schema.create(Type.LONG))),
+                        "",
+                        null));
+
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "date_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL),
+                                LogicalTypes.date()
+                                        .addToSchema(org.apache.avro.Schema.create(Type.INT))),
+                        "",
+                        null));
+
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "time_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL),
+                                LogicalTypes.timeMicros()
+                                        .addToSchema(org.apache.avro.Schema.create(Type.LONG))),
+                        "",
+                        null));
+
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "datetime_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL),
+                                LogicalTypes.localTimestampMicros()
+                                        .addToSchema(org.apache.avro.Schema.create(Type.LONG))),
+                        "",
+                        null));
+
+        org.apache.avro.Schema geoSchema =
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+        geoSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "geography_wkt");
+        org.apache.avro.Schema geographyFieldSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(Type.NULL), geoSchema);
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "geography_field", geographyFieldSchema, "", null));
+
+        org.apache.avro.Schema jsonSchema =
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+        jsonSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "Json");
+        org.apache.avro.Schema recordFieldSchema =
+                org.apache.avro.Schema.createRecord(
+                        "record_field",
+                        "Translated Avro Schema for record_field",
+                        "com.google.cloud.flink.bigquery",
+                        false);
+        ArrayList<org.apache.avro.Schema.Field> nestedFields = new ArrayList<>();
+        nestedFields.add(
+                new org.apache.avro.Schema.Field(
+                        "json_field",
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(Type.NULL), jsonSchema)));
+        nestedFields.add(
+                new org.apache.avro.Schema.Field(
+                        "geography_field", geographyFieldSchema, "", null));
+        recordFieldSchema.setFields(nestedFields);
+        fields.add(new org.apache.avro.Schema.Field("record_field", recordFieldSchema, "", null));
+        allTypesSchema.setFields(fields);
+
+        Schema expectedBqSchema =
+                Schema.of(
+                        createRequiredBigqueryField("string_field", StandardSQLTypeName.STRING),
+                        createRequiredBigqueryField("bytes_field", StandardSQLTypeName.BYTES),
+                        createRequiredBigqueryField("integer_field", StandardSQLTypeName.INT64),
+                        createRepeatedBigqueryField("array_field", StandardSQLTypeName.FLOAT64),
+                        createNullableBigqueryField("numeric_field", StandardSQLTypeName.NUMERIC),
+                        createNullableBigqueryField(
+                                "bignumeric_field", StandardSQLTypeName.BIGNUMERIC),
+                        createNullableBigqueryField("boolean_field", StandardSQLTypeName.BOOL),
+                        createNullableBigqueryField("ts_field", StandardSQLTypeName.TIMESTAMP),
+                        createNullableBigqueryField("date_field", StandardSQLTypeName.DATE),
+                        createNullableBigqueryField("time_field", StandardSQLTypeName.TIME),
+                        createNullableBigqueryField("datetime_field", StandardSQLTypeName.DATETIME),
+                        createNullableBigqueryField(
+                                "geography_field", StandardSQLTypeName.GEOGRAPHY),
+                        Field.newBuilder(
+                                        "record_field",
+                                        LegacySQLTypeName.RECORD,
+                                        FieldList.of(
+                                                createNullableBigqueryField(
+                                                        "json_field", StandardSQLTypeName.JSON),
+                                                createNullableBigqueryField(
+                                                        "geography_field",
+                                                        StandardSQLTypeName.GEOGRAPHY)))
+                                .setMode(Field.Mode.REQUIRED)
+                                .build());
+
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(allTypesSchema);
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    /** Tests Avro Schema with all Logical Data Types */
+    @Test
+    public void testLogicalTypesSuccessful() {
+        // Create an Avro schema with logical types
+        org.apache.avro.Schema avroSchema =
+                org.apache.avro.Schema.createRecord("RecordWithLogicalTypes", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> logicalFields = new ArrayList<>();
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "dateField",
+                        LogicalTypes.date().addToSchema(org.apache.avro.Schema.create(Type.INT)),
+                        null,
+                        null));
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "timeMillisField",
+                        LogicalTypes.timeMillis()
+                                .addToSchema(org.apache.avro.Schema.create(Type.INT)),
+                        null,
+                        null));
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "timestampMillisField",
+                        LogicalTypes.timestampMillis()
+                                .addToSchema(org.apache.avro.Schema.create(Type.LONG)),
+                        null,
+                        null));
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "localTimestampMillisField",
+                        LogicalTypes.localTimestampMillis()
+                                .addToSchema(org.apache.avro.Schema.create(Type.LONG)),
+                        null,
+                        null));
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "decimalField",
+                        LogicalTypes.decimal(10, 2)
+                                .addToSchema(org.apache.avro.Schema.create(Type.BYTES)),
+                        "Decimal Field Description",
+                        null));
+        logicalFields.add(
+                new org.apache.avro.Schema.Field(
+                        "uuidField",
+                        LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(Type.STRING)),
+                        null,
+                        null));
+        org.apache.avro.Schema durationSchema = org.apache.avro.Schema.create(Type.BYTES);
+        durationSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "duration");
+        logicalFields.add(
+                new org.apache.avro.Schema.Field("durationField", durationSchema, null, null));
+        org.apache.avro.Schema geoSchema =
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+        geoSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "geography_wkt");
+        logicalFields.add(
+                new org.apache.avro.Schema.Field("geographyWKTField", geoSchema, null, null));
+        org.apache.avro.Schema jsonSchema =
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+        jsonSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "Json");
+        logicalFields.add(new org.apache.avro.Schema.Field("jsonField", jsonSchema, null, null));
+        avroSchema.setFields(logicalFields);
+
+        Schema expectedBqSchema =
+                Schema.of(
+                        createRequiredBigqueryField("dateField", StandardSQLTypeName.DATE),
+                        createRequiredBigqueryField("timeMillisField", StandardSQLTypeName.TIME),
+                        createRequiredBigqueryField(
+                                "timestampMillisField", StandardSQLTypeName.TIMESTAMP),
+                        createRequiredBigqueryField(
+                                "localTimestampMillisField", StandardSQLTypeName.DATETIME),
+                        createRequiredBigqueryField("decimalField", StandardSQLTypeName.NUMERIC)
+                                .toBuilder()
+                                .setPrecision(10L)
+                                .setDescription("Decimal Field Description")
+                                .build(),
+                        createRequiredBigqueryField("uuidField", StandardSQLTypeName.STRING),
+                        createRequiredBigqueryField("durationField", StandardSQLTypeName.BYTES),
+                        createRequiredBigqueryField(
+                                "geographyWKTField", StandardSQLTypeName.GEOGRAPHY),
+                        createRequiredBigqueryField("jsonField", StandardSQLTypeName.JSON));
+
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(avroSchema);
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    /** Tests Avro record schema with nesting upto 15 levels */
+    @Test
+    public void testDeeplyNestedSchemaSuccessful() {
+        org.apache.avro.Schema currentSchema = null;
+        for (int i = 13; i >= 0; i--) {
+            org.apache.avro.Schema nextSchema =
+                    org.apache.avro.Schema.createRecord("level_" + i, null, null, false);
+            if (currentSchema != null) {
+                ArrayList<org.apache.avro.Schema.Field> nestedFields = new ArrayList<>();
+                nestedFields.add(
+                        (new org.apache.avro.Schema.Field(
+                                "level_" + (i + 1), currentSchema, null, null)));
+                nextSchema.setFields(nestedFields);
+            } else {
+                ArrayList<org.apache.avro.Schema.Field> nestedFields = new ArrayList<>();
+                nestedFields.add(
+                        new org.apache.avro.Schema.Field(
+                                "value", org.apache.avro.Schema.create(Type.LONG), null, null));
+                nextSchema.setFields(nestedFields);
+            }
+            currentSchema = nextSchema;
+        }
+        org.apache.avro.Schema level0Schema = currentSchema;
+        org.apache.avro.Schema nestedSchema =
+                org.apache.avro.Schema.createRecord("nestedTypeIT", null, null, false);
+        ArrayList<org.apache.avro.Schema.Field> recordFields = new ArrayList<>();
+        recordFields.add(
+                new org.apache.avro.Schema.Field(
+                        "unique_key", org.apache.avro.Schema.create(Type.STRING), null, null));
+        recordFields.add(
+                new org.apache.avro.Schema.Field(
+                        "name", org.apache.avro.Schema.create(Type.STRING), null, null));
+        recordFields.add(
+                new org.apache.avro.Schema.Field(
+                        "number", org.apache.avro.Schema.create(Type.LONG), null, null));
+        recordFields.add(
+                new org.apache.avro.Schema.Field(
+                        "ts",
+                        LogicalTypes.timestampMicros()
+                                .addToSchema(org.apache.avro.Schema.create(Type.LONG)),
+                        null,
+                        null));
+        recordFields.add(new org.apache.avro.Schema.Field("level_0", level0Schema, null, null));
+        nestedSchema.setFields(recordFields);
+
+        Field currentField = createRequiredBigqueryField("value", StandardSQLTypeName.INT64);
+        for (int i = 13; i >= 0; i--) {
+            currentField = createRecordField("level_" + i, currentField);
+        }
+        Field level0Field = currentField;
+
+        Schema expectedBqSchema =
+                Schema.of(
+                        createRequiredBigqueryField("unique_key", StandardSQLTypeName.STRING),
+                        createRequiredBigqueryField("name", StandardSQLTypeName.STRING),
+                        createRequiredBigqueryField("number", StandardSQLTypeName.INT64),
+                        createRequiredBigqueryField("ts", StandardSQLTypeName.TIMESTAMP),
+                        level0Field);
+
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(nestedSchema);
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    /**
+     * Tests Avro Schema: {"type": "record", "name": "LongList", "fields" : [{"name": "value",
+     * "type": "long"}, {"name": "next", "type": ["null", "LongList"]}]}
+     *
+     * <p>This should throw Exception as this is an infinite recursion and is not supported by
+     * BigQuery
+     */
+    @Test
+    public void testInfiniteRecursiveSchemaThrowsException() {
+        // Build the Avro schema programmatically
+        org.apache.avro.Schema longListSchema =
+                org.apache.avro.Schema.createRecord("LongList", "", "", false);
+        longListSchema.addAlias("LinkedLongs");
+
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "value", org.apache.avro.Schema.create(Type.LONG), "", null));
+
+        org.apache.avro.Schema nullableLongListSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(Type.NULL), longListSchema);
+        fields.add(new org.apache.avro.Schema.Field("next", nullableLongListSchema, "", null));
+        longListSchema.setFields(fields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(longListSchema));
+    }
+
+    /**
+     * Tests Avro record schema with more than 15 levels of nesting. This should throw an Exception.
+     */
+    @Test
+    public void testNestedRecordExceedsLimitThrowsException() {
+        org.apache.avro.Schema nestedSchema =
+                org.apache.avro.Schema.createRecord("NestedRecord", "", "", false);
+        List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        org.apache.avro.Schema currentSchema = nestedSchema;
+        for (int i = 0; i < 16; i++) {
+            org.apache.avro.Schema nextSchema =
+                    org.apache.avro.Schema.createRecord("NestedRecord" + i, "", "", false);
+            fields.add(new org.apache.avro.Schema.Field("nestedField", nextSchema, "", null));
+            currentSchema.setFields(fields);
+            currentSchema = nextSchema;
+            fields = new ArrayList<>();
+        }
+
+        org.apache.avro.Schema nestedRecord =
+                org.apache.avro.Schema.createRecord("NestedRecord", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> nestedFields = new ArrayList<>();
+        nestedFields.add(new org.apache.avro.Schema.Field("nestedField", nestedRecord, "", null));
+        nestedRecord.setFields(nestedFields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(nestedRecord));
+    }
+
+    /**
+     * Tests Avro schema: { "type": "record", "name": "ArrayRecord", "fields": [ { "name":
+     * "arrayField", "type": { "type": "array", "items": { "type": "array", "items": "int" } } } ] }
+     * It should throw an exception since recursive Arrays are not supported by BigQuery
+     */
+    @Test
+    public void testArrayOfArraysThrowsException() {
+        org.apache.avro.Schema arrayOfArraysSchema =
+                org.apache.avro.Schema.createArray(
+                        org.apache.avro.Schema.createArray(
+                                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT)));
+
+        org.apache.avro.Schema arrayRecord =
+                org.apache.avro.Schema.createRecord("ArrayRecord", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> arrayFields = new ArrayList<>();
+        arrayFields.add(
+                new org.apache.avro.Schema.Field("arrayField", arrayOfArraysSchema, "", null));
+        arrayRecord.setFields(arrayFields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(arrayRecord));
+    }
+
+    /**
+     * Avro Schema: {"type": "record", "name": "RecordWithNullableArray", "fields": [{"name":
+     * "nullableArray", "type": ["null", {"type": "array", "items": "int"}]}]} Tests that an
+     * exception is thrown because BigQuery doesn't support nullable array types
+     */
+    @Test
+    public void testNullableArrayThrowsException() {
+        org.apache.avro.Schema intArraySchema =
+                org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(Type.INT));
+        org.apache.avro.Schema nullableArraySchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(Type.NULL), intArraySchema);
+
+        org.apache.avro.Schema recordSchema =
+                org.apache.avro.Schema.createRecord("RecordWithNullableArray", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(
+                new org.apache.avro.Schema.Field("nullableArray", nullableArraySchema, "", null));
+        recordSchema.setFields(fields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(recordSchema));
+    }
+
+    /**
+     * Tests Avro schema: { "type": "record", "name": "ArrayRecord", "fields": [ { "name":
+     * "arrayMultipleDataTypesField", "type": { "type": "array", "items": [ "int", "string", "float"
+     * ] } } ] }
+     */
+    @Test
+    public void testArrayWithMultipleDatatypesThrowsException() {
+        org.apache.avro.Schema unionArraySchema =
+                org.apache.avro.Schema.createArray(
+                        org.apache.avro.Schema.createUnion(
+                                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+                                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FLOAT)));
+
+        org.apache.avro.Schema arrayRecord =
+                org.apache.avro.Schema.createRecord("ArrayRecord", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> arrayFields = new ArrayList<>();
+        arrayFields.add(
+                new org.apache.avro.Schema.Field(
+                        "arrayMultipleDataTypesField", unionArraySchema, "", null));
+        arrayRecord.setFields(arrayFields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(arrayRecord));
+    }
+
+    /**
+     * Tests Avro Schema: { "type": "record", "name": "OuterRecord", "fields": [ { "name":
+     * "stringField", "type": "string" }, { "name": "arrayField", "type": { "type": "array",
+     * "items": { "type": "record", "name": "InnerRecord", "fields": [ { "name": "stringField",
+     * "type": "string" }, { "name": "intField", "type": "int" } ] } } }, { "name": "tsField",
+     * "type": { "type": "long", "logicalType": "timestamp-micros" } } ] }
+     */
+    @Test
+    public void testArrayOfRecordsDatatypeSuccessful() {
+        org.apache.avro.Schema innerRecordSchema =
+                org.apache.avro.Schema.createRecord("InnerRecord", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> innerFields = new ArrayList<>();
+        innerFields.add(
+                new org.apache.avro.Schema.Field(
+                        "stringField", org.apache.avro.Schema.create(Type.STRING), "", null));
+        innerFields.add(
+                new org.apache.avro.Schema.Field(
+                        "intField", org.apache.avro.Schema.create(Type.INT), "", null));
+        innerRecordSchema.setFields(innerFields);
+
+        org.apache.avro.Schema arrayOfRecordsSchema =
+                org.apache.avro.Schema.createArray(innerRecordSchema);
+
+        org.apache.avro.Schema arrayRecordSchema =
+                org.apache.avro.Schema.createRecord("OuterRecord", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> arrayFields = new ArrayList<>();
+        arrayFields.add(
+                new org.apache.avro.Schema.Field(
+                        "stringField", org.apache.avro.Schema.create(Type.STRING), "", null));
+        arrayFields.add(
+                new org.apache.avro.Schema.Field("arrayField", arrayOfRecordsSchema, "", null));
+        arrayFields.add(
+                new org.apache.avro.Schema.Field(
+                        "tsField",
+                        LogicalTypes.timestampMicros()
+                                .addToSchema(org.apache.avro.Schema.create(Type.LONG)),
+                        "",
+                        null));
+        arrayRecordSchema.setFields(arrayFields);
+
+        ArrayList<Field> bqRecordFields = new ArrayList<>();
+        bqRecordFields.add(createRequiredBigqueryField("stringField", StandardSQLTypeName.STRING));
+        bqRecordFields.add(createRequiredBigqueryField("intField", StandardSQLTypeName.INT64));
+        Schema expectedBqSchema =
+                Schema.of(
+                        createRequiredBigqueryField("stringField", StandardSQLTypeName.STRING),
+                        Field.newBuilder(
+                                        "arrayField",
+                                        LegacySQLTypeName.RECORD,
+                                        FieldList.of(bqRecordFields))
+                                .setMode(Field.Mode.REPEATED)
+                                .build(),
+                        createRequiredBigqueryField("tsField", StandardSQLTypeName.TIMESTAMP));
+
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(arrayRecordSchema);
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    /**
+     * Tests Avro Schema: {"type": "record", "name": "Record", "fields": [{"name": "nullableField",
+     * "type": ["null"]}]}
+     */
+    @Test
+    public void testNullableFieldWithOnlyNullTypeThrowsException() {
+        org.apache.avro.Schema nullableSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL));
+
+        org.apache.avro.Schema recordSchema =
+                org.apache.avro.Schema.createRecord("Record", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(new org.apache.avro.Schema.Field("nullableField", nullableSchema, "", null));
+        recordSchema.setFields(fields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(recordSchema));
+    }
+
+    /**
+     * Tests Avro Schema: {"type": "record", "name": "Record", "fields": [{"name": "unionField",
+     * "type": ["int", "string"]}]}
+     */
+    @Test
+    public void testUnionFieldWithMultipleNonNullTypesThrowsException() {
+        org.apache.avro.Schema unionSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+
+        org.apache.avro.Schema recordSchema =
+                org.apache.avro.Schema.createRecord("Record", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(new org.apache.avro.Schema.Field("unionField", unionSchema, "", null));
+        recordSchema.setFields(fields);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(recordSchema));
+    }
+
+    /**
+     * Tests Avro Schema: {"type": "record", "name": "Record", "fields": [{"name":
+     * "nullableStringField", "type": ["null", "string"]}]}
+     */
+    @Test
+    public void testNullableFieldWithValidUnion() {
+        org.apache.avro.Schema nullableStringSchema =
+                org.apache.avro.Schema.createUnion(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL),
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+
+        org.apache.avro.Schema recordSchema =
+                org.apache.avro.Schema.createRecord("Record", "", "", false);
+        ArrayList<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "nullableStringField", nullableStringSchema, "", null));
+        recordSchema.setFields(fields);
+        Schema expectedBqSchema =
+                Schema.of(
+                        createNullableBigqueryField(
+                                "nullableStringField", StandardSQLTypeName.STRING));
+
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(recordSchema);
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    /**
+     * Tested Avro schema tested: "string" It should throw an Exception since this schema has no
+     * property as "name"
+     */
+    @Test
+    public void testSchemaWithoutNamedFieldsThrowsException() {
+        org.apache.avro.Schema avroUnNamedSchema = org.apache.avro.Schema.create(Type.STRING);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AvroToBigQuerySchemaTransform.getBigQuerySchema(avroUnNamedSchema));
+    }
+
+    /**
+     * Tested Avro schema: { "type": "enum", "name": "EnumSchema", "symbols": [ "enumValue" ] } This
+     * should be successful as even without "fields", this schema has "name" and a "type" property
+     */
+    @Test
+    public void testSchemaWithoutFieldsSuccessful() {
+        // Create a simple enum schema without fields
+        org.apache.avro.Schema avroSchema =
+                SchemaBuilder.enumeration("EnumSchema").symbols("enumValue");
+
+        // Convert to BigQuery schema
+        Schema bqSchema = AvroToBigQuerySchemaTransform.getBigQuerySchema(avroSchema);
+
+        Schema expectedBqSchema =
+                Schema.of(createRequiredBigqueryField("EnumSchema", StandardSQLTypeName.STRING));
+
+        assertExactSchema(bqSchema, expectedBqSchema);
+    }
+
+    // Helper function to assert equality of two BigQuery schemas
+    private void assertExactSchema(Schema actual, Schema expected) {
+        assertThat(actual.getFields().size()).isEqualTo(expected.getFields().size());
+        for (int i = 0; i < actual.getFields().size(); i++) {
+            Field actualField = actual.getFields().get(i);
+            Field expectedField = expected.getFields().get(i);
+            assertThat(actualField.getName()).isEqualTo(expectedField.getName());
+            assertThat(actualField.getType()).isEqualTo(expectedField.getType());
+            assertThat(actualField.getMode()).isEqualTo(expectedField.getMode());
+            if (actualField.getType() == LegacySQLTypeName.RECORD) {
+                assertExactSchema(
+                        Schema.of(actualField.getSubFields()),
+                        Schema.of(expectedField.getSubFields()));
+            }
+        }
+    }
+
+    private static Field createRequiredBigqueryField(String name, StandardSQLTypeName type) {
+        return Field.newBuilder(name, type).setMode(Field.Mode.REQUIRED).build();
+    }
+
+    private static Field createNullableBigqueryField(String name, StandardSQLTypeName type) {
+        return Field.newBuilder(name, type).setMode(Field.Mode.NULLABLE).build();
+    }
+
+    private static Field createRecordField(String name, Field... subFields) {
+        return Field.newBuilder(name, LegacySQLTypeName.RECORD, FieldList.of(subFields))
+                .setMode(Field.Mode.REQUIRED)
+                .build();
+    }
+
+    private static Field createRepeatedBigqueryField(String name, StandardSQLTypeName type) {
+        return Field.newBuilder(name, type).setMode(Field.Mode.REPEATED).build();
+    }
+}


### PR DESCRIPTION
This PR introduces a new utility class, `AvroToBigQuerySchemaTransform`, to convert Avro schemas to BigQuery schemas. This is necessary for creating BigQuery tables dynamically based on the Avro schema of the incoming record in a Flink connector sink.

The following Type Conversions take place:
Reference: [Type Conversions while loading avro file in BigQuery](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#avro_conversions)

### Data Type Transformation:

| Avro Type             | BigQuery Type        | Notes                                                                |
|-----------------------|----------------------|----------------------------------------------------------------------|
| `string`              | `STRING`             |                                                                      |
| `bytes`               | `BYTES`              |                                                                      |
| `int`                 | `INT64`              |                                                                      |
| `long`                | `INT64`              |                                                                      |
| `float`               | `FLOAT64`             |                                                                      |
| `double`              | `FLOAT64`             |                                                                      |
| `boolean`             | `BOOL`               |                                                                      |
| `enum`                | `STRING`             |                                                                      |
| `fixed`               | `BYTES`              |                                                                      |
| `record`              | `RECORD`             |                                                                      |
| `array`               | `REPEATED`           |                                                                      |
| `union(null, type)`   | `NULLABLE type`      |                                                                      |
| `logicalType: date`   | `DATE`               |                                                                      |
| `logicalType: time`   | `TIME`               |                                                                      |
| `logicalType: timestamp` | `TIMESTAMP`         |                                                                      |
| `logicalType: local-timestamp` | `DATETIME`     |                                                                      |
| `logicalType: decimal` | `NUMERIC`/`BIGNUMERIC` | Depending on precision; `STRING` if precision is out of range |
| `logicalType: geography_wkt` | `GEOGRAPHY`      |                                                                      |
| `logicalType: uuid`   | `STRING`             |                                                                      |
| `logicalType: Json`   | `JSON`               |                                                                      |


### Exception Handling:

| Exception                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                          |
|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `IllegalArgumentException`   | Thrown when the Avro schema does not have named fields (required for BigQuery columns).                                                                                                                                                                                                                                                                                                                                                               |
| `UnsupportedOperationException` | Thrown in the following cases: <ul><li>Avro schema contains unsupported types like `MAP`, `NULL`, or primitive types without names.</li><li>BigQuery schema exceeds the maximum nesting level of 15.</li><li>Avro schema contains arrays of arrays.</li><li>Avro schema contains nullable elements of repeated fields or multiple data types.</li><li>Avro schema contains unions with unsupported types or multiple non-null types.</li><li>Avro schema contains logical types not supported by BigQuery.</li></ul> |
