### PR TITLE
Allow higher parallelism in multi-regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,11 +303,16 @@ Check out BigQuery SQL's [DDL](https://cloud.google.com/bigquery/docs/reference/
 ### Sink Details [MUST READ]
 
 * BigQuery sinks require that checkpoint is enabled.
-* When using a BigQuery sink, checkpoint timeout should be liberal (1+ minutes). This is because sink writers are
-  [throttled](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/05fe7b14f2dc688bc808f553c3f863ba2380e317/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/BigQueryWriterThrottler.java#L26) 
-  before they start sending data to BigQuery. Depending on the sink's parallelism, this throttling can be as high as 40 seconds. 
-  Throttling is necessary to gracefully handle BigQuery's rate limiting on certain APIs used by the sink writers. Note that this only
-  affects the first checkpoint.
+* The maximum parallelism of BigQuery sinks has been capped at **512** for multi-regions US or EU, and **128** for the rest.
+  This is to respect BigQuery storage [write quotas](https://cloud.google.com/bigquery/quotas#write-api-limits) while keeping
+  [throughput](https://cloud.google.com/bigquery/docs/write-api#connections) and
+  [best usage practices](https://cloud.google.com/bigquery/docs/write-api-best-practices) in mind. Users should either set
+  [sink level parallelism](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/datastream/execution/parallel/#operator-level)
+  explicitly, or ensure that default job level parallelism is under region-specific maximums (512 or 128).
+* When using a BigQuery sink, checkpoint timeout should be liberal. This is because sink writers are
+  [throttled](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/main/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/BigQueryWriterThrottler.java) 
+  before they start sending data to BigQuery. Depending on the destination dataset's region, an estimate of this throttling is 3 minutes for US and EU multi-regions, and 45 seconds for others. 
+  Throttling is necessary to gracefully handle BigQuery's rate limiting on certain APIs used by the sink writers. Note that this throttling happens once per writer, before the first checkpoint they encounter after   accepting data.
 * Delivery guarantee can be [at-least-once](https://nightlies.apache.org/flink/flink-docs-release-1.17/api/java/org/apache/flink/connector/base/DeliveryGuarantee.html#AT_LEAST_ONCE) or 
   [exactly-once](https://nightlies.apache.org/flink/flink-docs-release-1.17/api/java/org/apache/flink/connector/base/DeliveryGuarantee.html#EXACTLY_ONCE).
 * The at-least-once sink enables BigQuery client [multiplexing](https://cloud.google.com/bigquery/docs/write-api-streaming#use_multiplexing)
@@ -321,12 +326,6 @@ Check out BigQuery SQL's [DDL](https://cloud.google.com/bigquery/docs/reference/
   when maintaining records in avro format. Check Flink's [blog on non-trivial serialization](https://nightlies.apache.org/flink/flink-docs-release-1.17/api/java/org/apache/flink/connector/base/DeliveryGuarantee.html#AT_LEAST_ONCE).
   Note that avro schema of an existing BigQuery table can be obtained from
   [BigQuerySchemaProviderImpl](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/main/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProviderImpl.java).
-* The maximum parallelism of BigQuery sinks has been capped at **512** for multi-regions US or EU, and **128** for the rest.
-  This is to respect BigQuery storage [write quotas](https://cloud.google.com/bigquery/quotas#write-api-limits) while keeping
-  [throughput](https://cloud.google.com/bigquery/docs/write-api#connections) and
-  [best usage practices](https://cloud.google.com/bigquery/docs/write-api-best-practices) in mind. Users should either set
-  [sink level parallelism](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/datastream/execution/parallel/#operator-level)
-  explicitly, or ensure that default job level parallelism is under region-specific maximums (512 or 128).
 * BigQuerySinkConfig requires the StreamExecutionEnvironment if delivery guarantee is exactly-once.   
   **Restart strategy must be explicitly set in the StreamExecutionEnvironment**.  
   This is to [validate](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/92db3690c741fb2cdb99e28c575e19affb5c8b69/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java#L185) 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ BigQuerySinkTableConfig sinkTableConfig = BigQuerySinkTableConfig.newBuilder()
         .project(...) // REQUIRED
         .dataset(...) // REQUIRED
         .streamExecutionEnvironment(env) // REQUIRED if deliveryGuarantee is EXACTLY_ONCE
-        .sinkParallelism(...) // OPTIONAL; Should be atmost 128
+        .sinkParallelism(...) // OPTIONAL;
         .deliveryGuarantee(...) // OPTIONAL; Default is AT_LEAST_ONCE
         .enableTableCreation(...) // OPTIONAL
         .partitionField(...) // OPTIONAL
@@ -321,11 +321,12 @@ Check out BigQuery SQL's [DDL](https://cloud.google.com/bigquery/docs/reference/
   when maintaining records in avro format. Check Flink's [blog on non-trivial serialization](https://nightlies.apache.org/flink/flink-docs-release-1.17/api/java/org/apache/flink/connector/base/DeliveryGuarantee.html#AT_LEAST_ONCE).
   Note that avro schema of an existing BigQuery table can be obtained from
   [BigQuerySchemaProviderImpl](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/main/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProviderImpl.java).
-* The maximum parallelism of BigQuery sinks has been capped at **128**. This is to respect BigQuery storage
-  [write quotas](https://cloud.google.com/bigquery/quotas#write-api-limits) while adhering to
-  [best usage practices](https://cloud.google.com/bigquery/docs/write-api-best-practices). Users should either set
+* The maximum parallelism of BigQuery sinks has been capped at **512** for multi-regions US or EU, and **128** for the rest.
+  This is to respect BigQuery storage [write quotas](https://cloud.google.com/bigquery/quotas#write-api-limits) while keeping
+  [throughput](https://cloud.google.com/bigquery/docs/write-api#connections) and
+  [best usage practices](https://cloud.google.com/bigquery/docs/write-api-best-practices) in mind. Users should either set
   [sink level parallelism](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/datastream/execution/parallel/#operator-level)
-  explicitly, or ensure that default job level parallelism is under 128.
+  explicitly, or ensure that default job level parallelism is under region-specific maximums (512 or 128).
 * BigQuerySinkConfig requires the StreamExecutionEnvironment if delivery guarantee is exactly-once.   
   **Restart strategy must be explicitly set in the StreamExecutionEnvironment**.  
   This is to [validate](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/92db3690c741fb2cdb99e28c575e19affb5c8b69/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java#L185) 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -151,8 +151,10 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
     // Max sink parallelism is deduced using destination dataset's region.
     // Ensure instance variable 'region' is assigned before invoking this method.
     private int getMaxParallelism() {
-        if (BQ_MULTI_REGIONS.contains(region)) {
-            return MULTI_REGION_MAX_SINK_PARALLELISM;
+        for (String multiRegion : BQ_MULTI_REGIONS) {
+            if (multiRegion.equalsIgnoreCase(region)) {
+                return MULTI_REGION_MAX_SINK_PARALLELISM;
+            }
         }
         return DEFAULT_MAX_SINK_PARALLELISM;
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -43,6 +43,7 @@ class BigQueryDefaultSink extends BigQueryBaseSink {
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                maxParallelism,
                 traceId,
                 context);
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
@@ -56,6 +56,7 @@ public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                maxParallelism,
                 traceId,
                 context);
     }
@@ -82,6 +83,7 @@ public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                maxParallelism,
                 traceId,
                 context);
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandling.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandling.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink.client;
 
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
@@ -132,6 +133,21 @@ public class BigQueryClientWithErrorHandling {
                             connectOptions.getProjectId(),
                             connectOptions.getDataset(),
                             connectOptions.getTable()),
+                    e);
+        }
+    }
+
+    public static Dataset getDataset(BigQueryConnectOptions connectOptions) {
+        try {
+            BigQueryServices.QueryDataClient queryDataClient =
+                    BigQueryServicesFactory.instance(connectOptions).queryClient();
+            return queryDataClient.getDataset(
+                    connectOptions.getProjectId(), connectOptions.getDataset());
+        } catch (BigQueryException e) {
+            throw new BigQueryConnectorException(
+                    String.format(
+                            "Unable to check existence of BigQuery dataset %s.%s",
+                            connectOptions.getProjectId(), connectOptions.getDataset()),
                     e);
         }
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/BigQueryWriterThrottler.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/throttle/BigQueryWriterThrottler.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.flink.bigquery.sink.throttle;
 
-import com.google.cloud.flink.bigquery.sink.BigQueryExactlyOnceSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,18 +39,18 @@ import java.util.concurrent.TimeUnit;
  */
 public class BigQueryWriterThrottler implements Throttler {
 
-    // MAX_SINK_PARALLELISM is set as 128.
-    public static final int MAX_BUCKETS = BigQueryExactlyOnceSink.MAX_SINK_PARALLELISM / 3;
     private static final Logger LOG = LoggerFactory.getLogger(BigQueryWriterThrottler.class);
     private final int writerId;
+    private final int maxBuckets;
 
-    public BigQueryWriterThrottler(int writerId) {
+    public BigQueryWriterThrottler(int writerId, int maxParallelism) {
         this.writerId = writerId;
+        this.maxBuckets = maxParallelism / 3;
     }
 
     @Override
     public void throttle() {
-        int waitSeconds = writerId % MAX_BUCKETS;
+        int waitSeconds = writerId % maxBuckets;
         LOG.debug("Throttling writer {} for {} second", writerId, waitSeconds);
         try {
             // Sleep does nothing if input is 0 or less.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -124,6 +124,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            int maxParallelism,
             String traceId) {
         this.subtaskId = subtaskId;
         this.tablePath = tablePath;
@@ -135,7 +136,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
         appendRequestSizeBytes = 0L;
         appendResponseFuturesQueue = new LinkedList<>();
         protoRowsBuilder = ProtoRows.newBuilder();
-        throttler = new BigQueryWriterThrottler(subtaskId);
+        throttler = new BigQueryWriterThrottler(subtaskId, maxParallelism);
     }
 
     /** Append pending records and validate all remaining append responses. */

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -106,6 +106,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            int maxParallelism,
             String traceId,
             InitContext context) {
         this(
@@ -119,6 +120,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions,
+                maxParallelism,
                 traceId,
                 context);
     }
@@ -134,6 +136,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            int maxParallelism,
             String traceId,
             InitContext context) {
         super(
@@ -143,6 +146,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions,
+                maxParallelism,
                 traceId);
         this.streamNameInState = StringUtils.isNullOrWhitespaceOnly(streamName) ? "" : streamName;
         this.streamName = this.streamNameInState;

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -63,6 +63,7 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            int maxParallelism,
             String taceId,
             InitContext context) {
         super(
@@ -72,6 +73,7 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
                 schemaProvider,
                 serializer,
                 createTableOptions,
+                maxParallelism,
                 taceId);
         streamName = String.format("%s/streams/_default", tablePath);
         totalRecordsSeen = 0L;

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
@@ -262,10 +262,10 @@ public class BigQueryDefaultSinkTest {
                         .serializer(new AvroToProtoSerializer())
                         .enableTableCreation(true)
                         .streamExecutionEnvironment(env)
-                        .region("us")
+                        .region("US")
                         .build();
         BigQueryDefaultSink sink = new BigQueryDefaultSink(sinkConfig);
-        assertEquals("us", sink.region);
+        assertEquals("US", sink.region);
         assertEquals(512, sink.maxParallelism);
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSinkTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.sink.serializer.FakeBigQuerySerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.TestBigQuerySchemas;
@@ -60,7 +61,7 @@ public class BigQueryExactlyOnceSinkTest {
     public void testConstructor() {
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -95,7 +96,7 @@ public class BigQueryExactlyOnceSinkTest {
                 .thenReturn(UnregisteredMetricsGroup.createSinkWriterMetricGroup());
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -113,7 +114,7 @@ public class BigQueryExactlyOnceSinkTest {
                 .thenReturn(UnregisteredMetricsGroup.createSinkWriterMetricGroup());
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -136,7 +137,7 @@ public class BigQueryExactlyOnceSinkTest {
                 .thenReturn(UnregisteredMetricsGroup.createSinkWriterMetricGroup());
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -161,7 +162,7 @@ public class BigQueryExactlyOnceSinkTest {
     public void testCreateCommitter() {
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -174,7 +175,7 @@ public class BigQueryExactlyOnceSinkTest {
     public void testGetCommittableSerializer() {
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
@@ -187,12 +188,20 @@ public class BigQueryExactlyOnceSinkTest {
     public void testGetWriterStateSerializer() {
         BigQuerySinkConfig sinkConfig =
                 BigQuerySinkConfig.newBuilder()
-                        .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                        .connectOptions(getConnectOptions(true))
                         .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
                         .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
                         .streamExecutionEnvironment(env)
                         .build();
         BigQueryExactlyOnceSink exactlyOnceSink = new BigQueryExactlyOnceSink(sinkConfig);
         assertNotNull(exactlyOnceSink.getWriterStateSerializer());
+    }
+
+    private static BigQueryConnectOptions getConnectOptions(boolean tableExists) {
+        return StorageClientFaker.createConnectOptions(
+                null,
+                new StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageWriteClient(null),
+                new StorageClientFaker.FakeBigQueryServices.FakeQueryDataClient(
+                        tableExists, null, null, null));
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -1149,6 +1149,7 @@ public class BigQueryBufferedWriterTest {
                 TestBigQuerySchemas.getSimpleRecordSchema(),
                 mockSerializer,
                 null,
+                128,
                 "traceId",
                 context);
     }
@@ -1189,6 +1190,7 @@ public class BigQueryBufferedWriterTest {
                 schemaProvider,
                 mockSerializer,
                 createTableOptions,
+                128,
                 "traceId",
                 context);
     }
@@ -1224,6 +1226,7 @@ public class BigQueryBufferedWriterTest {
                 TestBigQuerySchemas.getSimpleRecordSchema(),
                 mockSerializer,
                 null,
+                128,
                 "traceId",
                 context);
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -398,6 +398,7 @@ public class BigQueryDefaultWriterTest {
                 schemaProvider,
                 mockSerializer,
                 createTableOptions,
+                128,
                 "traceId",
                 mockInitContext);
     }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
@@ -20,6 +20,7 @@ import org.apache.flink.annotation.Internal;
 
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamResponse;
@@ -217,6 +218,15 @@ public interface BigQueryServices extends Serializable {
          * @return The BigQuery table {@link TableSchema}.
          */
         TableSchema getTableSchema(String project, String dataset, String table);
+
+        /**
+         * Get BigQuery dataset.
+         *
+         * @param project The GCP project.
+         * @param dataset The BigQuery dataset.
+         * @return The BigQuery {@link Dataset}.
+         */
+        Dataset getDataset(String project, String dataset);
 
         /**
          * Create BigQuery dataset.

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
@@ -35,6 +35,8 @@ import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.StandardSQLTypeName;
@@ -457,6 +459,12 @@ public class BigQueryServicesImpl implements BigQueryServices {
         @Override
         public TableSchema getTableSchema(String project, String dataset, String table) {
             return BigQueryTableInfo.getSchema(bigQuery, project, dataset, table);
+        }
+
+        @Override
+        public Dataset getDataset(String project, String dataset) {
+            DatasetId datasetId = DatasetId.of(project, dataset);
+            return bigQuery.getDataset(datasetId);
         }
 
         @Override


### PR DESCRIPTION
Allow max parallelism of 512 in US and EU, while maintaining 128 in remaining regions.

/gcbrun