### PR TITLE
Add Bytes Read metric to BQ Source Connector

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/BigQuerySourceReaderContext.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/BigQuerySourceReaderContext.java
@@ -20,6 +20,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 import org.apache.flink.util.UserCodeClassLoader;
 
@@ -32,10 +33,24 @@ public class BigQuerySourceReaderContext implements SourceReaderContext {
     private final SourceReaderContext readerContext;
     private final AtomicLong readCount = new AtomicLong(0);
     private final int limit;
+    private Counter bytesRead;
 
     public BigQuerySourceReaderContext(SourceReaderContext readerContext, int limit) {
         this.readerContext = readerContext;
         this.limit = limit;
+        initializeMetrics();
+    }
+
+    private void initializeMetrics() {
+        bytesRead = readerContext.metricGroup().counter("bytesRead");
+    }
+
+    public void incrementBytesRead(long bytes) {
+        bytesRead.inc(bytes);
+    }
+
+    public Counter getBytesReadCounter() {
+        return bytesRead;
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReader.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReader.java
@@ -178,6 +178,10 @@ public class BigQuerySourceSplitReader implements SplitReader<GenericRecord, Big
                 Long itStartTime = System.currentTimeMillis();
                 while (readStreamIterator.hasNext()) {
                     ReadRowsResponse response = readStreamIterator.next();
+                    if (response.hasAvroRows()) {
+                        readerContext.incrementBytesRead(
+                                response.getAvroRows().getSerializedBinaryRows().size());
+                    }
                     if (!response.hasAvroRows()) {
                         LOG.info(
                                 "[subtask #{}][hostname {}] The response contained"

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReaderTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReaderTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.flink.bigquery.source.split.reader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.metrics.SimpleCounter;
 
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -42,7 +43,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         10, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, 10);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
         // wake the thing up
@@ -91,7 +93,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         totalRecordCount, 1, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         // no limits in the read
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, -1);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
@@ -141,7 +144,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         10, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, 10);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
         // wake the thing up
@@ -176,5 +180,28 @@ public class BigQuerySourceSplitReaderTest {
         // Assert that the client was created exactly ONCE
         assertThat(StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.get())
                 .isEqualTo(1);
+    }
+
+    @Test
+    public void testBytesReadMetric() throws IOException {
+        BigQueryReadOptions readOptions =
+                StorageClientFaker.createReadOptions(
+                        10, 1, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
+        SimpleCounter bytesReadCounter = new SimpleCounter();
+        Mockito.when(readerContext.metricGroup().counter("bytesRead")).thenReturn(bytesReadCounter);
+        BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, -1);
+        BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
+
+        BigQuerySourceSplit split = new BigQuerySourceSplit("stream1", 0L);
+        SplitsAddition<BigQuerySourceSplit> change = new SplitsAddition<>(Arrays.asList(split));
+        reader.handleSplitsChanges(change);
+
+        // fetch all records
+        reader.fetch();
+
+        // bytesRead counter should have been incremented
+        assertThat(context.getBytesReadCounter().getCount()).isGreaterThan(0);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/BigQuerySourceReaderContext.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/BigQuerySourceReaderContext.java
@@ -20,6 +20,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 import org.apache.flink.util.UserCodeClassLoader;
 
@@ -32,10 +33,24 @@ public class BigQuerySourceReaderContext implements SourceReaderContext {
     private final SourceReaderContext readerContext;
     private final AtomicLong readCount = new AtomicLong(0);
     private final int limit;
+    private Counter bytesRead;
 
     public BigQuerySourceReaderContext(SourceReaderContext readerContext, int limit) {
         this.readerContext = readerContext;
         this.limit = limit;
+        initializeMetrics();
+    }
+
+    private void initializeMetrics() {
+        bytesRead = readerContext.metricGroup().counter("bytesRead");
+    }
+
+    public void incrementBytesRead(long bytes) {
+        bytesRead.inc(bytes);
+    }
+
+    public Counter getBytesReadCounter() {
+        return bytesRead;
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReader.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReader.java
@@ -174,6 +174,10 @@ public class BigQuerySourceSplitReader implements SplitReader<GenericRecord, Big
             Long itStartTime = System.currentTimeMillis();
             while (readStreamIterator.hasNext()) {
                 ReadRowsResponse response = readStreamIterator.next();
+                if (response.hasAvroRows()) {
+                    readerContext.incrementBytesRead(
+                            response.getAvroRows().getSerializedBinaryRows().size());
+                }
                 if (!response.hasAvroRows()) {
                     LOG.info(
                             "[subtask #{}][hostname {}] The response contained"

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReaderTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/BigQuerySourceSplitReaderTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.flink.bigquery.source.split.reader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.metrics.SimpleCounter;
 
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -42,7 +43,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         10, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, 10);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
         // wake the thing up
@@ -91,7 +93,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         totalRecordCount, 1, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         // no limits in the read
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, -1);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
@@ -141,7 +144,8 @@ public class BigQuerySourceSplitReaderTest {
         BigQueryReadOptions readOptions =
                 StorageClientFaker.createReadOptions(
                         10, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
-        SourceReaderContext readerContext = Mockito.mock(SourceReaderContext.class);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
         BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, 10);
         BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
         // wake the thing up
@@ -176,5 +180,28 @@ public class BigQuerySourceSplitReaderTest {
         // Assert that the client was created exactly ONCE
         assertThat(StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.get())
                 .isEqualTo(1);
+    }
+
+    @Test
+    public void testBytesReadMetric() throws IOException {
+        BigQueryReadOptions readOptions =
+                StorageClientFaker.createReadOptions(
+                        10, 1, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
+        SourceReaderContext readerContext =
+                Mockito.mock(SourceReaderContext.class, Mockito.RETURNS_DEEP_STUBS);
+        SimpleCounter bytesReadCounter = new SimpleCounter();
+        Mockito.when(readerContext.metricGroup().counter("bytesRead")).thenReturn(bytesReadCounter);
+        BigQuerySourceReaderContext context = new BigQuerySourceReaderContext(readerContext, -1);
+        BigQuerySourceSplitReader reader = new BigQuerySourceSplitReader(readOptions, context);
+
+        BigQuerySourceSplit split = new BigQuerySourceSplit("stream1", 0L);
+        SplitsAddition<BigQuerySourceSplit> change = new SplitsAddition<>(Arrays.asList(split));
+        reader.handleSplitsChanges(change);
+
+        // fetch all records
+        reader.fetch();
+
+        // bytesRead counter should have been incremented
+        assertThat(context.getBytesReadCounter().getCount()).isGreaterThan(0);
     }
 }


### PR DESCRIPTION
[Internal issue](https://github.com/Shopify/streaming-compute/issues/969)

Adds a `bytesRead` counter metric to the BQ source reader that tracks the Avro payload bytes received from BigQuery's Storage Read API for both 1.17 and 2.1 connector versions.