### PR TITLE
Sanitize Avro Names [Project id] using readAvros

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/BigQuerySource.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/BigQuerySource.java
@@ -311,8 +311,10 @@ public abstract class BigQuerySource<OUT>
                                 SchemaTransform.toGenericAvroSchema(
                                                 String.format(
                                                         "%s.%s.%s",
-                                                        connectOptions.getProjectId(),
-                                                        connectOptions.getDataset(),
+                                                        sanitizeAvroSchemaName(
+                                                                connectOptions.getProjectId()),
+                                                        sanitizeAvroSchemaName(
+                                                                connectOptions.getDataset()),
                                                         sanitizeAvroSchemaName(
                                                                 connectOptions.getTable())),
                                                 tableSchema.getFields())

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ under the License.
     </distributionManagement>
 
     <properties>
-        <revision>0.5-SNAPSHOT</revision>
+        <revision>0.5.0-SNAPSHOT</revision>
         <flink.version>1.17.1</flink.version>
         <bigquery.guava.version>32.1.3-jre</bigquery.guava.version>
         <google-lib-bom.version>26.33.0</google-lib-bom.version>
@@ -93,7 +93,8 @@ under the License.
 
     <modules>
         <module>flink-connector-bigquery-common</module>
-    </modules>
+		<module>flink-1.17-connector-bigquery</module>
+	</modules>
 
     <dependencies>
         <!-- Root dependencies for all projects -->
@@ -296,7 +297,7 @@ under the License.
                 <version>3.24.2</version>
                 <scope>test</scope>
             </dependency>
-            
+
             <!-- Unavoidable Flink Dependencies -->
             <!-- The Idea is to have one same flink
             version that governs annotations and flink-core version -->
@@ -306,7 +307,7 @@ under the License.
                 <artifactId>flink-annotations</artifactId>
                 <version>${flink.version}</version>
             </dependency>
-            <!-- Dependency required for SerializableSupplier, 
+            <!-- Dependency required for SerializableSupplier,
                 Preconditions, BiConsumerWithException,
                 FunctionWithException used across the Project. -->
             <dependency>


### PR DESCRIPTION
We need to sanitize the project id from the readAvros function. Otherwise you get

```
Exception in thread "main" org.apache.avro.SchemaParseException: Namespace part "sdp-stg-shop-ml" is invalid: Illegal character in: sdp-stg-shop-ml
	at org.apache.avro.ParseContext.validateName(ParseContext.java:242)
	at org.apache.avro.ParseContext.requireValidFullName(ParseContext.java:233)
	at org.apache.avro.ParseContext.put(ParseContext.java:214)
	at org.apache.avro.Schema.parseRecord(Schema.java:1865)
	at org.apache.avro.Schema.parse(Schema.java:1835)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1538)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1515)
	at com.google.cloud.flink.bigquery.source.reader.deserializer.AvroDeserializationSchema.getProducedType(AvroDeserializationSchema.java:47)
	at com.google.cloud.flink.bigquery.source.BigQuerySource.getProducedType(BigQuerySource.java:139)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.getTypeInfo(StreamExecutionEnvironment.java:2921)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.fromSource(StreamExecutionEnvironment.java:2282)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.fromSource(StreamExecutionEnvironment.java:2253)
	at com.shopify.disco.bigquery.BigQueryJob.main(BigQueryJob.java:41)
```

Even though the project id is valid


Important to note that there are other interfaces that likely also need this change