### PR TITLE
feat: report standard Flink numRecordsSend/numBytesSend sink metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,16 +497,44 @@ Apache Flink allows collecting metrics internally to better understand the statu
 clusters during the development process.
 Each operator in Flink maintains its own set of metrics,
 which are collected by the Task Manager where the operator is running.
-Currently, the Flink-BigQuery Connector 
-supports collection and reporting of the following metrics in BigQuery sink:
 
-| Metric Name                                        | Metric Description                                                                                                                                                                                                                                                                                                                                                               | Supported By (At-least Once Sink /Exactly Once Sink) |
-|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| `numberOfRecordsSeenByWriter`                      | Counter to keep track of the total number of records seen by the writer.                                                                                                                                                                                                                                                                                                         | At-least Once Sink, Exactly Once Sink                |
-| `numberOfRecordsSeenByWriterSinceCheckpoint `      | Counter to keep track of the number of records seen by the writer since the last checkpoint.                                                                                                                                                                                                                                                                                     | At-least Once Sink, Exactly Once Sink                |
-| `numberOfRecordsWrittenToBigQuery`                 | Counter to keep track of the number of records successfully written to BigQuery until now.                                                                                                                                                                                                                                                                                       | At-least Once Sink, Exactly Once Sink                |
-| `numberOfRecordsWrittenToBigQuerySinceCheckpoint`  | Counter to keep track of the number of records successfully written to BigQuery since the last checkpoint.                                                                                                                                                                                                                                                                       | At-least Once Sink                                   |
-| `numberOfRecordsBufferedByBigQuerySinceCheckpoint` | Counter to keep track of the number of records currently buffered by the Storage Write API stream before committing them to the BigQuery Table. These records will be added to the Table following [Two Phase Commit Protocol's](https://nightlies.apache.org/flink/flink-docs-release-1.20/api/java/org/apache/flink/api/connector/sink2/Committer.html) `commit()` invocation. | Exactly Once Sink                                    |
+### Standard Flink Sink Metrics
+
+The connector reports the following standard Flink sink metrics via `SinkWriterMetricGroup`.
+These are the metrics that the Flink Web UI and monitoring integrations (Datadog, Prometheus, etc.) display automatically for any sink connector.
+
+| Metric Name      | Metric Description                                                                                                                                                                          | Supported By (At-least Once Sink / Exactly Once Sink) |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `numRecordsSend` | Total number of records serialized and buffered for sending to BigQuery. Excludes records that failed serialization or exceeded the maximum request size. Does not wait for BigQuery confirmation. | At-least Once Sink, Exactly Once Sink                 |
+| `numBytesSend`   | Total serialized protobuf bytes (including per-row overhead) buffered for sending to BigQuery.                                                                                               | At-least Once Sink, Exactly Once Sink                 |
+
+### Connector-Specific Metrics
+
+The connector also reports the following custom metrics for more detailed observability of the write pipeline:
+
+| Metric Name                                        | Metric Description                                                                                                                                                                                                                                                                                                                                                               | Supported By (At-least Once Sink / Exactly Once Sink) |
+|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `numberOfRecordsSeenByWriter`                      | Counter to keep track of the total number of records seen by the writer. Includes all records, even those that fail serialization or exceed the maximum request size.                                                                                                                                                                                                             | At-least Once Sink, Exactly Once Sink                 |
+| `numberOfRecordsSeenByWriterSinceCheckpoint `      | Counter to keep track of the number of records seen by the writer since the last checkpoint.                                                                                                                                                                                                                                                                                     | At-least Once Sink, Exactly Once Sink                 |
+| `numberOfRecordsWrittenToBigQuery`                 | Counter to keep track of the number of records confirmed as successfully written by BigQuery.                                                                                                                                                                                                                                                                                    | At-least Once Sink, Exactly Once Sink                 |
+| `numberOfRecordsWrittenToBigQuerySinceCheckpoint`  | Counter to keep track of the number of records successfully written to BigQuery since the last checkpoint.                                                                                                                                                                                                                                                                       | At-least Once Sink                                    |
+| `numberOfRecordsBufferedByBigQuerySinceCheckpoint` | Counter to keep track of the number of records currently buffered by the Storage Write API stream before committing them to the BigQuery Table. These records will be added to the Table following [Two Phase Commit Protocol's](https://nightlies.apache.org/flink/flink-docs-release-1.20/api/java/org/apache/flink/api/connector/sink2/Committer.html) `commit()` invocation. | Exactly Once Sink                                     |
+
+### How Record Counters Relate
+
+The three record counters track records at different stages of the write pipeline:
+
+```
+write() called
+  → numberOfRecordsSeenByWriter (all records, including failures)
+  → serialize record
+  → numRecordsSend (records successfully serialized and buffered)
+  → ... BigQuery confirms ...
+  → numberOfRecordsWrittenToBigQuery (records confirmed by BigQuery)
+```
+
+If `numberOfRecordsSeenByWriter` is higher than `numRecordsSend`, records are failing serialization.
+If `numRecordsSend` is higher than `numberOfRecordsWrittenToBigQuery`, records are buffered but not yet confirmed by BigQuery.
 
 ### Viewing Flink Metrics
 * Flink offers a variety of metric reporters which the users could use to view these metrics.

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -20,11 +20,13 @@ collect and report Flink Metrics for a Flink Application.
 The details of the metrics supported so far are available in the 
 [README](https://github.com/GoogleCloudDataproc/flink-bigquery-connector/blob/main/README.md#flink-metrics).
 
-An overview of records seen by the writer and number of records successfully written to 
-BigQuery would enable users to track the flow of records through their application. 
-Comparison of the counts would help troubleshoot if records are being seen by the Sink (Writer) 
-at all, are being serialized and send to the Write API and if BigQuery is able to write 
-these records.
+The connector reports standard Flink sink metrics (`numRecordsSend`, `numBytesSend`) that appear
+automatically in the Flink Web UI and monitoring tools, as well as connector-specific metrics for
+deeper observability.
+
+Comparing the three record counters helps pinpoint where records are being lost:
+- `numberOfRecordsSeenByWriter` > `numRecordsSend` → records are failing serialization
+- `numRecordsSend` > `numberOfRecordsWrittenToBigQuery` → records are buffered but not yet confirmed by BigQuery
 
 See Flink’s documentation on 
 [Metric Reporters](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/) 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -123,6 +123,8 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     Counter numberOfRecordsWrittenToBigQuery;
     Counter numberOfRecordsSeenByWriter;
     Counter numberOfRecordsSeenByWriterSinceCheckpoint;
+    Counter numRecordsSend;
+    Counter numBytesSend;
 
     BaseWriter(
             int subtaskId,
@@ -230,7 +232,10 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     /** Add serialized record to append request. */
     void addToAppendRequest(ByteString protoRow) {
         protoRowsBuilder.addSerializedRows(protoRow);
-        appendRequestSizeBytes += getProtoRowBytes(protoRow);
+        int rowBytes = getProtoRowBytes(protoRow);
+        appendRequestSizeBytes += rowBytes;
+        numRecordsSend.inc();
+        numBytesSend.inc(rowBytes);
     }
 
     /** Send append request to BigQuery storage and prepare for next append request. */
@@ -398,6 +403,8 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
                 sinkWriterMetricGroup.counter("numberOfRecordsWrittenToBigQuery");
         numberOfRecordsSeenByWriterSinceCheckpoint =
                 sinkWriterMetricGroup.counter("numberOfRecordsSeenByWriterSinceCheckpoint");
+        numRecordsSend = sinkWriterMetricGroup.getNumRecordsSendCounter();
+        numBytesSend = sinkWriterMetricGroup.getNumBytesSendCounter();
     }
 
     TableDefinition getTableDefinition() {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -93,6 +93,8 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(0, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(0, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test
@@ -116,7 +118,23 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        assertEquals(1, defaultWriter.numRecordsSend.getCount());
+        assertEquals(5, defaultWriter.numBytesSend.getCount());
         getTestQueryClient();
+    }
+
+    @Test
+    public void testStandardFlinkMetrics_afterWrite() {
+        BigQueryDefaultWriter<Object> defaultWriter =
+                createDefaultWriter(
+                        new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")), null);
+        // "foo" is 3 bytes, plus 2 bytes protobuf overhead = 5 bytes per record.
+        defaultWriter.write(new Object(), null);
+        assertEquals(1, defaultWriter.numRecordsSend.getCount());
+        assertEquals(5, defaultWriter.numBytesSend.getCount());
+        defaultWriter.write(new Object(), null);
+        assertEquals(2, defaultWriter.numRecordsSend.getCount());
+        assertEquals(10, defaultWriter.numBytesSend.getCount());
     }
 
     @Test
@@ -320,6 +338,10 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        // Standard metrics should NOT be incremented when serialization fails
+        // (record not added to append request).
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test(expected = BigQueryConnectorException.class)
@@ -358,6 +380,9 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        // Standard metrics should NOT be incremented when element exceeds max request size.
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test(expected = BigQueryConnectorException.class)

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -123,6 +123,8 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     Counter numberOfRecordsWrittenToBigQuery;
     Counter numberOfRecordsSeenByWriter;
     Counter numberOfRecordsSeenByWriterSinceCheckpoint;
+    Counter numRecordsSend;
+    Counter numBytesSend;
 
     BaseWriter(
             int subtaskId,
@@ -226,7 +228,10 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     /** Add serialized record to append request. */
     void addToAppendRequest(ByteString protoRow) {
         protoRowsBuilder.addSerializedRows(protoRow);
-        appendRequestSizeBytes += getProtoRowBytes(protoRow);
+        int rowBytes = getProtoRowBytes(protoRow);
+        appendRequestSizeBytes += rowBytes;
+        numRecordsSend.inc();
+        numBytesSend.inc(rowBytes);
     }
 
     /** Send append request to BigQuery storage and prepare for next append request. */
@@ -394,6 +399,8 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
                 sinkWriterMetricGroup.counter("numberOfRecordsWrittenToBigQuery");
         numberOfRecordsSeenByWriterSinceCheckpoint =
                 sinkWriterMetricGroup.counter("numberOfRecordsSeenByWriterSinceCheckpoint");
+        numRecordsSend = sinkWriterMetricGroup.getNumRecordsSendCounter();
+        numBytesSend = sinkWriterMetricGroup.getNumBytesSendCounter();
     }
 
     TableDefinition getTableDefinition() {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -93,6 +93,8 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(0, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(0, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test
@@ -116,7 +118,23 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        assertEquals(1, defaultWriter.numRecordsSend.getCount());
+        assertEquals(5, defaultWriter.numBytesSend.getCount());
         getTestQueryClient();
+    }
+
+    @Test
+    public void testStandardFlinkMetrics_afterWrite() {
+        BigQueryDefaultWriter<Object> defaultWriter =
+                createDefaultWriter(
+                        new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")), null);
+        // "foo" is 3 bytes, plus 2 bytes protobuf overhead = 5 bytes per record.
+        defaultWriter.write(new Object(), null);
+        assertEquals(1, defaultWriter.numRecordsSend.getCount());
+        assertEquals(5, defaultWriter.numBytesSend.getCount());
+        defaultWriter.write(new Object(), null);
+        assertEquals(2, defaultWriter.numRecordsSend.getCount());
+        assertEquals(10, defaultWriter.numBytesSend.getCount());
     }
 
     @Test
@@ -322,6 +340,10 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        // Standard metrics should NOT be incremented when serialization fails
+        // (record not added to append request).
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test(expected = BigQueryConnectorException.class)
@@ -360,6 +382,9 @@ public class BigQueryDefaultWriterTest {
         assertEquals(0, defaultWriter.numberOfRecordsWrittenToBigQuerySinceCheckpoint.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriter.getCount());
         assertEquals(1, defaultWriter.numberOfRecordsSeenByWriterSinceCheckpoint.getCount());
+        // Standard metrics should NOT be incremented when element exceeds max request size.
+        assertEquals(0, defaultWriter.numRecordsSend.getCount());
+        assertEquals(0, defaultWriter.numBytesSend.getCount());
     }
 
     @Test(expected = BigQueryConnectorException.class)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                           
                                                            
  - Add standard Flink sink output metrics (`numRecordsSend` / `numBytesSend`) to the BigQuery connector so the Flink Web UI and monitoring tools (Datadog, Prometheus, etc.) display output throughput                                                
  - Retrieve counters from `SinkWriterMetricGroup.getNumRecordsSendCounter()` / `getNumBytesSendCounter()` and increment them in `BaseWriter.addToAppendRequest()`
  - Changes applied to both Flink 1.17 and 2.1 modules                                                                                                                                                                                                 
  - Updated README and TROUBLESHOOT docs                    
                                                                                                                                                                                                                                                       
  ## How numRecordsSend relates to existing custom metrics  

  The connector has three record counters at different stages of the write pipeline:                                                                                                                                                                   
   
  ```mermaid                                                                                                                                                                                                                                           
  flowchart LR                                              
      A["write() called"] --> B["preWrite()"]
      B -->|"numberOfRecordsSeenByWriter
      (all records, including failures)"| C["serialize record"]                                                                                                                                                                                        
      C -->|"serialization fails or
      record too large"| D["❌ record dropped"]                                                                                                                                                                                                        
      C -->|success| E["addToAppendRequest()"]              
      E -->|"numRecordsSend NEW                                                                                                                                                                                                                     
      numBytesSend NEW                                   
      (serialized and buffered)"| F["BigQuery append"]                                                                                                                                                                                                 
      F --> G["validateAppendResponse()"]                   
      G -->|"numberOfRecordsWrittenToBigQuery                                                                                                                                                                                                          
      (confirmed by BigQuery)"| H["✅ done"]                
  ```                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                       
  | Metric | Incremented at | What it captures |
  |--------|---------------|------------------|                                                                                                                                                                                                        
  | `numberOfRecordsSeenByWriter` | `preWrite()` - on entry to `write()` | All records, including ones that fail serialization or exceed max request size |
  | **`numRecordsSend`** (NEW) | `addToAppendRequest()` - after serialization | Records successfully serialized and buffered for sending. Excludes serialization failures. Does not wait for BigQuery confirmation |                                   
  | **`numBytesSend`** (NEW) | `addToAppendRequest()` -  after serialization | Serialized protobuf bytes (including 2-byte per-row overhead) buffered for sending |
  | `numberOfRecordsWrittenToBigQuery` | `validateAppendResponse()` - after BigQuery confirms | Only records confirmed by BigQuery |                                                                                                                   
                                                                                                                                                                                                                                                       
  **Troubleshooting with these counters:**                                                                                                                                                                                                             
  - `numberOfRecordsSeenByWriter` > `numRecordsSend` → records are failing serialization                                                                                                                                                               
  - `numRecordsSend` > `numberOfRecordsWrittenToBigQuery` → records are buffered but not yet confirmed by BigQuery                                                                                                                                     
                                                                                                                                                                                                                                                       
  ## Test plan
                                                                                                                                                                                                                                                       
  - [ ] `BigQueryDefaultWriterTest` passes for both Flink 1.17 and 2.1 (40 tests each)
  - [ ] `BigQueryBufferedWriterTest` passes for both modules (no changes needed — `addToAppendRequest` is in `BaseWriter`)
  - [ ] New `testStandardFlinkMetrics_afterWrite` test verifies counters accumulate correctly across writes                                                                                                                                            
  - [ ] Existing tests for serialization failures and oversized elements verify counters are NOT incremented
