### PR TITLE
Fix NoClassDefFoundError in shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,14 @@ under the License.
                                     <exclude>org.apache.flink:*</exclude>
                                 </excludes>
                             </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>joda-time:joda-time</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>com.google</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@ under the License.
                                     <include>io.grpc:*</include>
                                     <include>io.opencensus:*</include>
                                     <include>io.perfmark:*</include>
+                                    <include>io.opentelemetry:*</include>
                                     <include>joda-time:joda-time</include>
                                     <include>org.json:json</include>
                                 </includes>
@@ -429,6 +430,10 @@ under the License.
                                 <relocation>
                                     <pattern>io.perfmark</pattern>
                                     <shadedPattern>com.google.cloud.flink.bigquery.shaded.io.perfmark</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.opentelemetry</pattern>
+                                    <shadedPattern>com.google.cloud.flink.bigquery.shaded.io.opentelemetry</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml</pattern>

--- a/scripts/verify-shading.sh
+++ b/scripts/verify-shading.sh
@@ -28,5 +28,20 @@ if [ $? -eq 0 ]; then
   exit 1
 else
   echo "No unshaded classes found"
-  exit 0
 fi
+
+# Verify required dependencies are present (not stripped by minimizeJar)
+REQUIRED_SHADED_PACKAGES=(
+  "com/google/cloud/flink/bigquery/shaded/org/joda/time"
+)
+
+JAR_CONTENT=$(jar tvf "${JAR_FILE}")
+for pkg in "${REQUIRED_SHADED_PACKAGES[@]}"; do
+  if ! echo "${JAR_CONTENT}" | grep -q "${pkg}"; then
+    echo "ERROR: Required shaded package '${pkg}' not found in JAR"
+    exit 1
+  fi
+done
+
+echo "All required shaded packages found"
+exit 0

--- a/scripts/verify-shading.sh
+++ b/scripts/verify-shading.sh
@@ -33,6 +33,7 @@ fi
 # Verify required dependencies are present (not stripped by minimizeJar)
 REQUIRED_SHADED_PACKAGES=(
   "com/google/cloud/flink/bigquery/shaded/org/joda/time"
+  "com/google/cloud/flink/bigquery/shaded/io/opentelemetry"
 )
 
 JAR_CONTENT=$(jar tvf "${JAR_FILE}")


### PR DESCRIPTION
## Summary

Fix NoClassDefFoundError in **_shaded_** jar (unshaded jar was fine)

- Fix `NoClassDefFoundError` for `joda-time` classes stripped by `minimizeJar`
- Fix `NoClassDefFoundError` for `io.opentelemetry` classes missing from the shaded JAR entirely
- Add `verify-shading.sh` positive checks to prevent regressions

## Problem

The shaded JAR is missing classes at runtime, causing two distinct `NoClassDefFoundError` failures:

### 1. joda-time stripped by `minimizeJar`

`minimizeJar: true` in the maven-shade-plugin removes classes it considers unreachable. joda-time classes are only referenced via reflection/dynamic loading paths in `AvroToProtoSerializer`, so the shade plugin incorrectly strips them.

```
java.lang.NoClassDefFoundError: org/joda/time/ReadableInstant
    at com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl.fieldDescriptorFromSchemaField(BigQuerySchemaProviderImpl.java:267)
    at com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl.getDescriptorSchemaFromAvroSchema(BigQuerySchemaProviderImpl.java:205)
    at com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl.<init>(BigQuerySchemaProviderImpl.java:77)
    at com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig.forTable(BigQuerySinkConfig.java:306)
    at com.google.cloud.flink.bigquery.table.BigQueryDynamicTableSink.<init>(BigQueryDynamicTableSink.java:59)
    ...
Caused by: java.lang.ClassNotFoundException: org.joda.time.ReadableInstant
```

### 2. OpenTelemetry not included at all

`google-cloud-bigquerystorage:3.19.1` added a transitive dependency on `io.opentelemetry` for its `TelemetryMetrics` class. But `io.opentelemetry` was not in the shade plugin's `<artifactSet><includes>`, so it's entirely absent from the shaded JAR. The shaded `TelemetryMetrics` class has dangling references to `io.opentelemetry.api.common.AttributeKey` etc.

```
java.lang.NoClassDefFoundError: io/opentelemetry/api/common/AttributeKey
    at com.google.cloud.flink.bigquery.shaded.com.google.cloud.bigquery.storage.v1.TelemetryMetrics.<clinit>(TelemetryMetrics.java:60)
    at com.google.cloud.flink.bigquery.shaded.com.google.cloud.bigquery.storage.v1.ConnectionWorker.<init>(ConnectionWorker.java:430)
    at com.google.cloud.flink.bigquery.shaded.com.google.cloud.bigquery.storage.v1.ConnectionWorkerPool.createConnectionWorker(ConnectionWorkerPool.java:405)
    at com.google.cloud.flink.bigquery.shaded.com.google.cloud.bigquery.storage.v1.ConnectionWorkerPool.createOrReuseConnectionWorker(ConnectionWorkerPool.java:316)
    ...
    at com.google.cloud.flink.bigquery.sink.writer.BigQueryDefaultWriter.flush(BigQueryDefaultWriter.java:119)
    ...
Caused by: java.lang.ClassNotFoundException: io.opentelemetry.api.common.AttributeKey
```

## Fix

**`pom.xml`:**
- Add a `<filter>` for `joda-time:joda-time` to force-include all its classes, preventing `minimizeJar` from stripping them
- Add `io.opentelemetry:*` to `<artifactSet><includes>` so OpenTelemetry JARs are included in the shaded JAR
- Add a `<relocation>` rule to relocate `io.opentelemetry` → `com.google.cloud.flink.bigquery.shaded.io.opentelemetry`

**`scripts/verify-shading.sh`:**
- Add positive verification checks that confirm required shaded packages (`org/joda/time`, `io/opentelemetry`) are actually present in the JAR, so these regressions are caught at build time