### PR TITLE
Encode better default read stream counts based on task parallelism

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -65,7 +65,13 @@ public class BigQuerySourceEnumerator
             BigQueryReadOptions readOptions, BigQuerySourceEnumState sourceEnumState) {
         switch (this.boundedness) {
             case BOUNDED:
-                return BigQuerySourceSplitAssigner.createBounded(readOptions, sourceEnumState);
+                BigQueryReadOptions optionsWithParallelism =
+                        readOptions
+                                .toBuilder()
+                                .setParallelism(context.currentParallelism())
+                                .build();
+                return BigQuerySourceSplitAssigner.createBounded(
+                        optionsWithParallelism, sourceEnumState);
             default:
                 throw new IllegalArgumentException(
                         "Non supported boundedness: " + this.boundedness);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/assigner/BoundedSplitAssigner.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/assigner/BoundedSplitAssigner.java
@@ -37,7 +37,6 @@ public class BoundedSplitAssigner extends BigQuerySourceSplitAssigner {
 
     @Override
     public void discoverSplits() {
-
         this.remainingTableStreams.addAll(
                 SplitDiscoverer.discoverSplits(
                         this.readOptions.getBigQueryConnectOptions(),
@@ -45,7 +44,8 @@ public class BoundedSplitAssigner extends BigQuerySourceSplitAssigner {
                         this.readOptions.getColumnNames(),
                         this.readOptions.getRowRestriction(),
                         this.readOptions.getSnapshotTimestampInMillis(),
-                        this.readOptions.getMaxStreamCount()));
+                        this.readOptions.getEffectiveMaxStreamCount(),
+                        this.readOptions.getEffectivePreferredMinStreamCount()));
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -343,6 +343,7 @@ public class StorageClientFaker {
             private final SerializableFunction<RecordGenerationParams, List<GenericRecord>>
                     dataGenerator;
             private final Double errorPercentage;
+            private CreateReadSessionRequest lastCreateReadSessionRequest;
 
             public FakeBigQueryStorageReadClient(
                     ReadSession session,
@@ -362,7 +363,12 @@ public class StorageClientFaker {
 
             @Override
             public ReadSession createReadSession(CreateReadSessionRequest request) {
+                this.lastCreateReadSessionRequest = request;
                 return session;
+            }
+
+            public CreateReadSessionRequest getLastCreateReadSessionRequest() {
+                return lastCreateReadSessionRequest;
             }
 
             @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/assigner/BigQuerySourceSplitAssignerTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/assigner/BigQuerySourceSplitAssignerTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.flink.bigquery.source.split.assigner;
 
+import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
 import com.google.cloud.flink.bigquery.source.enumerator.BigQuerySourceEnumState;
@@ -39,7 +41,10 @@ public class BigQuerySourceSplitAssignerTest {
     public void beforeTest() throws IOException {
         this.readOptions =
                 StorageClientFaker.createReadOptions(
-                        0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
+                        .toBuilder()
+                        .setParallelism(1)
+                        .build();
     }
 
     @Test
@@ -77,5 +82,48 @@ public class BigQuerySourceSplitAssignerTest {
         maybeSplit = assigner.getNext();
         Truth8.assertThat(maybeSplit).isEmpty();
         assertThat(assigner.noMoreSplits()).isTrue();
+    }
+
+    @Test
+    public void
+            testOptimizeStreamCountSetsMaxToHundredTimesAndPreferredMinToThreeTimesParallelism() {
+        assertStreamCounts(0, 1, 100, 3);
+        assertStreamCounts(0, 2, 200, 6);
+        assertStreamCounts(0, 4, 400, 12);
+    }
+
+    @Test
+    public void testOptimizeReadStreamCountDisabledWhenMaxStreamCountSet() {
+        // When max-count is explicitly set, optimization is skipped
+        assertStreamCounts(20, 4, 20, 20);
+    }
+
+    private void assertStreamCounts(
+            int configuredMaxStreamCount,
+            int parallelism,
+            int expectedMaxStreamCount,
+            int expectedPreferredMin) {
+        StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient readClient =
+                new StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient(
+                        StorageClientFaker.fakeReadSession(
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING),
+                        params -> StorageClientFaker.createRecordList(params));
+        BigQueryConnectOptions connectOptions =
+                StorageClientFaker.createConnectOptions(readClient, null);
+        BigQueryReadOptions options =
+                BigQueryReadOptions.builder()
+                        .setBigQueryConnectOptions(connectOptions)
+                        .setMaxStreamCount(configuredMaxStreamCount)
+                        .setParallelism(parallelism)
+                        .build();
+
+        BigQuerySourceSplitAssigner assigner =
+                BigQuerySourceSplitAssigner.createBounded(
+                        options, BigQuerySourceEnumState.initialState());
+        assigner.openAndDiscoverSplits();
+
+        CreateReadSessionRequest request = readClient.getLastCreateReadSessionRequest();
+        assertThat(request.getMaxStreamCount()).isEqualTo(expectedMaxStreamCount);
+        assertThat(request.getPreferredMinStreamCount()).isEqualTo(expectedPreferredMin);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -65,7 +65,13 @@ public class BigQuerySourceEnumerator
             BigQueryReadOptions readOptions, BigQuerySourceEnumState sourceEnumState) {
         switch (this.boundedness) {
             case BOUNDED:
-                return BigQuerySourceSplitAssigner.createBounded(readOptions, sourceEnumState);
+                BigQueryReadOptions optionsWithParallelism =
+                        readOptions
+                                .toBuilder()
+                                .setParallelism(context.currentParallelism())
+                                .build();
+                return BigQuerySourceSplitAssigner.createBounded(
+                        optionsWithParallelism, sourceEnumState);
             default:
                 throw new IllegalArgumentException(
                         "Non supported boundedness: " + this.boundedness);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/assigner/BoundedSplitAssigner.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/assigner/BoundedSplitAssigner.java
@@ -37,7 +37,6 @@ public class BoundedSplitAssigner extends BigQuerySourceSplitAssigner {
 
     @Override
     public void discoverSplits() {
-
         this.remainingTableStreams.addAll(
                 SplitDiscoverer.discoverSplits(
                         this.readOptions.getBigQueryConnectOptions(),
@@ -45,7 +44,8 @@ public class BoundedSplitAssigner extends BigQuerySourceSplitAssigner {
                         this.readOptions.getColumnNames(),
                         this.readOptions.getRowRestriction(),
                         this.readOptions.getSnapshotTimestampInMillis(),
-                        this.readOptions.getMaxStreamCount()));
+                        this.readOptions.getEffectiveMaxStreamCount(),
+                        this.readOptions.getEffectivePreferredMinStreamCount()));
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -342,6 +342,7 @@ public class StorageClientFaker {
             private final SerializableFunction<RecordGenerationParams, List<GenericRecord>>
                     dataGenerator;
             private final Double errorPercentage;
+            private CreateReadSessionRequest lastCreateReadSessionRequest;
 
             public FakeBigQueryStorageReadClient(
                     ReadSession session,
@@ -361,7 +362,12 @@ public class StorageClientFaker {
 
             @Override
             public ReadSession createReadSession(CreateReadSessionRequest request) {
+                this.lastCreateReadSessionRequest = request;
                 return session;
+            }
+
+            public CreateReadSessionRequest getLastCreateReadSessionRequest() {
+                return lastCreateReadSessionRequest;
             }
 
             @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/assigner/BigQuerySourceSplitAssignerTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/assigner/BigQuerySourceSplitAssignerTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.flink.bigquery.source.split.assigner;
 
+import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
 import com.google.cloud.flink.bigquery.source.enumerator.BigQuerySourceEnumState;
@@ -39,7 +41,10 @@ public class BigQuerySourceSplitAssignerTest {
     public void beforeTest() throws IOException {
         this.readOptions =
                 StorageClientFaker.createReadOptions(
-                        0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
+                        .toBuilder()
+                        .setParallelism(1)
+                        .build();
     }
 
     @Test
@@ -77,5 +82,48 @@ public class BigQuerySourceSplitAssignerTest {
         maybeSplit = assigner.getNext();
         Truth8.assertThat(maybeSplit).isEmpty();
         assertThat(assigner.noMoreSplits()).isTrue();
+    }
+
+    @Test
+    public void
+            testOptimizeStreamCountSetsMaxToHundredTimesAndPreferredMinToThreeTimesParallelism() {
+        assertStreamCounts(0, 1, 100, 3);
+        assertStreamCounts(0, 2, 200, 6);
+        assertStreamCounts(0, 4, 400, 12);
+    }
+
+    @Test
+    public void testOptimizeReadStreamCountDisabledWhenMaxStreamCountSet() {
+        // When max-count is explicitly set, optimization is skipped
+        assertStreamCounts(20, 4, 20, 20);
+    }
+
+    private void assertStreamCounts(
+            int configuredMaxStreamCount,
+            int parallelism,
+            int expectedMaxStreamCount,
+            int expectedPreferredMin) {
+        StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient readClient =
+                new StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient(
+                        StorageClientFaker.fakeReadSession(
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING),
+                        params -> StorageClientFaker.createRecordList(params));
+        BigQueryConnectOptions connectOptions =
+                StorageClientFaker.createConnectOptions(readClient, null);
+        BigQueryReadOptions options =
+                BigQueryReadOptions.builder()
+                        .setBigQueryConnectOptions(connectOptions)
+                        .setMaxStreamCount(configuredMaxStreamCount)
+                        .setParallelism(parallelism)
+                        .build();
+
+        BigQuerySourceSplitAssigner assigner =
+                BigQuerySourceSplitAssigner.createBounded(
+                        options, BigQuerySourceEnumState.initialState());
+        assigner.openAndDiscoverSplits();
+
+        CreateReadSessionRequest request = readClient.getLastCreateReadSessionRequest();
+        assertThat(request.getMaxStreamCount()).isEqualTo(expectedMaxStreamCount);
+        assertThat(request.getPreferredMinStreamCount()).isEqualTo(expectedPreferredMin);
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/config/BigQueryReadOptions.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/config/BigQueryReadOptions.java
@@ -38,6 +38,9 @@ import java.util.Optional;
 @PublicEvolving
 public abstract class BigQueryReadOptions implements Serializable {
 
+    private static final int PREFERRED_MIN_STREAM_COUNT_MULTIPLIER = 3;
+    private static final int MAX_STREAM_COUNT_MULTIPLIER = 100;
+
     public abstract List<String> getColumnNames();
 
     public abstract String getRowRestriction();
@@ -50,7 +53,33 @@ public abstract class BigQueryReadOptions implements Serializable {
 
     public abstract Integer getMaxRecordsPerSplitFetch();
 
+    public abstract Integer getParallelism();
+
     public abstract BigQueryConnectOptions getBigQueryConnectOptions();
+
+    public int getEffectiveMaxStreamCount() {
+        Preconditions.checkState(
+                getParallelism() > 0,
+                "parallelism must be set before calling getEffectiveMaxStreamCount()");
+
+        if (getMaxStreamCount() == 0) {
+            return MAX_STREAM_COUNT_MULTIPLIER * getParallelism();
+        } else {
+            return getMaxStreamCount();
+        }
+    }
+
+    public int getEffectivePreferredMinStreamCount() {
+        Preconditions.checkState(
+                getParallelism() > 0,
+                "parallelism must be set before calling getEffectivePreferredMinStreamCount()");
+
+        if (getMaxStreamCount() == 0) {
+            return PREFERRED_MIN_STREAM_COUNT_MULTIPLIER * getParallelism();
+        } else {
+            return getMaxStreamCount();
+        }
+    }
 
     @Override
     public final int hashCode() {
@@ -59,6 +88,7 @@ public abstract class BigQueryReadOptions implements Serializable {
                 getRowRestriction(),
                 getSnapshotTimestampInMillis(),
                 getMaxStreamCount(),
+                getParallelism(),
                 getBigQueryConnectOptions());
     }
 
@@ -79,6 +109,7 @@ public abstract class BigQueryReadOptions implements Serializable {
                 && Objects.equals(
                         this.getSnapshotTimestampInMillis(), other.getSnapshotTimestampInMillis())
                 && Objects.equals(this.getMaxStreamCount(), other.getMaxStreamCount())
+                && Objects.equals(this.getParallelism(), other.getParallelism())
                 && Objects.equals(
                         this.getBigQueryConnectOptions(), other.getBigQueryConnectOptions());
     }
@@ -101,6 +132,7 @@ public abstract class BigQueryReadOptions implements Serializable {
                 .setColumnNames(Arrays.asList())
                 .setMaxStreamCount(0)
                 .setMaxRecordsPerSplitFetch(10000)
+                .setParallelism(0)
                 .setSnapshotTimestampInMillis(null);
     }
 
@@ -160,6 +192,15 @@ public abstract class BigQueryReadOptions implements Serializable {
          * @return This {@link Builder} instance.
          */
         public abstract Builder setMaxRecordsPerSplitFetch(Integer maxRecordsPerSplitFetch);
+
+        /**
+         * Sets the parallelism of the source, used to compute effective stream counts when {@code
+         * maxStreamCount} is not explicitly set.
+         *
+         * @param parallelism The parallelism of the source.
+         * @return This {@link Builder} instance.
+         */
+        public abstract Builder setParallelism(Integer parallelism);
 
         /**
          * Sets the {@link BigQueryConnectOptions} instance.

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/split/SplitDiscoverer.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/split/SplitDiscoverer.java
@@ -54,6 +54,8 @@ public class SplitDiscoverer {
      * @param snapshotTimeInMillis The storage snapshot time in millis since epoch, if null is
      *     considered as now.
      * @param maxStreamCount The max stream count required, -1 let BigQuery decide the stream count.
+     * @param preferredMinStreamCount The preferred minimum stream count, BigQuery will make a best
+     *     effort to provide at least this many streams.
      * @return A list with the read stream identifiers.
      */
     public static List<String> discoverSplits(
@@ -62,7 +64,8 @@ public class SplitDiscoverer {
             List<String> columnNames,
             String rowRestriction,
             Optional<Long> snapshotTimeInMillis,
-            Integer maxStreamCount) {
+            Integer maxStreamCount,
+            Integer preferredMinStreamCount) {
         try (BigQueryServices.StorageReadClient client =
                 BigQueryServicesFactory.instance(connectionOptions).storageRead()) {
             String parent = String.format("projects/%s", connectionOptions.getProjectId());
@@ -109,7 +112,8 @@ public class SplitDiscoverer {
                     CreateReadSessionRequest.newBuilder()
                             .setParent(parent)
                             .setReadSession(sessionBuilder)
-                            .setMaxStreamCount(maxStreamCount);
+                            .setMaxStreamCount(maxStreamCount)
+                            .setPreferredMinStreamCount(preferredMinStreamCount);
 
             // request the session
             ReadSession session = client.createReadSession(builder.build());
@@ -118,7 +122,7 @@ public class SplitDiscoverer {
                             + " estimated row count {}, estimated scanned bytes {},"
                             + " streams count {}, expired time {} (seconds after epoch), "
                             + " format: {}, column names: {}, row restriction: \"{}\","
-                            + " snapshot time: {}, max stream count: {}.",
+                            + " snapshot time: {}, max stream count: {}, preferred min stream count: {}.",
                     session.getName(),
                     session.getEstimatedRowCount(),
                     session.getEstimatedTotalBytesScanned(),
@@ -128,7 +132,8 @@ public class SplitDiscoverer {
                     columnNames,
                     rowRestriction,
                     snapshotTimeInMillis,
-                    maxStreamCount);
+                    maxStreamCount,
+                    preferredMinStreamCount);
             // get all the stream names added to the initialized state
             return session.getStreamsList().stream()
                     .map(stream -> stream.getName())


### PR DESCRIPTION
## Summary

Automatically sets BigQuery read stream count hints based on task parallelism:
- `maxStreamCount` = `100 x parallelism`
- `preferredMinStreamCount` = `3 x parallelism`

## Why

Today, the connector sends no stream count hints to BigQuery by default. BigQuery then decides how many streams to create on its own, without any awareness of the Flink job's parallelism. Anecdotally, we see tgat this tends to produce far too many streams (e.g. 1,180 streams for a job with parallelism=3), leading to significant overhead from (presumably) managing and switching between excessive splits (see benchmarking results below).

This change encodes sensible defaults so the connector requests an appropriate number of streams from BigQuery based on how many task managers will actually be reading.

## Why not just minimize stream count?

While fewer streams reduce split-switching overhead and improve raw throughput, there is a trade-off between performance and fault tolerance / resource utilization:

### 1. Checkpoint granularity

Streams that a reader finishes before a checkpoint are durably committed — only *active* (in-progress) streams need to be re-read on failure. With very few streams (e.g. 1 per task), a failure between checkpoints means losing *all* progress and restarting from the beginning of that stream. With more streams per task, most completed streams are already checkpointed, so only the one active stream needs to be replayed.

### 2. Uneven filters

According to Google documentation, BigQuery creates streams *before* any row-level filtering is applied. If filters eliminate data unevenly across streams, some tasks may finish early with nothing left to do while others are still processing. More streams reduce the impact of this skew by distributing the work more evenly. (Splitting existing in-progress streams could address this more directly but is an orthogonal concern for a separate PR).

### 3. Auto-scaling headroom

Flink's [reactive mode](https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/elastic_scaling/#reactive-mode) can add task managers at runtime. The connector naturally supports this; new readers pull splits from the existing session's remaining streams. However, if the initial stream count is too low, there may be no remaining streams to assign to new readers, leaving them idle. A higher stream count provides headroom for scaling up. (Again, splitting existing in-progress streams could address this more directly but is an orthogonal concern for a separate PR).

## How did we decide on the 3x - 100x multiple range?

We benchmarked different stream counts using a simple Flink application that reads from (a 100 million row sample of) `bigquery-public-data.pypi.file_downloads` and writes to a Blackhole Sink with `parallelism = 3` in the cloud. All numbers are `MB/taskmanager/second` across one benchmark run.

| Number of streams | Run 1 | Run 2 | Run 3 | Avg   |
|-------------------|-------|-------|-------|-------|
| 3                 | 62.76 | 63.59 | 76.74 | 67.70 |
| 15                | 61.88 | 53.22 | 65.76 | 60.28 |
| 30                | 54.42 | 54.74 | 53.41 | 54.19 |
| 300               | 70.40 | 51.23 | 78.29 | 66.64 |
| 1180              | 49.13 | 47.09 | 48.59 | 48.27 |

The last row (1,180 streams) is what BigQuery chose when given no hints (i.e. max-stream-count=0). Stream counts in the 1x – 100x range of parallelism consistently produced the best throughput.

Given the trade-offs above:
- **Min 3x parallelism**: enough streams to provide checkpoint granularity, filter-skew resilience, and auto-scaling headroom
- **Max 100x parallelism**: caps overhead while staying close to the optimal throughput range