### PR TITLE
Add configs for sink table creation

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.connector.sink2.Sink;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
+import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +46,14 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
 
     BigQueryBaseSink(BigQuerySinkConfig sinkConfig) {
         validateSinkConfig(sinkConfig);
-        this.connectOptions = sinkConfig.getConnectOptions();
-        this.schemaProvider = sinkConfig.getSchemaProvider();
-        this.serializer = sinkConfig.getSerializer();
-        this.tablePath =
+        connectOptions = sinkConfig.getConnectOptions();
+        if (sinkConfig.getSchemaProvider() == null) {
+            schemaProvider = new BigQuerySchemaProviderImpl(connectOptions);
+        } else {
+            schemaProvider = sinkConfig.getSchemaProvider();
+        }
+        serializer = sinkConfig.getSerializer();
+        tablePath =
                 String.format(
                         "projects/%s/datasets/%s/tables/%s",
                         connectOptions.getProjectId(),
@@ -62,9 +67,6 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         }
         if (sinkConfig.getSerializer() == null) {
             throw new IllegalArgumentException("BigQuery serializer cannot be null");
-        }
-        if (sinkConfig.getSchemaProvider() == null) {
-            throw new IllegalArgumentException("BigQuery schema provider cannot be null");
         }
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.types.logical.LogicalType;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
@@ -35,6 +36,7 @@ import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -53,6 +55,12 @@ public class BigQuerySinkConfig {
     private final DeliveryGuarantee deliveryGuarantee;
     private final BigQuerySchemaProvider schemaProvider;
     private final BigQueryProtoSerializer serializer;
+    private final boolean enableTableCreation;
+    private final String partitionField;
+    private final TimePartitioning.Type partitionType;
+    private final Long partitionExpirationMillis;
+    private final List<String> clusteredFields;
+    private final String region;
 
     public static Builder newBuilder() {
         return new Builder();
@@ -61,7 +69,16 @@ public class BigQuerySinkConfig {
     @Override
     public int hashCode() {
         return Objects.hash(
-                this.connectOptions, this.deliveryGuarantee, this.schemaProvider, this.serializer);
+                connectOptions,
+                deliveryGuarantee,
+                schemaProvider,
+                serializer,
+                enableTableCreation,
+                partitionField,
+                partitionType,
+                partitionExpirationMillis,
+                clusteredFields,
+                region);
     }
 
     @Override
@@ -76,25 +93,40 @@ public class BigQuerySinkConfig {
             return false;
         }
         BigQuerySinkConfig object = (BigQuerySinkConfig) obj;
-        if (this.getConnectOptions() == object.getConnectOptions()
+        return (this.getConnectOptions() == object.getConnectOptions()
                 && (this.getSerializer().getClass() == object.getSerializer().getClass())
-                && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())) {
-            BigQuerySchemaProvider thisSchemaProvider = this.getSchemaProvider();
-            BigQuerySchemaProvider objSchemaProvider = object.getSchemaProvider();
-            return thisSchemaProvider.getAvroSchema().equals(objSchemaProvider.getAvroSchema());
-        }
-        return false;
+                && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())
+                && (this.enableTableCreation() == object.enableTableCreation())
+                && (Objects.equals(this.getPartitionField(), object.getPartitionField()))
+                && (this.getPartitionType() == object.getPartitionType())
+                && (Objects.equals(
+                        this.getPartitionExpirationMillis(), object.getPartitionExpirationMillis()))
+                && (Objects.equals(this.getClusteredFields(), object.getClusteredFields()))
+                && (Objects.equals(this.getRegion(), object.getRegion()))
+                && (Objects.equals(this.getSchemaProvider(), object.getSchemaProvider())));
     }
 
     private BigQuerySinkConfig(
             BigQueryConnectOptions connectOptions,
             DeliveryGuarantee deliveryGuarantee,
             BigQuerySchemaProvider schemaProvider,
-            BigQueryProtoSerializer serializer) {
+            BigQueryProtoSerializer serializer,
+            boolean enableTableCreation,
+            String partitionField,
+            TimePartitioning.Type partitionType,
+            Long partitionExpirationMillis,
+            List<String> clusteredFields,
+            String region) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
         this.serializer = serializer;
+        this.enableTableCreation = enableTableCreation;
+        this.partitionField = partitionField;
+        this.partitionType = partitionType;
+        this.partitionExpirationMillis = partitionExpirationMillis;
+        this.clusteredFields = clusteredFields;
+        this.region = region;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -113,6 +145,30 @@ public class BigQuerySinkConfig {
         return schemaProvider;
     }
 
+    public boolean enableTableCreation() {
+        return enableTableCreation;
+    }
+
+    public String getPartitionField() {
+        return partitionField;
+    }
+
+    public TimePartitioning.Type getPartitionType() {
+        return partitionType;
+    }
+
+    public Long getPartitionExpirationMillis() {
+        return partitionExpirationMillis;
+    }
+
+    public List<String> getClusteredFields() {
+        return clusteredFields;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
     /** Builder for BigQuerySinkConfig. */
     public static class Builder {
 
@@ -120,6 +176,12 @@ public class BigQuerySinkConfig {
         private DeliveryGuarantee deliveryGuarantee;
         private BigQuerySchemaProvider schemaProvider;
         private BigQueryProtoSerializer serializer;
+        private boolean enableTableCreation;
+        private String partitionField;
+        private TimePartitioning.Type partitionType;
+        private Long partitionExpirationMillis;
+        private List<String> clusteredFields;
+        private String region;
         private StreamExecutionEnvironment env;
 
         public Builder connectOptions(BigQueryConnectOptions connectOptions) {
@@ -142,6 +204,36 @@ public class BigQuerySinkConfig {
             return this;
         }
 
+        public Builder enableTableCreation(boolean enableTableCreation) {
+            this.enableTableCreation = enableTableCreation;
+            return this;
+        }
+
+        public Builder partitionField(String partitionField) {
+            this.partitionField = partitionField;
+            return this;
+        }
+
+        public Builder partitionType(TimePartitioning.Type partitionType) {
+            this.partitionType = partitionType;
+            return this;
+        }
+
+        public Builder partitionExpirationMillis(Long partitionExpirationMillis) {
+            this.partitionExpirationMillis = partitionExpirationMillis;
+            return this;
+        }
+
+        public Builder clusteredFields(List<String> clusteredFields) {
+            this.clusteredFields = clusteredFields;
+            return this;
+        }
+
+        public Builder region(String region) {
+            this.region = region;
+            return this;
+        }
+
         public Builder streamExecutionEnvironment(
                 StreamExecutionEnvironment streamExecutionEnvironment) {
             this.env = streamExecutionEnvironment;
@@ -153,7 +245,16 @@ public class BigQuerySinkConfig {
                 validateStreamExecutionEnvironment(env);
             }
             return new BigQuerySinkConfig(
-                    connectOptions, deliveryGuarantee, schemaProvider, serializer);
+                    connectOptions,
+                    deliveryGuarantee,
+                    schemaProvider,
+                    serializer,
+                    enableTableCreation,
+                    partitionField,
+                    partitionType,
+                    partitionExpirationMillis,
+                    clusteredFields,
+                    region);
         }
     }
 
@@ -164,13 +265,25 @@ public class BigQuerySinkConfig {
     public static BigQuerySinkConfig forTable(
             BigQueryConnectOptions connectOptions,
             DeliveryGuarantee deliveryGuarantee,
-            LogicalType logicalType) {
+            LogicalType logicalType,
+            boolean enableTableCreation,
+            String partitionField,
+            TimePartitioning.Type partitionType,
+            Long partitionExpirationMillis,
+            List<String> clusteredFields,
+            String region) {
         return new BigQuerySinkConfig(
                 connectOptions,
                 deliveryGuarantee,
                 new BigQuerySchemaProviderImpl(
                         BigQueryTableSchemaProvider.getAvroSchemaFromLogicalSchema(logicalType)),
-                new RowDataToProtoSerializer());
+                new RowDataToProtoSerializer(),
+                enableTableCreation,
+                partitionField,
+                partitionType,
+                partitionExpirationMillis,
+                clusteredFields,
+                region);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProviderImpl.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProviderImpl.java
@@ -42,6 +42,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -90,6 +91,29 @@ public class BigQuerySchemaProviderImpl implements BigQuerySchemaProvider {
     @Override
     public Schema getAvroSchema() {
         return this.avroSchema;
+    }
+
+    @Override
+    public int hashCode() {
+        Schema thisAvroSchema = getAvroSchema();
+        if (thisAvroSchema == null) {
+            return Integer.MIN_VALUE;
+        }
+        return thisAvroSchema.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return Objects.equals(getAvroSchema(), ((BigQuerySchemaProviderImpl) obj).getAvroSchema());
     }
 
     // ----------- Initialize Maps between Avro Schema to Descriptor Proto schema -------------

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -78,6 +78,12 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.DELIVERY_GUARANTEE);
         additionalOptions.add(BigQueryConnectorOptions.PARTITION_DISCOVERY_INTERVAL);
         additionalOptions.add(BigQueryConnectorOptions.SINK_PARALLELISM);
+        additionalOptions.add(BigQueryConnectorOptions.ENABLE_TABLE_CREATION);
+        additionalOptions.add(BigQueryConnectorOptions.PARTITION_FIELD);
+        additionalOptions.add(BigQueryConnectorOptions.PARTITION_TYPE);
+        additionalOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
+        additionalOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
+        additionalOptions.add(BigQueryConnectorOptions.REGION);
 
         return additionalOptions;
     }
@@ -101,6 +107,12 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.DELIVERY_GUARANTEE);
         forwardOptions.add(BigQueryConnectorOptions.PARTITION_DISCOVERY_INTERVAL);
         forwardOptions.add(BigQueryConnectorOptions.SINK_PARALLELISM);
+        forwardOptions.add(BigQueryConnectorOptions.ENABLE_TABLE_CREATION);
+        forwardOptions.add(BigQueryConnectorOptions.PARTITION_FIELD);
+        forwardOptions.add(BigQueryConnectorOptions.PARTITION_TYPE);
+        forwardOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
+        forwardOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
+        forwardOptions.add(BigQueryConnectorOptions.REGION);
 
         return forwardOptions;
     }
@@ -146,8 +158,14 @@ public class BigQueryDynamicTableFactory
 
         return new BigQueryDynamicTableSink(
                 configProvider.translateBigQueryConnectOptions(),
-                configProvider.translateDeliveryGuarantee(),
+                configProvider.getDeliveryGuarantee(),
                 context.getPhysicalRowDataType().getLogicalType(),
-                configProvider.getParallelism().orElse(null));
+                configProvider.getParallelism().orElse(null),
+                configProvider.enableTableCreation(),
+                configProvider.getPartitionField().orElse(null),
+                configProvider.getPartitionType().orElse(null),
+                configProvider.getPartitionExpirationMillis().orElse(null),
+                configProvider.getClusteredFields().orElse(null),
+                configProvider.getRegion().orElse(null));
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -22,6 +22,8 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 
+import com.google.cloud.bigquery.TimePartitioning;
+
 /**
  * Base options for the BigQuery connector. Needs to be public so that the {@link
  * org.apache.flink.table.api.TableDescriptor} can access it.
@@ -169,11 +171,11 @@ public class BigQueryConnectorOptions {
             ConfigOptions.key("read.discovery-interval")
                     .intType()
                     .defaultValue(10)
-                    .withDescription("Partition Discovery interval(in minutes)");
+                    .withDescription("Partition discovery interval(in minutes)");
 
     /**
-     * [OPTIONAL, Sink Configuration] Enum value indicating the delivery guarantee of the sink job.
-     * Can be <code>DeliveryGuarantee.AT_LEAST_ONCE</code> or <code>DeliveryGuarantee.EXACTLY_ONCE
+     * [OPTIONAL, Sink Configuration] Enum value indicating the delivery guarantee of the sink. Can
+     * be <code>DeliveryGuarantee.AT_LEAST_ONCE</code> or <code>DeliveryGuarantee.EXACTLY_ONCE
      * </code><br>
      * Default: <code>DeliveryGuarantee.AT_LEAST_ONCE</code> - At-least Once Mode.
      */
@@ -183,10 +185,57 @@ public class BigQueryConnectorOptions {
                     .defaultValue(DeliveryGuarantee.AT_LEAST_ONCE)
                     .withDescription("Delivery Guarantee (AT_LEAST_ONCE or EXACTLY_ONCE");
 
-    /** [OPTIONAL, Sink Configuration] Int value indicating the parallelism of the sink job. */
+    /** [OPTIONAL, Sink Configuration] Int value indicating the parallelism of the sink. */
     public static final ConfigOption<Integer> SINK_PARALLELISM =
             ConfigOptions.key("write.parallelism")
                     .intType()
                     .noDefaultValue()
-                    .withDescription("Sink Parallelism");
+                    .withDescription("Sink parallelism");
+
+    /** [OPTIONAL, Sink Configuration] Boolean flag controlling table creation in the sink. */
+    public static final ConfigOption<Boolean> ENABLE_TABLE_CREATION =
+            ConfigOptions.key("write.enable-table-creation")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Enable table creation in sink");
+
+    /** [OPTIONAL, Sink Configuration] Name of partitioning field. */
+    public static final ConfigOption<String> PARTITION_FIELD =
+            ConfigOptions.key("write.partition-field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Field for partitioning destination BigQuery table (used if new table is created)");
+
+    /** [OPTIONAL, Sink Configuration] Enum value indicating the partitioning frequency. */
+    public static final ConfigOption<TimePartitioning.Type> PARTITION_TYPE =
+            ConfigOptions.key("write.partition-type")
+                    .enumType(TimePartitioning.Type.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            "Time based partitioning frequency in destination BigQuery table (used if new table is created)");
+
+    /** [OPTIONAL, Sink Configuration] Long value indicating the partition expiration. */
+    public static final ConfigOption<Long> PARTITION_EXPIRATION_MILLIS =
+            ConfigOptions.key("write.partition-expiration-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Partition expiration in destination BigQuery table (used if new table is created)");
+
+    /** [OPTIONAL, Sink Configuration] Names of clustered fields, comma separated. */
+    public static final ConfigOption<String> CLUSTERED_FIELDS =
+            ConfigOptions.key("write.clustered-fields")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Comma separated fields for clustering destination BigQuery table (used if new table is created)");
+
+    /** [OPTIONAL, Sink Configuration] GCP region of destination BigQuery table. */
+    public static final ConfigOption<String> REGION =
+            ConfigOptions.key("write.region")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "GCP region of destination BigQuery table (used if new table is created)");
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQuerySinkTableConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQuerySinkTableConfig.java
@@ -20,7 +20,10 @@ import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableDescriptor;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig;
+
+import java.util.List;
 
 /**
  * Configurations for a BigQuery Table API Write.
@@ -33,6 +36,12 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
 
     private final DeliveryGuarantee deliveryGuarantee;
     private final Integer sinkParallelism;
+    private final boolean enableTableCreation;
+    private final String partitionField;
+    private final TimePartitioning.Type partitionType;
+    private final long partitionExpirationMillis;
+    private final List<String> clusteredFields;
+    private final String region;
 
     BigQuerySinkTableConfig(
             String project,
@@ -43,7 +52,13 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
             String credentialKey,
             boolean testMode,
             DeliveryGuarantee deliveryGuarantee,
-            Integer sinkParallelism) {
+            Integer sinkParallelism,
+            boolean enableTableCreation,
+            String partitionField,
+            TimePartitioning.Type partitionType,
+            long partitionExpirationMillis,
+            List<String> clusteredFields,
+            String region) {
         super(
                 project,
                 dataset,
@@ -54,10 +69,16 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
                 testMode);
         this.deliveryGuarantee = deliveryGuarantee;
         this.sinkParallelism = sinkParallelism;
+        this.enableTableCreation = enableTableCreation;
+        this.partitionField = partitionField;
+        this.partitionType = partitionType;
+        this.partitionExpirationMillis = partitionExpirationMillis;
+        this.clusteredFields = clusteredFields;
+        this.region = region;
     }
 
-    public static BigQuerySinkTableConfig.Builder newBuilder() {
-        return new BigQuerySinkTableConfig.Builder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     /**
@@ -86,46 +107,52 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
 
         private DeliveryGuarantee deliveryGuarantee;
         private Integer sinkParallelism;
+        private boolean enableTableCreation;
+        private String partitionField;
+        private TimePartitioning.Type partitionType;
+        private long partitionExpirationMillis;
+        private List<String> clusteredFields;
+        private String region;
         private StreamExecutionEnvironment env;
 
         @Override
-        public BigQuerySinkTableConfig.Builder project(String project) {
+        public Builder project(String project) {
             super.project = project;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder dataset(String dataset) {
+        public Builder dataset(String dataset) {
             super.dataset = dataset;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder table(String table) {
+        public Builder table(String table) {
             super.table = table;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder credentialAccessToken(String credentialAccessToken) {
+        public Builder credentialAccessToken(String credentialAccessToken) {
             super.credentialAccessToken = credentialAccessToken;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder credentialKey(String credentialKey) {
+        public Builder credentialKey(String credentialKey) {
             super.credentialKey = credentialKey;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder credentialFile(String credentialFile) {
+        public Builder credentialFile(String credentialFile) {
             super.credentialFile = credentialFile;
             return this;
         }
 
         @Override
-        public BigQuerySinkTableConfig.Builder testMode(Boolean testMode) {
+        public Builder testMode(Boolean testMode) {
             super.testMode = testMode;
             return this;
         }
@@ -140,8 +167,7 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
          * @param deliveryGuarantee
          * @return Updated BigQuerySinkTableConfig builder
          */
-        public BigQuerySinkTableConfig.Builder deliveryGuarantee(
-                DeliveryGuarantee deliveryGuarantee) {
+        public Builder deliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
             this.deliveryGuarantee = deliveryGuarantee;
             return this;
         }
@@ -152,8 +178,79 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
          * @param sinkParallelism
          * @return Updated BigQuerySinkTableConfig builder
          */
-        public BigQuerySinkTableConfig.Builder sinkParallelism(Integer sinkParallelism) {
+        public Builder sinkParallelism(Integer sinkParallelism) {
             this.sinkParallelism = sinkParallelism;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] Boolean flag for automatic table creation.
+         *
+         * @param enableTableCreation
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder enableTableCreation(boolean enableTableCreation) {
+            this.enableTableCreation = enableTableCreation;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] Field for partitioning the BigQuery table. Considered if
+         * table auto creation is enabled.
+         *
+         * @param partitionField
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder partitionField(String partitionField) {
+            this.partitionField = partitionField;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] Time frequency for partitioning the BigQuery table.
+         * Considered if table auto creation is enabled.
+         *
+         * @param partitionType
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder partitionType(TimePartitioning.Type partitionType) {
+            this.partitionType = partitionType;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] Expiration duration of BigQuery table's partitions.
+         * Considered if table auto creation is enabled.
+         *
+         * @param partitionExpirationMillis
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder partitionExpirationMillis(long partitionExpirationMillis) {
+            this.partitionExpirationMillis = partitionExpirationMillis;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] Fields for clustering the BigQuery table. Considered if
+         * table auto creation is enabled.
+         *
+         * @param clusteredFields
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder clusteredFields(List<String> clusteredFields) {
+            this.clusteredFields = clusteredFields;
+            return this;
+        }
+
+        /**
+         * [OPTIONAL, Sink Configuration] GCP region for creating new BigQuery table. Considered if
+         * table auto creation is enabled.
+         *
+         * @param region
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder region(String region) {
+            this.region = region;
             return this;
         }
 
@@ -163,7 +260,7 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
          * @param streamExecutionEnvironment
          * @return Updated BigQuerySinkTableConfig builder
          */
-        public BigQuerySinkTableConfig.Builder streamExecutionEnvironment(
+        public Builder streamExecutionEnvironment(
                 StreamExecutionEnvironment streamExecutionEnvironment) {
             this.env = streamExecutionEnvironment;
             return this;
@@ -182,7 +279,13 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
                     credentialKey,
                     testMode,
                     deliveryGuarantee,
-                    sinkParallelism);
+                    sinkParallelism,
+                    enableTableCreation,
+                    partitionField,
+                    partitionType,
+                    partitionExpirationMillis,
+                    clusteredFields,
+                    region);
         }
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.util.function.SerializableSupplier;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.services.BigQueryServices;
@@ -29,6 +30,7 @@ import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -58,8 +60,41 @@ public class BigQueryTableConfigurationProvider {
         return config.get(BigQueryConnectorOptions.MODE) == Boundedness.CONTINUOUS_UNBOUNDED;
     }
 
+    public DeliveryGuarantee getDeliveryGuarantee() {
+        return config.get(BigQueryConnectorOptions.DELIVERY_GUARANTEE);
+    }
+
     public Optional<Integer> getParallelism() {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.SINK_PARALLELISM));
+    }
+
+    public boolean enableTableCreation() {
+        return config.get(BigQueryConnectorOptions.ENABLE_TABLE_CREATION);
+    }
+
+    public Optional<String> getPartitionField() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.PARTITION_FIELD));
+    }
+
+    public Optional<TimePartitioning.Type> getPartitionType() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.PARTITION_TYPE));
+    }
+
+    public Optional<Long> getPartitionExpirationMillis() {
+        return Optional.ofNullable(
+                config.get(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS));
+    }
+
+    public Optional<List<String>> getClusteredFields() {
+        String clusteredFields = config.get(BigQueryConnectorOptions.CLUSTERED_FIELDS);
+        if (clusteredFields == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Arrays.asList(clusteredFields.split(",")));
+    }
+
+    public Optional<String> getRegion() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.REGION));
     }
 
     public BigQueryReadOptions toBigQueryReadOptions() {
@@ -96,9 +131,5 @@ public class BigQueryTableConfigurationProvider {
                                         config.get(BigQueryConnectorOptions.CREDENTIALS_KEY))
                                 .build())
                 .build();
-    }
-
-    public DeliveryGuarantee translateDeliveryGuarantee() {
-        return config.get(BigQueryConnectorOptions.DELIVERY_GUARANTEE);
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
@@ -99,22 +99,6 @@ public class BigQueryDefaultSinkTest {
     }
 
     @Test
-    public void testConstructor_withoutSchemaProvider() {
-        env.setRestartStrategy(FIXED_DELAY_RESTART_STRATEGY);
-        BigQuerySinkConfig sinkConfig =
-                BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
-                        .schemaProvider(null)
-                        .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
-                        .streamExecutionEnvironment(env)
-                        .build();
-        IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class, () -> new BigQueryDefaultSink(sinkConfig));
-        assertThat(exception).hasMessageThat().contains("schema provider cannot be null");
-    }
-
-    @Test
     public void testCreateWriter() {
         env.setRestartStrategy(FIXED_DELAY_RESTART_STRATEGY);
         InitContext mockedContext = Mockito.mock(InitContext.class);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -25,12 +25,16 @@ import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,12 +43,28 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 /** Class to test {@link BigQueryDynamicTableSink}. */
 public class BigQueryDynamicTableSinkTest {
 
-    static LogicalType logicalTypeSchema =
+    private static final LogicalType SCHEMA =
             DataTypes.ROW(DataTypes.FIELD("number", DataTypes.BIGINT().notNull()))
                     .notNull()
                     .getLogicalType();
 
     private static final int PARALLELISM = 5;
+    private static final String PARTITIONING_FIELD = "foo";
+    private static final List<String> CLUSTERED_FIELDS = Arrays.asList("foo", "bar");
+    private static final String REGION = "us-central1";
+
+    private static final BigQueryDynamicTableSink TABLE_SINK =
+            new BigQueryDynamicTableSink(
+                    StorageClientFaker.createConnectOptionsForWrite(null),
+                    DeliveryGuarantee.AT_LEAST_ONCE,
+                    SCHEMA,
+                    PARALLELISM,
+                    true,
+                    PARTITIONING_FIELD,
+                    TimePartitioning.Type.DAY,
+                    null,
+                    CLUSTERED_FIELDS,
+                    REGION);
 
     @RegisterExtension
     static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
@@ -55,78 +75,46 @@ public class BigQueryDynamicTableSinkTest {
 
     @Test
     public void testConstructor() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema,
-                        PARALLELISM);
-        BigQuerySinkConfig obtainedSinkConfig = bigQueryDynamicTableSink.getSinkConfig();
-        assertEquals(logicalTypeSchema, bigQueryDynamicTableSink.getLogicalType());
-        assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, obtainedSinkConfig.getDeliveryGuarantee());
         Schema convertedAvroSchema =
                 new Schema.Parser()
                         .parse(
                                 "{\"type\":\"record\",\"name\":\"record\","
                                         + "\"namespace\":\"org.apache.flink.avro.generated\",\"fields\":"
                                         + "[{\"name\":\"number\",\"type\":\"long\"}]}");
+        BigQuerySinkConfig obtainedSinkConfig = TABLE_SINK.getSinkConfig();
+        assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, obtainedSinkConfig.getDeliveryGuarantee());
         assertEquals(convertedAvroSchema, obtainedSinkConfig.getSchemaProvider().getAvroSchema());
-        assertEquals(PARALLELISM, bigQueryDynamicTableSink.getSinkParallelism());
+        assertTrue(obtainedSinkConfig.enableTableCreation());
+        assertEquals(PARTITIONING_FIELD, obtainedSinkConfig.getPartitionField());
+        assertEquals(TimePartitioning.Type.DAY, obtainedSinkConfig.getPartitionType());
+        assertTrue(obtainedSinkConfig.getPartitionExpirationMillis() == null);
+        assertEquals(CLUSTERED_FIELDS, obtainedSinkConfig.getClusteredFields());
+        assertEquals(REGION, obtainedSinkConfig.getRegion());
+        assertEquals(SCHEMA, TABLE_SINK.getLogicalType());
+        assertEquals(PARALLELISM, TABLE_SINK.getSinkParallelism());
     }
 
     @Test
     public void testCopy() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema);
-        assertTrue(bigQueryDynamicTableSink.equals(bigQueryDynamicTableSink.copy()));
-    }
-
-    @Test
-    public void testCopyWithParallelism() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema,
-                        PARALLELISM);
-        assertTrue(bigQueryDynamicTableSink.equals(bigQueryDynamicTableSink.copy()));
+        assertEquals(TABLE_SINK, TABLE_SINK.copy());
     }
 
     @Test
     public void testSummaryString() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema);
-        assertEquals("BigQuery", bigQueryDynamicTableSink.asSummaryString());
+        assertEquals("BigQuery", TABLE_SINK.asSummaryString());
     }
 
     @Test
     public void testChangelogMode() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema);
         assertEquals(
                 ChangelogMode.insertOnly(),
-                bigQueryDynamicTableSink.getChangelogMode(Mockito.mock(ChangelogMode.class)));
+                TABLE_SINK.getChangelogMode(Mockito.mock(ChangelogMode.class)));
     }
 
     @Test
     public void testSinkRuntimeProvider() {
-        BigQueryDynamicTableSink bigQueryDynamicTableSink =
-                new BigQueryDynamicTableSink(
-                        StorageClientFaker.createConnectOptionsForWrite(null),
-                        DeliveryGuarantee.AT_LEAST_ONCE,
-                        logicalTypeSchema);
         assertInstanceOf(
                 SinkV2Provider.class,
-                bigQueryDynamicTableSink.getSinkRuntimeProvider(
-                        Mockito.mock(DynamicTableSink.Context.class)));
+                TABLE_SINK.getSinkRuntimeProvider(Mockito.mock(DynamicTableSink.Context.class)));
     }
 }


### PR DESCRIPTION
1. Accept additional configs in BQ sink (Datastream and Table API) for table creation, including partitioning and clustering
2. Create default schema provider in sink if not provided by user

/gcbrun