### PR TITLE
Fix: Add `fatalize-serializer` to supported BigQuery connector options

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -81,6 +81,7 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
         additionalOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         additionalOptions.add(BigQueryConnectorOptions.REGION);
+        additionalOptions.add(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
 
         return additionalOptions;
     }


### PR DESCRIPTION
Currently, the fatalize-serializer option is missing from the list of supported connector options, which results in the following error when a user attempts to set it:

```
Unsupported options:

write.fatalize-serializer

Supported options:

connector
credentials.access-token
credentials.file
credentials.key
dataset
...
```