### PR TITLE
Update the jdk version for presubmit dockerfile.

### DIFF
--- a/cloudbuild/presubmit/Dockerfile
+++ b/cloudbuild/presubmit/Dockerfile
@@ -1,2 +1,2 @@
 # This Dockerfile creates an image for running presubmit tests.
-FROM openjdk:8
+FROM openjdk:11


### PR DESCRIPTION
With recent demand to add support for flink 2.1, java 8 is no longer able to support the required versions for various dependencies. 

flink-annotations for example is https://screenshot.googleplex.com/4jYG6ohtKJRs3o8 facing a version mismatch because of this issue. 

/gcbrun