### PR TITLE
Fatalize serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ BigQuerySinkConfig<GenericRecord> sinkConfig =
                 .partitionExpirationMillis(...) // OPTIONAL
                 .clusteredFields(...) // OPTIONAL
                 .region(...)  // OPTIONAL
+                .fatalizeSerializer(...) // OPTIONAL
                 .build();
 
 Sink<GenericRecord> sink = BigQuerySink.get(sinkConfig);
@@ -271,6 +272,7 @@ BigQuerySinkTableConfig sinkTableConfig = BigQuerySinkTableConfig.newBuilder()
         .partitionExpirationMillis(...) // OPTIONAL
         .clusteredFields(...) // OPTIONAL
         .region(...)  // OPTIONAL
+        .fatalizeSerializer(...) // OPTIONAL
         .build();
 
 // Register the Sink Table
@@ -303,12 +305,13 @@ The connector supports a number of options to configure the source.
 | `table`                                      | String                 | BigQuery table name (not the full ID). This config is required.                                                                                                        |
 | `credentialsOptions`                         | CredentialsOptions     | Google credentials for connecting to BigQuery. This config is optional, and default behavior is to use the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.      |
 | `deliveryGuarantee`                          | DeliveryGuarantee      | Write consistency guarantee of the sink. This config is required.                                                                                                      |
-| `enableTableCreation`                        | Boolean                | Allows the sink to create the destination BigQuery table (mentioned above) if it doesn't already exist. This config is optional.                                       |
+| `enableTableCreation`                        | Boolean                | Allows the sink to create the destination BigQuery table (mentioned above) if it doesn't already exist. This config is optional, and defaults to false.                |
 | `partitionField`                             | String                 | Column to partition new sink table. This config is optional, and considered if enableTableCreation is true.                                                            |
 | `partitionType`                              | TimePartitioning.Type  | Column to partition new sink table. This config is optional, and considered if enableTableCreation is true.                                                            |
 | `partitionExpirationMillis`                  | Long                   | Expiration time of partitions in new sink table. This config is optional, and considered if enableTableCreation is true.                                               |
 | `clusteredFields`                            | List&lt;String&gt;     | Columns used for clustering new sink table. This config is optional, and considered if enableTableCreation is true.                                                    |
 | `region`                                     | String                 | BigQuery region to create the dataset (mentioned above) if it doesn't already exist. This config is optional, and considered if enableTableCreation is true.           |
+| `fatalizeSerializer`                         | Boolean                | If true, throws a fatal error if sink cannot serialize an input record, else logs the error and drops the record. This config is optional, and defaults to false.      |
 | `sinkParallelism`                            | Integer                | Sink's parallelism. This config is optional, and available only when sink is used with Table API.                                                                      |
 
 Knowing that this sink offers limited configurability when creating destination BigQuery table, we'd like to highlight that almost all

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -60,6 +60,7 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
     final Long partitionExpirationMillis;
     final List<String> clusteredFields;
     final String region;
+    final boolean fatalizeSerializer;
     final int maxParallelism;
     String traceId;
 
@@ -84,6 +85,7 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         partitionExpirationMillis = sinkConfig.getPartitionExpirationMillis();
         clusteredFields = sinkConfig.getClusteredFields();
         region = getRegion(sinkConfig.getRegion());
+        fatalizeSerializer = sinkConfig.fatalizeSerializer();
         maxParallelism = getMaxParallelism();
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -47,6 +47,7 @@ class BigQueryDefaultSink<IN> extends BigQueryBaseSink<IN> {
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                fatalizeSerializer,
                 maxParallelism,
                 traceId,
                 context);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryExactlyOnceSink.java
@@ -59,6 +59,7 @@ public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                fatalizeSerializer,
                 maxParallelism,
                 traceId,
                 context);
@@ -86,6 +87,7 @@ public class BigQueryExactlyOnceSink<IN> extends BigQueryBaseSink<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions(),
+                fatalizeSerializer,
                 maxParallelism,
                 traceId,
                 context);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -64,6 +64,7 @@ public class BigQuerySinkConfig<IN> {
     private final Long partitionExpirationMillis;
     private final List<String> clusteredFields;
     private final String region;
+    private final boolean fatalizeSerializer;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -81,7 +82,8 @@ public class BigQuerySinkConfig<IN> {
                 partitionType,
                 partitionExpirationMillis,
                 clusteredFields,
-                region);
+                region,
+                fatalizeSerializer);
     }
 
     @Override
@@ -106,7 +108,8 @@ public class BigQuerySinkConfig<IN> {
                         this.getPartitionExpirationMillis(), object.getPartitionExpirationMillis()))
                 && (Objects.equals(this.getClusteredFields(), object.getClusteredFields()))
                 && (Objects.equals(this.getRegion(), object.getRegion()))
-                && (Objects.equals(this.getSchemaProvider(), object.getSchemaProvider())));
+                && (Objects.equals(this.getSchemaProvider(), object.getSchemaProvider()))
+                && (this.fatalizeSerializer() == object.fatalizeSerializer()));
     }
 
     private BigQuerySinkConfig(
@@ -119,7 +122,8 @@ public class BigQuerySinkConfig<IN> {
             TimePartitioning.Type partitionType,
             Long partitionExpirationMillis,
             List<String> clusteredFields,
-            String region) {
+            String region,
+            boolean fatalizeSerializer) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -130,6 +134,7 @@ public class BigQuerySinkConfig<IN> {
         this.partitionExpirationMillis = partitionExpirationMillis;
         this.clusteredFields = clusteredFields;
         this.region = region;
+        this.fatalizeSerializer = fatalizeSerializer;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -172,6 +177,10 @@ public class BigQuerySinkConfig<IN> {
         return region;
     }
 
+    public boolean fatalizeSerializer() {
+        return fatalizeSerializer;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -189,6 +198,7 @@ public class BigQuerySinkConfig<IN> {
         private Long partitionExpirationMillis;
         private List<String> clusteredFields;
         private String region;
+        private boolean fatalizeSerializer;
         private StreamExecutionEnvironment env;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
@@ -241,6 +251,11 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> fatalizeSerializer(boolean fatalizeSerializer) {
+            this.fatalizeSerializer = fatalizeSerializer;
+            return this;
+        }
+
         public Builder<IN> streamExecutionEnvironment(
                 StreamExecutionEnvironment streamExecutionEnvironment) {
             this.env = streamExecutionEnvironment;
@@ -261,7 +276,8 @@ public class BigQuerySinkConfig<IN> {
                     partitionType,
                     partitionExpirationMillis,
                     clusteredFields,
-                    region);
+                    region,
+                    fatalizeSerializer);
         }
     }
 
@@ -278,7 +294,8 @@ public class BigQuerySinkConfig<IN> {
             TimePartitioning.Type partitionType,
             Long partitionExpirationMillis,
             List<String> clusteredFields,
-            String region) {
+            String region,
+            boolean fatalizeSerializer) {
         return new BigQuerySinkConfig<>(
                 connectOptions,
                 deliveryGuarantee,
@@ -290,7 +307,8 @@ public class BigQuerySinkConfig<IN> {
                 partitionType,
                 partitionExpirationMillis,
                 clusteredFields,
-                region);
+                region,
+                fatalizeSerializer);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
@@ -97,7 +97,7 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
         } catch (Exception e) {
             throw new BigQuerySerializationException(
                     String.format(
-                            "Error while serialising Avro GenericRecord: %s%nError: %s",
+                            "Error while serialising Avro GenericRecord: %s\nError: %s",
                             record, e.getMessage()),
                     e);
         }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
@@ -91,7 +91,7 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
         } catch (Exception e) {
             throw new BigQuerySerializationException(
                     String.format(
-                            "Error while serialising Row Data record: %s%nError: %s",
+                            "Error while serialising Row Data record: %s\nError: %s",
                             record, e.getMessage()),
                     e);
         }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -98,6 +98,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     private boolean firstWritePostConstructor = true;
 
     final CreateTableOptions createTableOptions;
+    final boolean fatalizeSerializer;
     final String traceId;
     final Queue<AppendInfo> appendResponseFuturesQueue;
     // Initialization of writeClient has been deferred to first append call. BigQuery's best
@@ -124,6 +125,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            boolean fatalizeSerializer,
             int maxParallelism,
             String traceId) {
         this.subtaskId = subtaskId;
@@ -132,6 +134,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
         this.schemaProvider = schemaProvider;
         this.serializer = serializer;
         this.createTableOptions = createTableOptions;
+        this.fatalizeSerializer = fatalizeSerializer;
         this.traceId = traceId;
         appendRequestSizeBytes = 0L;
         appendResponseFuturesQueue = new LinkedList<>();

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -106,6 +106,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            boolean fatalizeSerializer,
             int maxParallelism,
             String traceId,
             InitContext context) {
@@ -120,6 +121,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions,
+                fatalizeSerializer,
                 maxParallelism,
                 traceId,
                 context);
@@ -136,6 +138,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             BigQuerySchemaProvider schemaProvider,
             BigQueryProtoSerializer serializer,
             CreateTableOptions createTableOptions,
+            boolean fatalizeSerializer,
             int maxParallelism,
             String traceId,
             InitContext context) {
@@ -146,6 +149,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 schemaProvider,
                 serializer,
                 createTableOptions,
+                fatalizeSerializer,
                 maxParallelism,
                 traceId);
         this.streamNameInState = StringUtils.isNullOrWhitespaceOnly(streamName) ? "" : streamName;
@@ -184,6 +188,9 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             appendRequestRowCount++;
         } catch (BigQuerySerializationException e) {
             logger.error(String.format("Unable to serialize record %s. Dropping it!", element), e);
+            if (fatalizeSerializer) {
+                throw new BigQueryConnectorException("Unable to serialize record", e);
+            }
         }
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -108,6 +108,7 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
         forwardOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         forwardOptions.add(BigQueryConnectorOptions.REGION);
+        forwardOptions.add(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
 
         return forwardOptions;
     }
@@ -157,6 +158,7 @@ public class BigQueryDynamicTableFactory
                 configProvider.getPartitionType().orElse(null),
                 configProvider.getPartitionExpirationMillis().orElse(null),
                 configProvider.getClusteredFields().orElse(null),
-                configProvider.getRegion().orElse(null));
+                configProvider.getRegion().orElse(null),
+                configProvider.fatalizeSerializer());
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -51,7 +51,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             TimePartitioning.Type partitionType,
             Long partitionExpirationMillis,
             List<String> clusteredFields,
-            String region) {
+            String region,
+            boolean fatalizeSerializer) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
         this.sinkConfig =
@@ -64,7 +65,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         partitionType,
                         partitionExpirationMillis,
                         clusteredFields,
-                        region);
+                        region,
+                        fatalizeSerializer);
     }
 
     @Override
@@ -121,7 +123,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.getPartitionType(),
                 this.sinkConfig.getPartitionExpirationMillis(),
                 this.sinkConfig.getClusteredFields(),
-                this.sinkConfig.getRegion());
+                this.sinkConfig.getRegion(),
+                this.sinkConfig.fatalizeSerializer());
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -215,4 +215,11 @@ public class BigQueryConnectorOptions {
                     .noDefaultValue()
                     .withDescription(
                             "GCP region of destination BigQuery table (used if new table is created)");
+
+    /** [OPTIONAL, Sink Configuration] Fail if serializer cannot convert record to proto. */
+    public static final ConfigOption<Boolean> FATALIZE_SERIALIZER =
+            ConfigOptions.key("write.fatalize-serializer")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Fail if serializer cannot convert record to proto");
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQuerySinkTableConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQuerySinkTableConfig.java
@@ -43,6 +43,7 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
     private final long partitionExpirationMillis;
     private final List<String> clusteredFields;
     private final String region;
+    private final boolean fatalizeSerializer;
 
     BigQuerySinkTableConfig(
             String project,
@@ -59,7 +60,8 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
             TimePartitioning.Type partitionType,
             long partitionExpirationMillis,
             List<String> clusteredFields,
-            String region) {
+            String region,
+            boolean fatalizeSerializer) {
         super(
                 project,
                 dataset,
@@ -76,6 +78,7 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
         this.partitionExpirationMillis = partitionExpirationMillis;
         this.clusteredFields = clusteredFields;
         this.region = region;
+        this.fatalizeSerializer = fatalizeSerializer;
     }
 
     public static Builder newBuilder() {
@@ -121,6 +124,10 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
         if (!StringUtils.isNullOrWhitespaceOnly(region)) {
             tableDescriptorBuilder.option(BigQueryConnectorOptions.REGION, region);
         }
+        if (fatalizeSerializer) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.FATALIZE_SERIALIZER, fatalizeSerializer);
+        }
         return tableDescriptorBuilder.build();
     }
 
@@ -135,6 +142,7 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
         private long partitionExpirationMillis;
         private List<String> clusteredFields;
         private String region;
+        private boolean fatalizeSerializer;
         private StreamExecutionEnvironment env;
 
         @Override
@@ -277,6 +285,18 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
         }
 
         /**
+         * [OPTIONAL, Sink Configuration] Fail if serializer throws {@link
+         * BigQuerySerilizerException}.
+         *
+         * @param fatalizeSerializer
+         * @return Updated BigQuerySinkTableConfig builder
+         */
+        public Builder fatalizeSerializer(boolean fatalizeSerializer) {
+            this.fatalizeSerializer = fatalizeSerializer;
+            return this;
+        }
+
+        /**
          * [Required, Sink Configuration] StreamExecutionEnvironment associated with the Flink job.
          *
          * @param streamExecutionEnvironment
@@ -307,7 +327,8 @@ public class BigQuerySinkTableConfig extends BigQueryTableConfig {
                     partitionType,
                     partitionExpirationMillis,
                     clusteredFields,
-                    region);
+                    region,
+                    fatalizeSerializer);
         }
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -92,6 +92,10 @@ public class BigQueryTableConfigurationProvider {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.REGION));
     }
 
+    public boolean fatalizeSerializer() {
+        return config.get(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
+    }
+
     public BigQueryReadOptions toBigQueryReadOptions() {
         return BigQueryReadOptions.builder()
                 .setSnapshotTimestampInMillis(

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -80,6 +80,7 @@ public class BigQuerySinkConfigTest {
                         .partitionExpirationMillis(10000000000L)
                         .clusteredFields(Arrays.asList("foo", "bar", "qux"))
                         .region("LaLaLand")
+                        .fatalizeSerializer(true)
                         .build();
         assertEquals(connectOptions, sinkConfig.getConnectOptions());
         assertEquals(schemaProvider, sinkConfig.getSchemaProvider());
@@ -91,6 +92,7 @@ public class BigQuerySinkConfigTest {
         assertEquals(10000000000L, sinkConfig.getPartitionExpirationMillis().longValue());
         assertEquals(Arrays.asList("foo", "bar", "qux"), sinkConfig.getClusteredFields());
         assertEquals("LaLaLand", sinkConfig.getRegion());
+        assertTrue(sinkConfig.fatalizeSerializer());
     }
 
     @Test
@@ -108,6 +110,7 @@ public class BigQuerySinkConfigTest {
         assertNull(sinkConfig.getPartitionExpirationMillis());
         assertNull(sinkConfig.getClusteredFields());
         assertNull(sinkConfig.getRegion());
+        assertFalse(sinkConfig.fatalizeSerializer());
     }
 
     @Test

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -1149,6 +1149,7 @@ public class BigQueryBufferedWriterTest {
                 TestBigQuerySchemas.getSimpleRecordSchema(),
                 mockSerializer,
                 null,
+                false,
                 128,
                 "traceId",
                 context);
@@ -1190,6 +1191,7 @@ public class BigQueryBufferedWriterTest {
                 schemaProvider,
                 mockSerializer,
                 createTableOptions,
+                false,
                 128,
                 "traceId",
                 context);
@@ -1226,6 +1228,7 @@ public class BigQueryBufferedWriterTest {
                 TestBigQuerySchemas.getSimpleRecordSchema(),
                 mockSerializer,
                 null,
+                false,
                 128,
                 "traceId",
                 context);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -65,7 +65,8 @@ public class BigQueryDynamicTableSinkTest {
                     TimePartitioning.Type.DAY,
                     10000000000000L,
                     CLUSTERED_FIELDS,
-                    REGION);
+                    REGION,
+                    true);
 
     @RegisterExtension
     static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
@@ -93,6 +94,7 @@ public class BigQueryDynamicTableSinkTest {
         assertEquals(REGION, obtainedSinkConfig.getRegion());
         assertEquals(SCHEMA, TABLE_SINK.getLogicalType());
         assertEquals(PARALLELISM, TABLE_SINK.getSinkParallelism());
+        assertTrue(obtainedSinkConfig.fatalizeSerializer());
     }
 
     @Test


### PR DESCRIPTION
Till now, sink logged the error and dropped the record if it could not be serialized. Now, we add a configuration which allows user to choose between this behavior versus throwing a fatal exception.

/gcbrun