### PR TITLE
Introduced indexMap for createRowConverter

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -42,7 +42,6 @@ import com.google.cloud.flink.bigquery.common.utils.DateTimeFormatterPatterns;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroSchemaConvertor;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,17 +95,44 @@ public class AvroToRowDataConverters {
                         .map(AvroToRowDataConverters::createNullableConverter)
                         .toArray(AvroToRowDataConverter[]::new);
         final int arity = rowType.getFieldCount();
+        final String[] fieldNames =
+                rowType.getFields().stream().map(RowType.RowField::getName).toArray(String[]::new);
 
-        return avroObject -> {
-            IndexedRecord record = (IndexedRecord) avroObject;
-            GenericRowData row = new GenericRowData(arity);
-            for (int i = 0; i < arity; ++i) {
-                // avro always deserialize successfully even though the type isn't matched
-                // so no need to throw exception about which field can't be deserialized
-                row.setField(i, fieldConverters[i].convert(record.get(i)));
+        return new AvroToRowDataConverter() {
+            private int[] indexMapping;
+
+            @Override
+            public Object convert(Object avroObject) {
+                GenericRecord record = (GenericRecord) avroObject;
+                if (indexMapping == null) {
+                    indexMapping = computeIndexMapping(record, fieldNames);
+                }
+                GenericRowData row = new GenericRowData(arity);
+                for (int i = 0; i < arity; ++i) {
+                    row.setField(i, fieldConverters[i].convert(record.get(indexMapping[i])));
+                }
+                return row;
             }
-            return row;
         };
+    }
+
+    private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
+        int[] mapping = new int[fieldNames.length];
+        List<String> avroFieldNames = new java.util.ArrayList<>();
+        for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
+            avroFieldNames.add(f.name());
+        }
+        for (int i = 0; i < fieldNames.length; i++) {
+            org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
+            if (field == null) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Field '%s' not found in Avro schema. Available fields: %s",
+                                fieldNames[i], avroFieldNames));
+            }
+            mapping[i] = field.pos();
+        }
+        return mapping;
     }
 
     /** Creates a runtime converter which is null safe. */

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -118,13 +118,13 @@ public class AvroToRowDataConverters {
 
     private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
         int[] mapping = new int[fieldNames.length];
-        List<String> avroFieldNames = new java.util.ArrayList<>();
-        for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
-            avroFieldNames.add(f.name());
-        }
         for (int i = 0; i < fieldNames.length; i++) {
             org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
             if (field == null) {
+                List<String> avroFieldNames = new java.util.ArrayList<>();
+                for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
+                    avroFieldNames.add(f.name());
+                }
                 throw new IllegalArgumentException(
                         String.format(
                                 "Field '%s' not found in Avro schema. Available fields: %s",

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
@@ -4,9 +4,13 @@ import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
@@ -20,6 +24,7 @@ import org.apache.flink.types.RowKind;
 
 import com.google.cloud.flink.bigquery.source.reader.deserializer.AvroToRowDataConverters;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
@@ -30,6 +35,7 @@ import org.junit.Test;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -421,5 +427,148 @@ public class AvroToRowDataConvertersTest {
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "Unexpected Avro object abcd of type 'class java.lang.String' input for conversion to Flink's 'BYTE' logical type. Supported type(s): 'GenericFixed, byte[] and java.nio.ByteBuffer'");
+    }
+
+    @Test
+    public void testColumnOrderMismatchBetweenAvroAndRowType() {
+        // Create the logical type schema — fields in different order than Avro
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", new VarCharType()),
+                                new RowField("third_field", new DoubleType()),
+                                new RowField("first_field", new IntType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — fields in original table order
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"int\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"double\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", 42)
+                        .set("second_field", "value_b")
+                        .set("third_field", 99.5)
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(StringData.fromString("value_b"), 99.5, 42), result);
+    }
+
+    @Test
+    public void testColumnSubsetWithDifferentOrder() {
+        // Create the logical type schema — 2 of 4 columns, in reversed order
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("third_field", new BigIntType()),
+                                new RowField("second_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — all 4 columns in table order
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"int\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"long\"},\n"
+                        + "   {\"name\": \"fourth_field\", \"type\": \"string\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", 1)
+                        .set("second_field", "value_b")
+                        .set("third_field", 500L)
+                        .set("fourth_field", "value_d")
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(500L, StringData.fromString("value_b")), result);
+    }
+
+    @Test
+    public void testProjectionPushdownReordersColumns() {
+        // Create the logical type schema — projection reorders columns vs Avro
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", new BigIntType()),
+                                new RowField("first_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — Avro has first before second (opposite of RowType)
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"long\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"string\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", "value_a")
+                        .set("second_field", 12345L)
+                        .set("third_field", "value_c")
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(12345L, StringData.fromString("value_a")), result);
+    }
+
+    @Test
+    public void testNestedRowIndexMapping() {
+        // Create the logical type schema — reversed field order at both levels
+        RowType innerRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_inner", new VarCharType()),
+                                new RowField("first_inner", new VarCharType())));
+        RowType outerRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", innerRowType),
+                                new RowField("first_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outerRowType);
+        // Create the AvroRecord — first_field before second_field; first_inner before second_inner
+        Schema innerAvroSchema =
+                org.apache.avro.SchemaBuilder.record("second_field")
+                        .fields()
+                        .requiredString("first_inner")
+                        .requiredString("second_inner")
+                        .endRecord();
+        Schema outerAvroSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .requiredString("first_field")
+                        .name("second_field")
+                        .type(innerAvroSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord innerRecord =
+                new GenericRecordBuilder(innerAvroSchema)
+                        .set("first_inner", "inner_a")
+                        .set("second_inner", "inner_b")
+                        .build();
+        GenericRecord outerRecord =
+                new GenericRecordBuilder(outerAvroSchema)
+                        .set("first_field", "outer_a")
+                        .set("second_field", innerRecord)
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(outerRecord);
+        GenericRowData expectedInner =
+                GenericRowData.of(
+                        StringData.fromString("inner_b"), StringData.fromString("inner_a"));
+        GenericRowData expectedOuter =
+                GenericRowData.of(expectedInner, StringData.fromString("outer_a"));
+        assertEquals(expectedOuter, result);
+        // Verify sub-field access returns correct values after index mapping.
+        GenericRowData row = (GenericRowData) result;
+        GenericRowData innerRow = (GenericRowData) row.getField(0);
+        assertEquals(StringData.fromString("inner_b"), innerRow.getField(0));
+        assertEquals(StringData.fromString("inner_a"), innerRow.getField(1));
+        assertEquals(StringData.fromString("outer_a"), row.getField(1));
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -42,7 +42,6 @@ import com.google.cloud.flink.bigquery.common.utils.DateTimeFormatterPatterns;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroSchemaConvertor;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,17 +95,44 @@ public class AvroToRowDataConverters {
                         .map(AvroToRowDataConverters::createNullableConverter)
                         .toArray(AvroToRowDataConverter[]::new);
         final int arity = rowType.getFieldCount();
+        final String[] fieldNames =
+                rowType.getFields().stream().map(RowType.RowField::getName).toArray(String[]::new);
 
-        return avroObject -> {
-            IndexedRecord record = (IndexedRecord) avroObject;
-            GenericRowData row = new GenericRowData(arity);
-            for (int i = 0; i < arity; ++i) {
-                // avro always deserialize successfully even though the type isn't matched
-                // so no need to throw exception about which field can't be deserialized
-                row.setField(i, fieldConverters[i].convert(record.get(i)));
+        return new AvroToRowDataConverter() {
+            private int[] indexMapping;
+
+            @Override
+            public Object convert(Object avroObject) {
+                GenericRecord record = (GenericRecord) avroObject;
+                if (indexMapping == null) {
+                    indexMapping = computeIndexMapping(record, fieldNames);
+                }
+                GenericRowData row = new GenericRowData(arity);
+                for (int i = 0; i < arity; ++i) {
+                    row.setField(i, fieldConverters[i].convert(record.get(indexMapping[i])));
+                }
+                return row;
             }
-            return row;
         };
+    }
+
+    private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
+        int[] mapping = new int[fieldNames.length];
+        List<String> avroFieldNames = new java.util.ArrayList<>();
+        for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
+            avroFieldNames.add(f.name());
+        }
+        for (int i = 0; i < fieldNames.length; i++) {
+            org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
+            if (field == null) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Field '%s' not found in Avro schema. Available fields: %s",
+                                fieldNames[i], avroFieldNames));
+            }
+            mapping[i] = field.pos();
+        }
+        return mapping;
     }
 
     /** Creates a runtime converter which is null safe. */

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -118,13 +118,13 @@ public class AvroToRowDataConverters {
 
     private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
         int[] mapping = new int[fieldNames.length];
-        List<String> avroFieldNames = new java.util.ArrayList<>();
-        for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
-            avroFieldNames.add(f.name());
-        }
         for (int i = 0; i < fieldNames.length; i++) {
             org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
             if (field == null) {
+                List<String> avroFieldNames = new java.util.ArrayList<>();
+                for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
+                    avroFieldNames.add(f.name());
+                }
                 throw new IllegalArgumentException(
                         String.format(
                                 "Field '%s' not found in Avro schema. Available fields: %s",

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
@@ -4,9 +4,13 @@ import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
@@ -20,6 +24,7 @@ import org.apache.flink.types.RowKind;
 
 import com.google.cloud.flink.bigquery.source.reader.deserializer.AvroToRowDataConverters;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
@@ -30,6 +35,7 @@ import org.junit.Test;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -421,5 +427,148 @@ public class AvroToRowDataConvertersTest {
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "Unexpected Avro object abcd of type 'class java.lang.String' input for conversion to Flink's 'BYTE' logical type. Supported type(s): 'GenericFixed, byte[] and java.nio.ByteBuffer'");
+    }
+
+    @Test
+    public void testColumnOrderMismatchBetweenAvroAndRowType() {
+        // Create the logical type schema — fields in different order than Avro
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", new VarCharType()),
+                                new RowField("third_field", new DoubleType()),
+                                new RowField("first_field", new IntType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — fields in original table order
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"int\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"double\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", 42)
+                        .set("second_field", "value_b")
+                        .set("third_field", 99.5)
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(StringData.fromString("value_b"), 99.5, 42), result);
+    }
+
+    @Test
+    public void testColumnSubsetWithDifferentOrder() {
+        // Create the logical type schema — 2 of 4 columns, in reversed order
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("third_field", new BigIntType()),
+                                new RowField("second_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — all 4 columns in table order
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"int\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"long\"},\n"
+                        + "   {\"name\": \"fourth_field\", \"type\": \"string\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", 1)
+                        .set("second_field", "value_b")
+                        .set("third_field", 500L)
+                        .set("fourth_field", "value_d")
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(500L, StringData.fromString("value_b")), result);
+    }
+
+    @Test
+    public void testProjectionPushdownReordersColumns() {
+        // Create the logical type schema — projection reorders columns vs Avro
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", new BigIntType()),
+                                new RowField("first_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType);
+        // Create the AvroRecord — Avro has first before second (opposite of RowType)
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"first_field\", \"type\": \"string\"},\n"
+                        + "   {\"name\": \"second_field\", \"type\": \"long\"},\n"
+                        + "   {\"name\": \"third_field\", \"type\": \"string\"}]";
+        Schema avroSchema = getAvroSchemaFromFieldString(fieldString);
+        IndexedRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("first_field", "value_a")
+                        .set("second_field", 12345L)
+                        .set("third_field", "value_c")
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(record);
+        assertEquals(GenericRowData.of(12345L, StringData.fromString("value_a")), result);
+    }
+
+    @Test
+    public void testNestedRowIndexMapping() {
+        // Create the logical type schema — reversed field order at both levels
+        RowType innerRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_inner", new VarCharType()),
+                                new RowField("first_inner", new VarCharType())));
+        RowType outerRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("second_field", innerRowType),
+                                new RowField("first_field", new VarCharType())));
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outerRowType);
+        // Create the AvroRecord — first_field before second_field; first_inner before second_inner
+        Schema innerAvroSchema =
+                org.apache.avro.SchemaBuilder.record("second_field")
+                        .fields()
+                        .requiredString("first_inner")
+                        .requiredString("second_inner")
+                        .endRecord();
+        Schema outerAvroSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .requiredString("first_field")
+                        .name("second_field")
+                        .type(innerAvroSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord innerRecord =
+                new GenericRecordBuilder(innerAvroSchema)
+                        .set("first_inner", "inner_a")
+                        .set("second_inner", "inner_b")
+                        .build();
+        GenericRecord outerRecord =
+                new GenericRecordBuilder(outerAvroSchema)
+                        .set("first_field", "outer_a")
+                        .set("second_field", innerRecord)
+                        .build();
+        // Convert and Assert.
+        Object result = converter.convert(outerRecord);
+        GenericRowData expectedInner =
+                GenericRowData.of(
+                        StringData.fromString("inner_b"), StringData.fromString("inner_a"));
+        GenericRowData expectedOuter =
+                GenericRowData.of(expectedInner, StringData.fromString("outer_a"));
+        assertEquals(expectedOuter, result);
+        // Verify sub-field access returns correct values after index mapping.
+        GenericRowData row = (GenericRowData) result;
+        GenericRowData innerRow = (GenericRowData) row.getField(0);
+        assertEquals(StringData.fromString("inner_b"), innerRow.getField(0));
+        assertEquals(StringData.fromString("inner_a"), innerRow.getField(1));
+        assertEquals(StringData.fromString("outer_a"), row.getField(1));
     }
 }


### PR DESCRIPTION
## Fix name-based field mapping in Avro-to-RowData deserialization

### What

Replaces positional (index-based) field access in `AvroToRowDataConverters.createRowConverter` with a name-based index mapping that matches Avro fields to Flink's `RowType` fields by name rather than ordinal position. The mapping is computed lazily on the first record and cached for the lifetime of the converter. This allows for "out-of-order" columns in later statements to properly map the correct data from BQ.

**Note:** We must lazily compute our mapping because we don't have the Avro schema at  creation time + BigQuery [documents](https://docs.cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions): "The order of the fields in the read session schema is derived from the table schema and does not correspond to the order in which the fields are specified in this list." Means with the "arbitrary" column ordering we now allow, we have no assumption of Flink DDL and physical schema ordering being consistent, so must get our schema physically from first record.

### Why

The BigQuery Storage Read API returns fields in the order they appear in the table schema, regardless of the order requested via `selectedFields` in a projection pushdown. The previous implementation used `record.get(i)` which assumed the Avro field at position corresponded to the Flink `RowType` field at position. When `applyProjection()` requested columns in a different order than the table definition, this resulted in silent data corruption where values were placed into the wrong columns without throwing an exception. This behaviour is because of the fundamental assumption that the DDL ordering and the physical table ordering were consistent with each other, but in practise found that this assumption is easily missed by users and not loudly breaking when is violated. This is why we introduced this tolerance to different column ordering.

### How

- `createRowConverter` now extracts field names from the `RowType` and, on the first `convert()` call, builds an `int[] indexMapping` via `computeIndexMapping()`.
- `computeIndexMapping` looks up each `RowType` field name in the Avro record's schema using `Schema.getField(name)` and stores `field.pos()`.
- Deserialization uses `record.get(indexMapping[i])` instead of `record.get(i)`.
- The mapping is recursive where nested `ROW` types each get their own converter instance with an independent index map.
- If a field name is not found in the Avro schema, an `IllegalArgumentException` is thrown with a clear message listing available fields.

### Testing

Added 4 unit tests to `AvroToRowDataConvertersTest` for both Flink 1.17 and 2.1:

| Test | Scenario |
|------|----------|
| `testColumnOrderMismatchBetweenAvroAndRowType` | 3 fields where RowType order differs from Avro order |
| `testColumnSubsetWithDifferentOrder` | 2 of 4 fields selected in reversed order |
| `testProjectionPushdownReordersColumns` | Projection reorders columns with an extra unused Avro field |
| `testNestedRowIndexMapping` | Reversed field order at both outer and inner ROW levels, with sub-field access assertions |

