### PR TITLE
Apply constant traceID in default writer

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -22,7 +22,6 @@ import org.apache.flink.util.StringUtils;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
-import com.google.cloud.flink.bigquery.services.BigQueryServicesImpl;
 import com.google.cloud.flink.bigquery.sink.client.BigQueryClientWithErrorHandling;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
@@ -62,7 +61,7 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
     final List<String> clusteredFields;
     final String region;
     final int maxParallelism;
-    final String traceId;
+    String traceId;
 
     BigQueryBaseSink(BigQuerySinkConfig sinkConfig) {
         validateSinkConfig(sinkConfig);
@@ -86,7 +85,6 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         clusteredFields = sinkConfig.getClusteredFields();
         region = getRegion(sinkConfig.getRegion());
         maxParallelism = getMaxParallelism();
-        traceId = BigQueryServicesImpl.generateTraceId();
     }
 
     private void validateSinkConfig(BigQuerySinkConfig sinkConfig) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.SinkWriter;
 
+import com.google.cloud.flink.bigquery.services.BigQueryServicesImpl;
 import com.google.cloud.flink.bigquery.sink.writer.BigQueryDefaultWriter;
 
 /**
@@ -32,6 +33,7 @@ class BigQueryDefaultSink extends BigQueryBaseSink {
 
     BigQueryDefaultSink(BigQuerySinkConfig sinkConfig) {
         super(sinkConfig);
+        traceId = BigQueryServicesImpl.generateTraceId("default");
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
@@ -19,6 +19,7 @@ package com.google.cloud.flink.bigquery.sink;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
+import com.google.cloud.flink.bigquery.services.BigQueryServicesImpl;
 import com.google.cloud.flink.bigquery.sink.committer.BigQueryCommittable;
 import com.google.cloud.flink.bigquery.sink.committer.BigQueryCommittableSerializer;
 import com.google.cloud.flink.bigquery.sink.committer.BigQueryCommitter;
@@ -28,6 +29,7 @@ import com.google.cloud.flink.bigquery.sink.writer.BigQueryWriterStateSerializer
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.UUID;
 
 /**
  * Sink to write data into a BigQuery table using {@link BigQueryBufferedWriter}.
@@ -44,6 +46,7 @@ public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
 
     BigQueryExactlyOnceSink(BigQuerySinkConfig sinkConfig) {
         super(sinkConfig);
+        traceId = BigQueryServicesImpl.generateTraceId(UUID.randomUUID().toString());
     }
 
     @Override

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
@@ -77,7 +77,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -572,7 +571,7 @@ public class BigQueryServicesImpl implements BigQueryServices {
         }
     }
 
-    public static final String generateTraceId() {
-        return String.format(TRACE_ID_FORMAT, FLINK_VERSION, UUID.randomUUID().toString());
+    public static final String generateTraceId(String suffix) {
+        return String.format(TRACE_ID_FORMAT, FLINK_VERSION, suffix);
     }
 }


### PR DESCRIPTION
- The connector uses connection pool in default writer as it ensures more efficient usage of the default stream.
- Reason for this commit is a limitation in BQ storage write API's connection pool feature.
- If a user has multiple writers writing to BQ tables in the same BQ region, then all connections must have same traceID.

/gcbrun