### PR TITLE
Fix critical data loss bug: signal no-more-splits per reader and remove readers from queue 

### DIFF
--- a/docs/generate_diagrams.py
+++ b/docs/generate_diagrams.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Render Visual walkthrough SVGs (t0..t10) on a fixed grid.
+
+Every diagram shares the same box coordinates so the JobManager, TM1,
+TM2, TM3, and Output boxes line up when scrolling between panes in
+pr_description.md. Content inside the boxes changes per timestep; the
+layout does not.
+
+Regenerate:
+    python3 docs/generate_diagrams.py
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+from xml.sax.saxutils import escape
+
+# ---------------------------------------------------------------------------
+# Grid constants — change these in one place to rescale every pane.
+# ---------------------------------------------------------------------------
+
+CANVAS_W = 1120
+CANVAS_H = 640
+
+# JobManager box
+JM_X, JM_Y, JM_W, JM_H = 30, 55, 1060, 115
+
+# TM row
+TM_Y, TM_H = 280, 170
+TM_W = 340
+TM1_X = 30
+TM2_X = 390
+TM3_X = 750
+
+# Output box
+OUT_X, OUT_Y, OUT_W, OUT_H = 30, 540, 1060, 90
+
+# Zones between rows (used for arrows)
+UPPER_ARROW_TOP = JM_Y + JM_H
+UPPER_ARROW_BOTTOM = TM_Y
+LOWER_ARROW_TOP = TM_Y + TM_H
+LOWER_ARROW_BOTTOM = OUT_Y
+
+# Stylesheet — rendered inside each SVG. GitHub serves SVGs referenced by
+# `![](…)` standalone, so `prefers-color-scheme` inside the SVG works.
+STYLE = """
+<style>
+  .box        { fill: #f7f7f9; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #f3f0ea; stroke: #333;    stroke-width: 1.5; }
+  .box-warn   { fill: #f7f7f9; stroke: #b23a48; stroke-width: 2; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head { fill: #222; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #1e1f24; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #2b2620; stroke: #c8c9d0; }
+    .box-warn { fill: #1e1f24; stroke: #ff7a8a; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-head { fill: #e6e6e6; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #1e1f24; }
+  }
+</style>
+"""
+
+# Lane x-centers
+TM_LANES = {
+    "TM1": TM1_X + TM_W // 2,
+    "TM2": TM2_X + TM_W // 2,
+    "TM3": TM3_X + TM_W // 2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Arrow:
+    src: str  # "JM", "TM1", "TM2", "TM3", "OUT"
+    dst: str
+    label: str
+    dotted: bool = False
+
+
+@dataclass
+class TMState:
+    name: str  # "TM1", "TM2", "TM3" — or a display override
+    state: str
+    detail: str
+    warn: bool = False  # adds a subtle accent border
+    extra: Optional[str] = None  # rare third detail line
+
+
+@dataclass
+class Step:
+    ident: str  # "t5"
+    title: str  # "### t5: Bug 1 first fire, Bug 2 seeds the queue"
+    pool: str  # rendered as remainingSplits
+    awaiting: str  # rendered as readersAwaitingQueue
+    view: str  # rendered as pointOfView
+    awaiting_alert: bool = False  # highlights the awaiting line
+    view_alert: bool = False  # highlights a part of the view
+    tms: List[TMState] = field(default_factory=list)
+    output: str = ""
+    output_note: Optional[str] = None  # second line, e.g. "💀 S1 missing"
+    arrows: List[Arrow] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# SVG helpers
+# ---------------------------------------------------------------------------
+
+
+def svg_header() -> str:
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {CANVAS_W} {CANVAS_H}" width="{CANVAS_W}" height="{CANVAS_H}" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+  </defs>
+{STYLE}
+"""
+
+
+def rect(x, y, w, h, cls="box", rx=6):
+    return f'  <rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{rx}" class="{cls}"/>\n'
+
+
+def text(x, y, content, font_size=14, bold=False, cls="text", anchor="start", mono=False):
+    weight = ' font-weight="600"' if bold else ""
+    family = ' font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"' if mono else ""
+    # Preserve runs of spaces for the monospace lines so padded labels stay aligned.
+    preserve = ' xml:space="preserve"' if mono else ""
+    return f'  <text x="{x}" y="{y}" font-size="{font_size}" class="{cls}"{weight}{family}{preserve} text-anchor="{anchor}">{escape(content)}</text>\n'
+
+
+def divider(x1, y1, x2, y2):
+    return f'  <line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" class="divider"/>\n'
+
+
+def arrow_path(x1, y1, x2, y2, dotted=False):
+    cls = "arrow-dot" if dotted else "arrow"
+    return f'  <line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" class="{cls}" marker-end="url(#arrow)"/>\n'
+
+
+def label_box(cx, cy, content):
+    """Label overlaid on an arrow — opaque background so the arrow shows through only where
+    we want it to.
+    """
+    # crude width estimation: ~6.5 px per char for 12px font
+    width = max(40, int(len(content) * 6.8) + 12)
+    x = cx - width / 2
+    out = f'  <rect x="{x}" y="{cy - 10}" width="{width}" height="20" rx="3" class="label-bg"/>\n'
+    out += text(cx, cy + 4, content, font_size=12, anchor="middle")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Box drawing
+# ---------------------------------------------------------------------------
+
+
+def draw_jm(step: Step) -> str:
+    out = rect(JM_X, JM_Y, JM_W, JM_H, cls="box-jm")
+    out += text(JM_X + 16, JM_Y + 22, "JobManager", font_size=14, bold=True)
+    out += divider(JM_X + 12, JM_Y + 32, JM_X + JM_W - 12, JM_Y + 32)
+    # Widest label is "readersAwaitingQueue:" (21 chars); pad the others to match.
+    out += text(JM_X + 20, JM_Y + 55,
+                f"remainingSplits:      {step.pool}", font_size=13, mono=True)
+    cls = "text-accent" if step.awaiting_alert else "text"
+    out += text(JM_X + 20, JM_Y + 78,
+                f"readersAwaitingQueue: {step.awaiting}", font_size=13, mono=True, cls=cls)
+    cls = "text-accent" if step.view_alert else "text"
+    out += text(JM_X + 20, JM_Y + 101,
+                f"pointOfView:          {step.view}", font_size=13, mono=True, cls=cls)
+    return out
+
+
+def draw_tm(tm: TMState, x: int) -> str:
+    out = rect(x, TM_Y, TM_W, TM_H, cls="box-warn" if tm.warn else "box")
+    cx = x + TM_W // 2
+    out += text(cx, TM_Y + 30, tm.name, font_size=17, bold=True, anchor="middle")
+    out += divider(x + 16, TM_Y + 44, x + TM_W - 16, TM_Y + 44)
+    out += text(cx, TM_Y + 75, tm.state, font_size=15, bold=True, anchor="middle")
+    if tm.detail and tm.detail != "—":
+        out += text(cx, TM_Y + 105, tm.detail, font_size=13, anchor="middle", cls="text-muted")
+    if tm.extra and tm.extra != "—":
+        out += text(cx, TM_Y + 130, tm.extra, font_size=13, anchor="middle", cls="text-muted")
+    return out
+
+
+def draw_output(step: Step) -> str:
+    out = rect(OUT_X, OUT_Y, OUT_W, OUT_H, cls="box-out")
+    out += text(OUT_X + 16, OUT_Y + 24, "Output", font_size=14, bold=True)
+    out += divider(OUT_X + 12, OUT_Y + 34, OUT_X + OUT_W - 12, OUT_Y + 34)
+    cx = OUT_X + OUT_W // 2
+    if step.output:
+        out += text(cx, OUT_Y + 62, step.output, font_size=15, bold=True, anchor="middle")
+    if step.output_note:
+        out += text(cx, OUT_Y + 85, step.output_note, font_size=13, anchor="middle", cls="text-accent")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Arrow drawing
+# ---------------------------------------------------------------------------
+
+
+def endpoint(name: str, top_or_bottom: str) -> tuple:
+    """Return (x, y) for an arrow endpoint.
+
+    top_or_bottom: 'top' = edge facing away from JM; 'bottom' = edge facing away from OUT.
+    """
+    if name == "JM":
+        # JM only has a bottom edge relevant for arrows
+        return (0, JM_Y + JM_H)
+    if name == "OUT":
+        return (0, OUT_Y)
+    if name in TM_LANES:
+        lane_x = TM_LANES[name]
+        if top_or_bottom == "top":
+            return (lane_x, TM_Y)
+        return (lane_x, TM_Y + TM_H)
+    raise ValueError(name)
+
+
+def draw_arrows(arrows: List[Arrow]) -> str:
+    """Arrow routing.
+
+    Upper zone (between JM and TM row):
+        JM → TMi: vertical, at TMi's lane x, arrow pointing down
+        TMi → JM: vertical, at TMi's lane x, arrow pointing up
+    Lower zone (between TM row and Output):
+        TMi → OUT / OUT → TMi: vertical at TMi's lane x
+
+    When multiple arrows share a lane, stack them with x offsets so the
+    arrowheads don't collide.
+    """
+    svg = ""
+
+    # Group arrows by (zone, lane) so we can offset colliding ones.
+    upper_by_lane: dict[str, List[Arrow]] = {}
+    lower_by_lane: dict[str, List[Arrow]] = {}
+    for a in arrows:
+        if a.src == "JM" or a.dst == "JM":
+            tm = a.dst if a.src == "JM" else a.src
+            upper_by_lane.setdefault(tm, []).append(a)
+        elif a.src == "OUT" or a.dst == "OUT":
+            tm = a.dst if a.src == "OUT" else a.src
+            lower_by_lane.setdefault(tm, []).append(a)
+
+    # Upper zone
+    for tm, lane_arrows in upper_by_lane.items():
+        lane_x = TM_LANES[tm]
+        n = len(lane_arrows)
+        offsets = _offsets(n, spacing=30)
+        y_slots = _y_slots(UPPER_ARROW_TOP, UPPER_ARROW_BOTTOM, n)
+        for arrow, dx, y_label in zip(lane_arrows, offsets, y_slots):
+            x = lane_x + dx
+            y_top = UPPER_ARROW_TOP
+            y_bot = UPPER_ARROW_BOTTOM
+            if arrow.src == "JM":
+                svg += arrow_path(x, y_top + 2, x, y_bot - 2, dotted=arrow.dotted)
+            else:
+                svg += arrow_path(x, y_bot - 2, x, y_top + 2, dotted=arrow.dotted)
+            svg += label_box(x, y_label, arrow.label)
+
+    # Lower zone
+    for tm, lane_arrows in lower_by_lane.items():
+        lane_x = TM_LANES[tm]
+        n = len(lane_arrows)
+        offsets = _offsets(n, spacing=30)
+        y_slots = _y_slots(LOWER_ARROW_TOP, LOWER_ARROW_BOTTOM, n)
+        for arrow, dx, y_label in zip(lane_arrows, offsets, y_slots):
+            x = lane_x + dx
+            y_top = LOWER_ARROW_TOP
+            y_bot = LOWER_ARROW_BOTTOM
+            if arrow.dst == "OUT":
+                svg += arrow_path(x, y_top + 2, x, y_bot - 2, dotted=arrow.dotted)
+            else:
+                svg += arrow_path(x, y_bot - 2, x, y_top + 2, dotted=arrow.dotted)
+            svg += label_box(x, y_label, arrow.label)
+
+    return svg
+
+
+def _offsets(n: int, spacing: int) -> List[int]:
+    """Return n x-offsets symmetric around zero, spaced `spacing` px apart."""
+    if n == 1:
+        return [0]
+    start = -(n - 1) * spacing / 2
+    return [int(start + i * spacing) for i in range(n)]
+
+
+def _y_slots(top: int, bottom: int, n: int) -> List[int]:
+    """Return n y-positions distributed between top and bottom with ~28px separation."""
+    if n == 1:
+        return [int((top + bottom) / 2)]
+    # Keep labels clear of the box edges (14px buffer each side).
+    usable_top = top + 18
+    usable_bottom = bottom - 18
+    span = usable_bottom - usable_top
+    step = span / (n - 1)
+    return [int(usable_top + step * i) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Full render
+# ---------------------------------------------------------------------------
+
+
+def render(step: Step) -> str:
+    svg = svg_header()
+    svg += text(CANVAS_W // 2, 32, step.title, font_size=17, bold=True, anchor="middle")
+    svg += draw_jm(step)
+    for tm, x in zip(step.tms, [TM1_X, TM2_X, TM3_X]):
+        svg += draw_tm(tm, x)
+    svg += draw_output(step)
+    svg += draw_arrows(step.arrows)
+    svg += "</svg>\n"
+    return svg
+
+
+# ---------------------------------------------------------------------------
+# Timestep definitions — one Step per pane
+# ---------------------------------------------------------------------------
+
+
+def steps() -> List[Step]:
+    return [
+        Step(
+            ident="t0",
+            title="t0: Job starts, TM3 still provisioning",
+            pool="[S1, S2, S3]",
+            awaiting="[ ]",
+            view="TM1=RUNNING | TM2=RUNNING",
+            tms=[
+                TMState("TM1", "REGISTERED", "(idle)"),
+                TMState("TM2", "REGISTERED", "(idle)"),
+                TMState("TM3", "PROVISIONING", "(not registered)"),
+            ],
+            output="",
+        ),
+        Step(
+            ident="t1",
+            title="t1: Requests queue up in `awaiting`",
+            pool="[S1, S2, S3]",
+            awaiting="[TM1, TM2]",
+            view="TM1=RUNNING | TM2=RUNNING",
+            tms=[
+                TMState("TM1", "REGISTERED", "(idle)"),
+                TMState("TM2", "REGISTERED", "(idle)"),
+                TMState("TM3", "PROVISIONING", ""),
+            ],
+            output="",
+            arrows=[
+                Arrow("TM1", "JM", "1. sendSplitRequest", dotted=True),
+                Arrow("TM2", "JM", "2. sendSplitRequest", dotted=True),
+            ],
+        ),
+        Step(
+            ident="t2",
+            title="t2: Enumerator drains `awaiting`, assigns splits",
+            pool="[S3]",
+            awaiting="[ ]",
+            view="TM1=RUNNING | TM2=RUNNING",
+            tms=[
+                TMState("TM1", "RUNNING", "S1"),
+                TMState("TM2", "RUNNING", "S2"),
+                TMState("TM3", "PROVISIONING", ""),
+            ],
+            output="",
+            arrows=[
+                Arrow("JM", "TM1", "1. assign S1"),
+                Arrow("JM", "TM2", "2. assign S2"),
+            ],
+        ),
+        Step(
+            ident="t3",
+            title="t3: TM1 (fast) finishes S1, requests queue up",
+            pool="[S3]",
+            awaiting="[TM1]",
+            view="TM1=RUNNING | TM2=RUNNING",
+            tms=[
+                TMState("TM1", "RUNNING", "(idle, finished S1)"),
+                TMState("TM2", "RUNNING", "S2"),
+                TMState("TM3", "PROVISIONING", ""),
+            ],
+            output="S1",
+            arrows=[
+                Arrow("TM1", "OUT", "1. emit S1"),
+                Arrow("TM1", "JM", "2. sendSplitRequest", dotted=True),
+            ],
+        ),
+        Step(
+            ident="t4",
+            title="t4: Enumerator drains `awaiting`, assigns S3 to TM1",
+            pool="[ ]",
+            awaiting="[ ]",
+            view="TM1=RUNNING | TM2=RUNNING",
+            tms=[
+                TMState("TM1", "RUNNING", "S3"),
+                TMState("TM2", "RUNNING", "S2"),
+                TMState("TM3", "PROVISIONING", ""),
+            ],
+            output="S1",
+            arrows=[
+                Arrow("JM", "TM1", "1. assign S3"),
+            ],
+        ),
+        Step(
+            ident="t5",
+            title="t5: Bug 1 first fire, Bug 2 seeds the queue",
+            pool="[ ]",
+            awaiting="[TM1*]  ← Bug 2: stale",
+            view="TM1=RUNNING | TM2=RUNNING",
+            awaiting_alert=True,
+            tms=[
+                TMState("TM1", "FINISHING", "(processed NMS)"),
+                TMState("TM2", "RUNNING", "S2 (noted NMS)"),
+                TMState("TM3", "PROVISIONING", ""),
+            ],
+            output="S1, S3",
+            arrows=[
+                Arrow("TM1", "OUT", "1. emit S3"),
+                Arrow("TM1", "JM", "2. sendSplitRequest", dotted=True),
+                Arrow("JM", "TM1", "3. NoMoreSplits broadcast", dotted=True),
+            ],
+        ),
+        Step(
+            ident="t6",
+            title="t6: TM3 late-registers — Bug 1 re-fires",
+            pool="[ ]",
+            awaiting="[TM1*, TM3]",
+            view="TM1=RUNNING ⚠ | TM2=FINISHED | TM3=RUNNING",
+            awaiting_alert=True,
+            view_alert=True,
+            tms=[
+                TMState("TM1", "FINISHED on TM", "(JM: still RUNNING)", warn=True),
+                TMState("TM2", "FINISHED", ""),
+                TMState("TM3", "RUNNING", "(just registered)"),
+            ],
+            output="S1, S2, S3",
+            arrows=[
+                Arrow("TM2", "OUT", "1. emit S2"),
+                Arrow("TM3", "JM", "2. register + sendSplitRequest", dotted=True),
+                Arrow("JM", "TM1", "3. NoMoreSplits re-broadcast", dotted=True),
+                Arrow("JM", "TM3", "3. NoMoreSplits re-broadcast", dotted=True),
+            ],
+        ),
+        Step(
+            ident="t7",
+            title="t7: Delivery to TM1 fails — task failover",
+            pool="[S1, S3]",
+            awaiting="[TM1*, TM3]",
+            view="TM1=FAILED | TM2=FINISHED | TM3=RUNNING",
+            awaiting_alert=True,
+            tms=[
+                TMState("TM1", "FAILED", "outputs DISCARDED", warn=True),
+                TMState("TM2", "FINISHED", ""),
+                TMState("TM3", "RUNNING", "(idle)"),
+            ],
+            output="S2",
+            arrows=[
+                Arrow("TM1", "JM", "1. TaskNotRunningException → FAILED", dotted=True),
+                Arrow("TM1", "OUT", "2. discard (S1, S3)", dotted=True),
+                Arrow("TM1", "JM", "3. addSplitsBack(S1, S3)", dotted=True),
+            ],
+        ),
+        Step(
+            ident="t8",
+            title="t8: Queue filled — assignSplits re-invoked",
+            pool="[S1, S3]",
+            awaiting="[TM1*, TM3]",
+            view="TM1=FAILED | TM2=FINISHED | TM3=RUNNING",
+            awaiting_alert=True,
+            tms=[
+                TMState("TM1", "FAILED", "(stale in queue)", warn=True),
+                TMState("TM2", "FINISHED", ""),
+                TMState("TM3", "RUNNING", "(idle)"),
+            ],
+            output="S2",
+        ),
+        Step(
+            ident="t9",
+            title="t9: Queue drains — Bug 2 bites, S1 orphaned",
+            pool="[ ]",
+            awaiting="[ ]",
+            view="TM1=FAILED | TM2=FINISHED | TM3=RUNNING",
+            tms=[
+                TMState("TM1", "FAILED", "💀 S1 orphaned", warn=True),
+                TMState("TM2", "FINISHED", ""),
+                TMState("TM3", "RUNNING", "S3"),
+            ],
+            output="S2",
+            arrows=[
+                Arrow("JM", "TM1", "1. assign S1 (absorbed — ORPHANED)"),
+                Arrow("JM", "TM3", "2. assign S3"),
+            ],
+        ),
+        Step(
+            ident="t10",
+            title="t10: Final state — data loss",
+            pool="[ ]",
+            awaiting="[ ]",
+            view="TM1=FINISHED | TM2=FINISHED | TM3=FINISHED",
+            tms=[
+                TMState("TM1 attempt_1", "FINISHED", "(no splits)"),
+                TMState("TM2", "FINISHED", "S2 ✓"),
+                TMState("TM3", "FINISHED", "S3 ✓"),
+            ],
+            output="S2, S3",
+            output_note="💀 S1 missing",
+            arrows=[
+                Arrow("TM3", "OUT", "1. emit S3"),
+                Arrow("TM1", "JM", "2. sendSplitRequest", dotted=True),
+                Arrow("JM", "TM1", "3. NoMoreSplits", dotted=True),
+            ],
+        ),
+    ]
+
+
+def main() -> None:
+    out_dir = Path(__file__).parent / "svg"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for s in steps():
+        path = out_dir / f"{s.ident}.svg"
+        path.write_text(render(s))
+        print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pr_description.md
+++ b/docs/pr_description.md
@@ -1,0 +1,428 @@
+# Background
+
+Terms used throughout:
+
+- **Split** - a unit of input work wrapping one BigQuery Storage API *stream*. The stream yields a
+  subset of the source table's rows; reading the split streams those rows into Flink. Row counts per
+  stream vary. The enumerator hands splits to readers; each reader reads its splits sequentially. In
+  these runs the table is partitioned into 3,000 streams → 3,000 splits.
+- **Reader / registered reader** - a source subtask that has registered with the JobManager and will
+  request splits.
+- **Enumerator** - lives on the JobManager and hands out splits to readers on demand.
+- **`NoMoreSplitsEvent`** - event the enumerator signals when the assigner is drained; tells a
+  reader it can finish once its current split is done.
+
+# What?
+
+At high parallelism (≥ 1000 subtasks), two bugs in `BigQuerySourceEnumerator.assignSplits` compound
+to produce silent row loss:
+
+- **Bug 1** fails already-finishing reader tasks and returns their splits to the pool.
+- **Bug 2** then reassigns those returned splits to reader tasks that have since terminated. The
+  reassigned splits sit booked to dead tasks and are never re-read.
+
+In our reproductions we saw 50 – 80M rows being silently dropped.
+
+## Bug 1 - repeated `NoMoreSplitsEvent` signal broadcasts
+
+When the enumerator finds the split assigner drained, it broadcasts `NoMoreSplitsEvent` to *every*
+registered reader - including readers that have just finished on their TaskManager but whose
+FINISHED notification has not yet reached the JobManager. Those event deliveries fail, the
+JobManager marks the task FAILED, discards the output it already produced, and returns the splits it
+processed to the pool via `addSplitsBack` for re-execution.
+
+Normally, `NoMoreSplitsEvent` broadcasts only once. But at high parallelism (e.g. parallelism ≥
+1000), some reader tasks take longer to initialize - Kubernetes may still be acquiring resources for
+their TaskManagers. When these late readers come online and request a split, they find the pool
+drained, and each such late request triggers its own `NoMoreSplitsEvent` broadcast. Those repeated
+broadcasts are what catch tasks mid-transition and fail them.
+
+## Bug 2 - stale `readersAwaitingSplit` entries
+
+When a reader requests a split and the pool is empty, the enumerator triggers the broadcast
+described in Bug 1 but does not remove the requesting reader from `readersAwaitingSplit`. The reader
+has now been told no further splits are coming, so it finishes its current split (if any) and
+transitions to FINISHED - but its stale entry remains in the queue.
+
+Later, when the pool is refilled (by the failed tasks from Bug 1 returning their splits via
+`addSplitsBack`), the enumerator drains `readersAwaitingSplit` to reassign. The stale entries are
+handed splits, but the target reader has already FINISHED. No exception is raised; the split sits
+booked to a dead task and is never read.
+
+## Why both bugs have to be present
+
+Bug 1 *creates the conditions* for Bug 2 to trigger - the failed tasks are what refill the pool and
+re-invoke split assignment against a queue containing stale entries. Without Bug 1, reassignment is
+rare and Bug 2 rarely fires.
+
+Without Bug 2, Bug 1 would be just noisy retries - all splits eventually get re-read.
+
+See the [detailed failure flow](#detailed-failure-flow) below.
+
+# Solution
+
+Rewrite the `noMoreSplits` branch of the `while` loop over `readersAwaitingSplit` in
+`BigQuerySourceEnumerator.assignSplits`:
+
+```
+final Iterator<Integer> awaitingReader = readersAwaitingSplit.iterator();
+while (awaitingReader.hasNext()) {
+    int nextAwaiting = awaitingReader.next();
+    // ... other branches (split available, reader unregistered) ...
+    } else if (splitAssigner.noMoreSplits() && boundedness == Boundedness.BOUNDED) {
+        LOG.info("Signal NoMoreSplits to subtask {}", nextAwaiting);
+        context.signalNoMoreSplits(nextAwaiting);   // (1) fix Bug 1: signal only the requesting reader, not a broadcast
+        awaitingReader.remove();                    // (2) fix Bug 2: remove the requesting reader from the queue
+        break;
+    }
+}
+```
+
+# Validation
+
+|                               |                      Pre-fix Run 1 |                      Pre-fix Run 2 |                      Pre-fix Run 3 |                     Post-fix Run 1 |                     Post-fix Run 2 |                     Post-fix Run 3 |
+|-------------------------------|-----------------------------------:|-----------------------------------:|-----------------------------------:|-----------------------------------:|-----------------------------------:|-----------------------------------:|
+| Job ID                        | `ad9670649392bdd7262252a511829b93` | `0df37a3ee1ebb342d8fa42a4aa808b17` | `1cb49738c8ef661ad79959fdd4d2acf4` | `1b04343511102bcff1509826cbdfe134` | `6b9b3373b617cd4bfa8ce3903ba835ed` | `3381fa5e74687b67400f5707f575b2d9` |
+| BigQuery `streams count`      |                              3,000 |                              3,000 |                              3,000 |                              3,000 |                              3,000 |                              3,000 |
+| `Assign split`                |                              3,073 |                              3,054 |                              3,074 |                              3,000 |                              3,000 |                              3,000 |
+| `Read for split … completed`  |                              3,018 |                              3,012 |                              3,019 |                              3,000 |                              3,000 |                              3,000 |
+| `RUNNING → FAILED` events     |                                 27 |                                 35 |                                 39 |                                  0 |                                  0 |                                  0 |
+| `Discarding results` events ⁴ |                                 54 |                                 70 |                                 78 |                                  0 |                                  0 |                                  0 |
+| `addSplitsBack` events        |                                 27 |                                 35 |                                 39 |                                  0 |                                  0 |                                  0 |
+| Splits returned ¹             |                                 73 |                                 54 |                                 74 |                                  0 |                                  0 |                                  0 |
+| Rows read ²                   |                      3,947,561,552 |                      3,965,256,750 |                      3,946,741,896 |                      4,021,548,951 |                      4,021,548,951 |                      4,021,548,951 |
+| Rows missing ³                |                         73,987,399 |                         56,292,201 |                         74,807,055 |                              **0** |                              **0** |                              **0** |
+
+¹ *Splits returned* = total splits handed back via `addSplitsBack` across all events. A single
+failed task can return multiple in-flight splits at once, so this is ≥ `addSplitsBack events`. Each
+returned split is reassigned, which is why `Assign split` = 3,000 + *Splits returned*.  
+² *Rows read* comes from the Flink job output  
+³ *Rows missing* = expected_source_rows − rows_read  
+⁴ *`Discarding results` events* = counts of `Discarding the results produced by task execution ...`,
+which Flink logs twice per failed task (once per result partition), so this is 2×
+`RUNNING → FAILED`.
+
+# Detailed failure flow
+
+A minimal scenario that reproduces both bugs and loses one split's worth of
+rows: **3 splits** (Split1, Split2, Split3) and **3 TaskManagers** (Task1
+processes Split1 then Split3; Task2 processes Split2; Task3 late - Kubernetes
+provisioning delay). Task2 finishes first and its `sendSplitRequest`
+against the drained pool fires the first `NoMoreSplitsEvent` broadcast,
+leaving a stale entry for Task2 in `readersAwaitingSplit` (Bug 2). Task3's
+late `sendSplitRequest` re-triggers the broadcast - catching Task1
+mid-FINISHED-transition (which leads to failover and `addSplitsBack`),
+and leaving Task3 itself with a second stale entry in
+`readersAwaitingSplit` once it processes its own `NoMoreSplitsEvent` and
+finishes.
+
+Stale entries are highlighted in **red** in the diagrams.
+**Arrows** show events, method calls, exceptions, split assignments,
+and row emissions - `sendSplitRequest`, `NoMoreSplitsEvent`,
+`TaskNotRunningException`, output discard, FINISHED notification,
+`context.assignSplit`, splits emitted to downstream output. Color signals
+disposition: **green** for normal/positive flow, **red** for
+failure/orphaned events, **black** for neutral.
+**Numbered labels**
+(`1.`, `2.`, …) indicate event ordering within a pane; repeated numbers
+mean simultaneous events.
+
+## t0: Job starts, Task3 resources still being provisioned
+
+![t0: Job starts, Task3 still provisioning](svg/t0.svg)
+
+## t1: Requests queue up in `readersAwaitingSplit`
+
+Task1 and Task2 each `sendSplitRequest`. The enumerator adds each to
+`readersAwaitingSplit` before iterating the "queue" (not actually a queue but rather a `Set`) to
+assign.
+
+![t1: Requests queue up in `awaiting`](svg/t1.svg)
+
+## t2: Enumerator drains `awaiting`, assigns splits
+
+Enumerator iterates `readersAwaitingSplit`, assigning one split per reader and
+removing the entry. `readersAwaitingSplit` queue empties; pool drops to `[Split3]`.
+
+![t2: Enumerator drains `awaiting`, assigns splits](svg/t2.svg)
+
+## t3: Task1 finishes Split1, requests queue up
+
+Task1 finishes processing it's split first, emits Split1 rows, and another `sendSplitRequest`. The
+enumerator adds Task1 to `readersAwaitingSplit` before iterating the queue to assign.
+
+![t3: Task1 finishes Split1, requests queue up](svg/t3.svg)
+
+## t4: Enumerator drains `readersAwaitingSplit`, assigns Split3 to Task1
+
+Enumerator iterates `readersAwaitingSplit`, assigns Split3 to Task1, and
+removes the entry. Queue empties; pool drops to `[ ]`.
+
+![t4: Enumerator drains `awaiting`, assigns Split3 to Task1](svg/t4.svg)
+
+## t5: Task2 finishes Split2, requests queue up
+
+Task2 finishes processing Split2, emits Split2 rows, and `sendSplitRequest`s again. The enumerator
+adds Task2 to  `readersAwaitingSplit` before iterating the queue.
+
+![t5: Task2 finishes Split2, requests queue up](svg/t5.svg)
+
+## t6: Bug 1 first fire, Bug 2 seeds the queue
+
+Enumerator iterates the queue, finds the `remainingSplits` pool is empty, and **broadcasts**
+`NoMoreSplitsEvent` to every registered reader (Task1, Task2) - and **does
+not remove Task2 from the queue** (Bug 2 - the entry left in `readersAwaitingSplit`
+becomes stale once Task2 finishes). Task2 processes the event and transitions
+FINISHED on its TaskManager - but its FINISHED notification to the JobManager
+hasn't arrived yet, so `clusterState` still shows `Task2=RUNNING`. Task1 notes
+the event and keeps reading Split3.
+
+- **Code path:** `BigQuerySourceEnumerator.assignSplits` (JobManager).
+- **Side effect of `signalNoMoreSplits`:** sets `subtaskHasNoMoreSplits[i] = true`
+  for every _currently-registered_ reader, so their subsequent `sendSplitRequest`s
+  are silently dropped by
+  [
+  `SourceCoordinator.handleRequestSplitEvent`](https://github.com/apache/flink/blob/release-2.1/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java#L646-L659) -
+  they cannot trigger another broadcast. The first broadcast is benign on its own
+  (every target is RUNNING); danger comes from re-broadcasts via late-registering
+  readers (t8).
+
+![t6: Bug 1 first fire, Bug 2 seeds the queue](svg/t6.svg)
+
+## t7: JobManager learns Task2 is FINISHED
+
+Task2's FINISHED notification reaches the JobManager; `clusterState`
+flips `Task2=RUNNING` → `Task2=FINISHED`. Task1 is still processing Split3.
+Task3 is still provisioning.
+
+![t7: JobManager learns Task2 is FINISHED](svg/t7.svg)
+
+## t8: Task1 transitions FINISHED-on-TM, Task3 late-registers → Bug 1 **re-fires**
+
+Task1 finishes processing Split3, emits Split3Rows, processed the `NoMoreSplits` event it received
+at t6, and transitions from RUNNING to FINISHED on its TaskManager. Before the task is able to sent
+it's "final execution state FINISHED" notification to update the JobManager's `clusterState` (or
+while the notification is still in flight), Task3 finally registers and sends a `sendSplitRequest`
+which reaches the enumerator, hits the drained pool, gets added to `readersAwaitingSplit` queue, and
+triggers **another** `NoMoreSplitsEvent` broadcast to every registered reader. The broadcast catches
+Task1 in the race window.
+
+**Proof:** in a pre-fix run, the first three `signalNoMoreSplits` broadcasts fired at
+14:36:00.075, .088, and .121 - to 581, 582, and 583 registered readers respectively -
+*before* the first failure at 14:36:00.207. The registered-reader count grew 581→590
+as late-arriving attempt_0 readers registered and each triggered its own cascade:
+their `subtaskHasNoMoreSplits` slot was still `false` (never flipped by the prior
+broadcasts, which only covered the subtask indices that had registered at the time),
+so their `sendSplitRequest` sailed through the gate in `handleRequestSplitEvent`,
+re-hit the drained assigner, and re-broadcast to all registered readers.
+
+### How a late-registering reader bypasses the gate
+
+`SourceCoordinatorContext.subtaskHasNoMoreSplits` is pre-sized
+`new boolean[parallelism]` and initialized all-false
+([
+`SourceCoordinatorContext.java:570-571`](https://github.com/apache/flink/blob/release-2.1/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java#L570-L571)),
+so any subtask whose `handleReaderRegistrationEvent` fires *after* the first broadcast
+has its slot still at `false`; its `sendSplitRequest` sails through the
+`!context.hasNoMoreSplits(subtask)` gate in
+[
+`handleRequestSplitEvent`](https://github.com/apache/flink/blob/release-2.1/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java#L655-L657),
+reaches the enumerator, re-hits the drained assigner, and fires another broadcast.
+
+### Race window
+
+The race window the broadcast catches Task1 in is bounded by two simultaneous in-flight events
+
+- **TaskManager's RUNNING→FINISHED transition.** Task1 must have already reacted
+  to the first broadcast - processed `NoMoreSplitsEvent`, finished its last split,
+  and transitioned RUNNING→FINISHED on its TaskManager. Otherwise the event would be
+  accepted normally.
+- **JobManager's unregister round-trip.** Task1's "final execution state FINISHED"
+  notification (TaskManager → JobManager → coordinator drops reader from
+  `registeredReaders`) must still be in flight. Otherwise the broadcast would no
+  longer target Task1.
+
+![t8: Task1 transitions FINISHED-on-TM, Task3 late-registers → Bug 1 **re-fires**](svg/t8.svg)
+
+## t9: Delivery to Task1 fails → task failover
+
+Because Task1 is already finished, the `NoMoreSplitsEvent` delivery to Task1 raises a
+`TaskNotRunningException` on
+the TaskManager. `SubtaskGatewayImpl.sendEvent`'s completion handler
+sees the failure and - because JM-side `Execution.state` is still
+`RUNNING` - `isStillRunning()` returns true, so it raises the "event
+lost" `FlinkException`. The JobManager transitions Task1 RUNNING→FAILED,
+**discards** its outputs for Split1 and Split3, returns the splits to
+the pool via `addSplitsBack(Split1, Split3)`, and schedules a restart
+of the task.
+
+Meanwhile Task3 - which received the re-broadcast in t8 -
+processes its `NoMoreSplitsEvent`, transitions FINISHED, and notifies
+the JobManager. Now **both** Task2 and Task3 have stale entries in
+`readersAwaitingSplit` from their earlier `sendSplitRequest`s that were
+never removed (Bug 2).
+
+- **Code path (exception thrown):** `Task.deliverOperatorEvent` (TaskManager).
+- **Code path ("event lost" wrap):** `SubtaskGatewayImpl.sendEvent` (JobManager) -
+  any undelivered operator event to a task that the JobManager still recognizes as
+  RUNNING is treated as a consistency violation. See
+  [Flink's "event lost" guard](#flinks-event-lost-guard) for the exact source.
+- **Code path (failover):** JobManager scheduler →
+  `SourceCoordinator.subtaskReset` (`SourceCoordinator.java:368`) - marks the execution
+  FAILED, discards output, clears `subtaskHasNoMoreSplits[i]`, calls
+  `enumerator.addSplitsBack(splits_i)` to return in-flight splits to
+  `remainingSourceSplits`, and schedules the next attempt.
+- **Important:** although successfully produced rows are thrown away, `addSplitsBack`
+  returns the splits that produced those rows back to the pool so they can be re-read
+  in the next attempt. Whether this re-read succeeds is decided in t10–t11.
+
+**Proof:** we observed the race directly in a separate pre-fix run (~204 M rows
+missing, same workload as the validation table). One TaskManager's slot (allocation
+id `87a1325c51462432b2ff533b863e048e`) hosted two source subtasks in sequence; both
+finished successfully and both were then marked FAILED by the JobManager.
+
+| Time (EDT)      | Event                                                                                                                                                                                                                                 |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 08:10:10.2      | JobManager: subtask 156/1000 CREATED→SCHEDULED                                                                                                                                                                                        |
+| 08:10:10        | Pod `flink-taskmanager-1-218` created (`WorkerResourceSpec{cpu=1.0, numSlots=1, ...}`)                                                                                                                                                |
+| 08:10:40        | TaskManager container starts                                                                                                                                                                                                          |
+| 08:10:56.8      | TaskManager registered at ResourceManager (pekko endpoint `252.206.70.75:6122`)                                                                                                                                                       |
+| 08:10:57.5      | JobManager: 156/1000 DEPLOYING → deployed to TaskManager-1-218 with allocation `87a1325c...`                                                                                                                                          |
+| 08:11:11.3      | 156/1000 INITIALIZING→**RUNNING** on TaskManager                                                                                                                                                                                      |
+| 08:12:54.814    | 156/1000 RUNNING→**FINISHED** on TaskManager - task completed normally                                                                                                                                                                |
+| 08:12:54.814    | TaskManager: `Freeing task resources for Source: source_data[1] (156/1000)#0`                                                                                                                                                         |
+| 08:12:54.852    | TaskManager: "Un-registering task and sending final execution state FINISHED to JobManager"                                                                                                                                           |
+| ~08:12:54.85    | JobManager: `signalNoMoreSplits` broadcast fires (252 broadcasts in the 08:12:50–08:13:00 buckets)                                                                                                                                    |
+| ~08:12:54.90    | JobManager → TaskManager: `SubtaskGatewayImpl.sendEvent(NoMoreSplitsEvent)` → `TaskExecutor.sendOperatorEventToTask` → `Task.deliverOperatorEvent` rejects with `TaskNotRunningException: Task is not running, but in state FINISHED` |
+| 08:12:54.905    | JobManager: 156/1000 RUNNING→**FAILED** with `FlinkException: An OperatorEvent from an OperatorCoordinator to a task was lost. Triggering task failover to ensure consistency. Event: '[NoMoreSplitsEvent]'`                          |
+| 08:12:54.906    | JobManager: **"Discarding the results produced by task execution ... _155_0"** - successfully produced output is thrown away                                                                                                          |
+| 08:12:54.906    | JobManager: "1 tasks will be restarted to recover the failed task"                                                                                                                                                                    |
+| 08:12:55.79     | Attempt #1 of 156/1000 CREATED→SCHEDULED                                                                                                                                                                                              |
+| 08:12:59.21     | Subtask 867/1000 (a different parallel instance) deploys into the now-free slot on TaskManager-1-218 - same allocation id `87a1325c...`                                                                                               |
+| 08:12:59.23     | 867/1000 INITIALIZING→RUNNING                                                                                                                                                                                                         |
+| 08:13:00.21     | Attempt #1 of 156/1000 DEPLOYING on `flink-taskmanager-1-203`                                                                                                                                                                         |
+| 08:13:00.23     | Attempt #1 of 156/1000 RUNNING                                                                                                                                                                                                        |
+| 08:13:00.52     | 867/1000 RUNNING→**FINISHED** on TaskManager-1-218 (ran for ~1.3 s)                                                                                                                                                                   |
+| 08:13:01.24     | JobManager: 867/1000 RUNNING→**FAILED** with the same `NoMoreSplitsEvent` lost-operator-event exception                                                                                                                               |
+| **08:13:01.77** | Attempt #1 of 156/1000 RUNNING→**FINISHED** on TaskManager-1-203 (ran for ~1.5 s)                                                                                                                                                     |
+| 08:19:52.287    | At job shutdown, RM: "Disconnect TaskExecutor flink-taskmanager-1-218 because: ... has no more allocated slots for job"                                                                                                               |
+| 08:19:52.605    | TaskManager: `FlinkException: The TaskExecutor's registration at the ResourceManager has been rejected` (normal batch-job teardown, unrelated to data loss)                                                                           |
+
+![t9: Delivery to Task1 fails → task failover](svg/t9.svg)
+
+## t10: Task1 attempt_1 registers and requests a split
+
+The restart progresses: Task1 attempt = 1 is deployed and reaches RUNNING.
+It registers with the JobManager and sends `sendSplitRequest`. The
+enumerator appends Task1 to `readersAwaitingSplit`, which now holds
+**three** entries: the two stale entries for Task2 and Task3 (both
+already FINISHED, shown in red) and the live entry for Task1
+attempt = 1. The pool still holds Split1 and Split3.
+
+- **Why the request reaches the enumerator:** the `subtaskHasNoMoreSplits[i]` flag
+  was cleared during the failover (`resetSubtask`) in t9, so the new attempt's `sendSplitRequest`
+  passes the gate.
+
+![t10: Task1 attempt_1 registers and requests a split](svg/t10.svg)
+
+## t11: Queue drains - Task1 gets Split1, Bug 2 orphans Split3
+
+The enumerator drains the queue against the refilled pool. Task1
+attempt = 1 is assigned Split1 (green) and starts reading it. Then
+Task2 (stale, next in queue) is assigned Split3 - Task2 is already
+JobManager-FINISHED, so `isStillRunning()` returns false and the
+delivery is silently absorbed (red). No failover, **Split3 is booked
+to a dead task and never read**.
+
+- **Why this is the data-loss step:** the iterator would be safe if
+  `readersAwaitingSplit` accurately reflected RUNNING tasks, but it doesn't - any
+  task that hit the `noMoreSplits` branch previously was never removed (Bug 2),
+  so the queue can contain stale entries pointing to tasks that have since FINISHED.
+  The outcome of each delivered split now depends on the target subtask's state:
+    - **Branch (A) - target subtask still RUNNING and awaiting work:** receives
+      `Adding split(s) to reader`, reads the split normally. No orphan.
+      (Task1 attempt_1 with Split1 here.)
+    - **Branch (B) - target subtask already JobManager-FINISHED** (transitioned
+      during the cascade): the event is silently absorbed - no
+      `TaskNotRunningException`-driven restart (see
+      [Flink's "event lost" guard](#flinks-event-lost-guard)), no new attempt.
+      The split sits booked to a dead task and is never read, resulting in data
+      loss. (Task2 with Split3 here.)
+
+![t11: Queue drains - Task1 gets Split1, Bug 2 orphans Split3](svg/t11.svg)
+
+## t12: Task1 attempt=1 wraps up - request, NoMoreSplits, emit, finish
+
+Task1 attempt=1 finishes its work in four steps: (1) it sends another
+`sendSplitRequest`; (2) the pool is empty so the enumerator broadcasts
+`NoMoreSplitsEvent` back to Task1; (3) Task1 emits Split1's rows to the
+output; (4) Task1 transitions FINISHED and notifies the JobManager. The
+stale entries (Task2 and Task3) remain in `readersAwaitingSplit` - they
+are benign now that the pool is drained.
+
+![t12: Task1 attempt_1 wraps up](svg/t12.svg)
+
+## t13: Final state - data loss limited to Split3
+
+All tasks are now FINISHED from the JobManager's point of view, so the job progresses to whatever is
+the next operatoor in the DAG. Split1 (was recovered by attempt=1) and Split2
+(Task2's original read) are in the output. Split3 - orphaned to
+Task2's stale queue entry in t11 - was never re-read. That is the
+data loss.
+
+![t13: Final state - data loss limited to Split3](svg/t13.svg)
+
+# Flink's "event lost" guard
+
+The
+`FlinkException("An OperatorEvent from an OperatorCoordinator to a task was lost. Triggering task failover to ensure consistency. ...")`
+exception is raised in the completion handler attached inside
+`SubtaskGatewayImpl.sendEvent` ([
+`SubtaskGatewayImpl.java:111-132`](https://github.com/apache/flink/blob/release-2.1/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImpl.java#L111-L132)):
+
+```
+sendResult.whenCompleteAsync(
+    (success, failure) -> {
+        if (failure != null && subtaskAccess.isStillRunning()) {   // <-- guard
+            // ... triggerTaskFailover(new FlinkException(EVENT_LOSS_ERROR_MESSAGE, failure))
+        }
+    },
+    mainThreadExecutor);
+```
+
+`isStillRunning()` ([
+`ExecutionSubtaskAccess.java:96-99`](https://github.com/apache/flink/blob/release-2.1/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/ExecutionSubtaskAccess.java#L96-L99))
+is defined as:
+
+```java
+public boolean isStillRunning() {
+    return taskExecution.getState() == ExecutionState.RUNNING
+            || taskExecution.getState() == ExecutionState.INITIALIZING;
+}
+```
+
+So if the JobManager-side `Execution.state` is already `FINISHED` at the time the send completes,
+the failure is silently swallowed - no failover, no `FlinkException` raised.
+
+## Why Bug 1 triggers the exception
+
+Bug 1 is the `NoMoreSplitsEvent` delivery in step 3. When that delivery's failure callback fires,
+the JobManager-side `Execution.state` is still `RUNNING`: the TaskManager has already transitioned
+RUNNING→FINISHED locally, but its "final execution state FINISHED" notification back to the
+JobManager
+is still in flight, so the JobManager hasn't updated `state` yet. `isStillRunning()` returns `true`,
+`triggerTaskFailover` runs, the `FlinkException` surfaces, and the attempt transitions
+RUNNING→FAILED.
+
+This is the narrow window (TaskManager-FINISHED ∧ JobManager-RUNNING) that makes Bug 1 observable at
+all.
+
+## Why Bug 2 Branch (B) does not trigger the exception
+
+Bug 2 branch (B) is the `AddSplitEvent` delivery in step 7. By the time step 7 runs, the JobManager
+has
+long since observed the FINISHED transition - the TaskManager → JobManager round-trip completed
+several hundred
+milliseconds earlier (e.g. subtask 115 JobManager-FINISHED at 12:13:02.499, reassignment at
+12:13:03.281). `isStillRunning()` returns `false`, the failure is silently absorbed, and no
+failover or new attempt is scheduled.

--- a/docs/svg/t0.svg
+++ b/docs/svg/t0.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split1, Split2, Split3]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [ ]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-muted" text-anchor="middle">(idle)</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">(idle)</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+</svg>

--- a/docs/svg/t1.svg
+++ b/docs/svg/t1.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split1, Split2, Split3]</text>
+  <text x="50" y="133" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [Task1, Task2]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-muted" text-anchor="middle">(idle)</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">(idle)</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <line x1="200" y1="278" x2="200" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="129.5" y="215" width="141" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">1. sendSplitRequest</text>
+  <line x1="560" y1="278" x2="560" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="489.5" y="215" width="141" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-change" text-anchor="middle">2. sendSplitRequest</text>
+</svg>

--- a/docs/svg/t10.svg
+++ b/docs/svg/t10.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split1, Split3]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-accent">Task3</tspan>, <tspan class="text-change">Task1</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {<tspan class="text-change">Task1=RUNNING</tspan>, Task2=FINISHED, Task3=FINISHED}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-change" text-anchor="middle">attempt = 1</text>
+  <text x="200" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-muted" text-anchor="middle">(idle)</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="920" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed 0 splits</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="200" y1="278" x2="200" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="70.0" y="215" width="260" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">1. register + sendSplitRequest</text>
+</svg>

--- a/docs/svg/t11.svg
+++ b/docs/svg/t11.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-accent">Task3</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=FINISHED, Task3=FINISHED}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-change" text-anchor="middle">attempt = 1</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-change" text-anchor="middle">Processing Split1</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="920" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed 0 splits</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="145.0" y="215" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">1. Assign Split1</text>
+  <line x1="560" y1="172" x2="560" y2="278" class="arrow-bad" marker-end="url(#arrow-bad)"/>
+  <rect x="505.0" y="215" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-accent" text-anchor="middle">2. Assign Split3</text>
+</svg>

--- a/docs/svg/t12.svg
+++ b/docs/svg/t12.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-accent">Task3</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {<tspan class="text-change">Task1=FINISHED</tspan>, Task2=FINISHED, Task3=FINISHED}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-change" text-anchor="middle">attempt = 1</text>
+  <text x="200" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="200" y="400" font-size="13" class="text-change" text-anchor="middle">Processed Split1 ✓</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed Split2 ✓</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="920" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed 0 splits</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="420" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="485" y="605" font-size="14" class="text-change" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="570" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="635" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="130" y1="278" x2="130" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="60.0" y="190" width="140" height="20" rx="3" class="label-bg"/>
+  <text x="130" y="204" font-size="12" class="text-change" text-anchor="middle">1. sendSplitRequest</text>
+  <line x1="270" y1="278" x2="270" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="225.0" y="190" width="90" height="20" rx="3" class="label-bg"/>
+  <text x="270" y="204" font-size="12" class="text-change" text-anchor="middle">4. Finished</text>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="85.0" y="220" width="230" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="234" font-size="12" class="text-change" text-anchor="middle">2. NoMoreSplitsEvent broadcast</text>
+  <line x1="200" y1="452" x2="200" y2="538" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="135.0" y="485" width="130" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="499" font-size="12" class="text-change" text-anchor="middle">3. Emit Split1 rows</text>
+</svg>

--- a/docs/svg/t13.svg
+++ b/docs/svg/t13.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-accent">Task3</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=FINISHED, Task2=FINISHED, Task3=FINISHED}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 1</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="200" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed Split1 ✓</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed Split2 ✓</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="920" y="400" font-size="13" class="text-muted" text-anchor="middle">Processed 0 splits</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="420" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="485" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="570" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="635" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+</svg>

--- a/docs/svg/t2.svg
+++ b/docs/svg/t2.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split3]</text>
+  <text x="50" y="133" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [ ]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-change" text-anchor="middle">Processing Split1</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-change" text-anchor="middle">Processing Split2</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="145.0" y="215" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">1. Assign Split1</text>
+  <line x1="560" y1="172" x2="560" y2="278" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="505.0" y="215" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-change" text-anchor="middle">2. Assign Split2</text>
+</svg>

--- a/docs/svg/t3.svg
+++ b/docs/svg/t3.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split3]</text>
+  <text x="50" y="133" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [Task1]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">Processing Split2</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text-change" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <line x1="200" y1="278" x2="200" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="129.5" y="215" width="141" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">2. sendSplitRequest</text>
+  <line x1="200" y1="452" x2="200" y2="538" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="145.0" y="485" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="499" font-size="12" class="text-change" text-anchor="middle">1. Emit Split1 rows</text>
+</svg>

--- a/docs/svg/t4.svg
+++ b/docs/svg/t4.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [ ]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-change" text-anchor="middle">Processing Split3</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-muted" text-anchor="middle">Processing Split2</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="145.0" y="215" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-change" text-anchor="middle">1. Assign Split3</text>
+</svg>

--- a/docs/svg/t5.svg
+++ b/docs/svg/t5.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [Task2]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="400" font-size="13" class="text-muted" text-anchor="middle">Processing Split3</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="560" y="400" font-size="13" class="text-change" text-anchor="middle">(idle)</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="420" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="485" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="570" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="635" y="605" font-size="14" class="text-change" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="560" y1="278" x2="560" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="489.5" y="215" width="141" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-change" text-anchor="middle">2. sendSplitRequest</text>
+  <line x1="560" y1="452" x2="560" y2="538" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="497.0" y="485" width="126" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="499" font-size="12" class="text-change" text-anchor="middle">1. Emit Split2 rows</text>
+</svg>

--- a/docs/svg/t6.svg
+++ b/docs/svg/t6.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, Task2=RUNNING, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="397" font-size="13" class="text" text-anchor="middle">Processing Split3</text>
+  <text x="200" y="420" font-size="13" class="text-change" text-anchor="middle">(noted NoMoreSplitsEvent)</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="560" y="400" font-size="13" class="text-change" text-anchor="middle">(processed NoMoreSplitsEvent)</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="420" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="485" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="570" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="635" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="80.0" y="215" width="240" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-accent" text-anchor="middle">1. NoMoreSplitsEvent broadcast</text>
+  <line x1="560" y1="172" x2="560" y2="278" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="440.0" y="215" width="240" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-accent" text-anchor="middle">1. NoMoreSplitsEvent broadcast</text>
+</svg>

--- a/docs/svg/t7.svg
+++ b/docs/svg/t7.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {Task1=RUNNING, <tspan class="text-change">Task2=FINISHED</tspan>, Task3=PROVISIONING}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="200" y="397" font-size="13" class="text" text-anchor="middle">Processing Split3</text>
+  <text x="200" y="420" font-size="13" class="text" text-anchor="middle">(noted NoMoreSplitsEvent)</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">PROVISIONING</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="420" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="485" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="570" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="635" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="560" y1="278" x2="560" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="510.0" y="215" width="100" height="20" rx="3" class="label-bg"/>
+  <text x="560" y="229" font-size="12" class="text-change" text-anchor="middle">1. FINISHED</text>
+</svg>

--- a/docs/svg/t8.svg
+++ b/docs/svg/t8.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [ ]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-change">Task3</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {<tspan class="text-accent">Task1=RUNNING</tspan>, Task2=FINISHED, <tspan class="text-change">Task3=RUNNING</tspan>}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">RUNNING</text>
+  <text x="920" y="400" font-size="13" class="text-change" text-anchor="middle">(idle)</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="345" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="410" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split1 rows</text>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <rect x="645" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="710" y="605" font-size="14" class="text-change" font-weight="600" text-anchor="middle">Split3 rows</text>
+  <line x1="200" y1="452" x2="200" y2="538" class="arrow-change" marker-end="url(#arrow-change)"/>
+  <rect x="137.0" y="485" width="126" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="499" font-size="12" class="text-change" text-anchor="middle">1. Emit Split3 rows</text>
+  <line x1="865" y1="278" x2="865" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="757.0" y="190" width="216" height="20" rx="3" class="label-bg"/>
+  <text x="865" y="204" font-size="12" class="text-change" text-anchor="middle">2. Register + sendSplitRequest</text>
+  <line x1="975" y1="172" x2="975" y2="278" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="855.0" y="245" width="240" height="20" rx="3" class="label-bg"/>
+  <text x="975" y="259" font-size="12" class="text-accent" text-anchor="middle">3. NoMoreSplitsEvent re-broadcast</text>
+  <line x1="200" y1="172" x2="200" y2="278" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="80.0" y="215" width="240" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-accent" text-anchor="middle">3. NoMoreSplitsEvent re-broadcast</text>
+</svg>

--- a/docs/svg/t9.svg
+++ b/docs/svg/t9.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 640" width="1120" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="arrow-change" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-change"/>
+    </marker>
+    <marker id="arrow-bad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head-bad"/>
+    </marker>
+  </defs>
+
+<style>
+  .box        { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-jm     { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .box-out    { fill: #eef3fb; stroke: #333;    stroke-width: 1.5; }
+  .divider    { stroke: #aab;  stroke-width: 1; }
+  .arrow      { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-dot  { stroke: #222;  stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change     { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-change-dot { stroke: #1a7f37; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad        { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-bad-dot    { stroke: #b23a48; stroke-width: 1.6; fill: none; stroke-dasharray: 5 3; }
+  .arrow-head        { fill: #222; }
+  .arrow-head-change { fill: #1a7f37; }
+  .arrow-head-bad    { fill: #b23a48; }
+  .text       { fill: #222; }
+  .text-muted { fill: #555; }
+  .text-change{ fill: #1a7f37; }
+  .text-accent{ fill: #b23a48; }
+  .label-bg   { fill: #ffffff; stroke: none; }
+  .row-box    { fill: #ffffff; stroke: #555;    stroke-width: 1; }
+  @media (prefers-color-scheme: dark) {
+    .box      { fill: #20293a; stroke: #c8c9d0; }
+    .box-jm   { fill: #20293a; stroke: #c8c9d0; }
+    .box-out  { fill: #20293a; stroke: #c8c9d0; }
+    .divider  { stroke: #6b6f7a; }
+    .arrow,
+    .arrow-dot{ stroke: #e6e6e6; }
+    .arrow-change, .arrow-change-dot { stroke: #56d364; }
+    .arrow-bad, .arrow-bad-dot       { stroke: #ff7a8a; }
+    .arrow-head        { fill: #e6e6e6; }
+    .arrow-head-change { fill: #56d364; }
+    .arrow-head-bad    { fill: #ff7a8a; }
+    .text     { fill: #e6e6e6; }
+    .text-muted { fill: #a8abb3; }
+    .text-change{ fill: #56d364; }
+    .text-accent{ fill: #ff7a8a; }
+    .label-bg { fill: #20293a; }
+    .row-box  { fill: #2b3445; stroke: #8b8e99; }
+  }
+</style>
+
+  <rect x="30" y="55" width="1060" height="115" rx="6" class="box-jm"/>
+  <text x="46" y="77" font-size="14" class="text" font-weight="600" text-anchor="start">JobManager</text>
+  <line x1="42" y1="87" x2="1078" y2="87" class="divider"/>
+  <text x="50" y="110" font-size="13" class="text-change" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">remainingSplits:      [Split1, Split3]</text>
+  <text x="50" y="133" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">readersAwaitingSplit: [<tspan class="text-accent">Task2</tspan>, <tspan class="text-accent">Task3</tspan>]</text>
+  <text x="50" y="156" font-size="13" class="text" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" xml:space="preserve" text-anchor="start">clusterState:         {<tspan class="text-accent">Task1=FAILED</tspan>, Task2=FINISHED, <tspan class="text-change">Task3=FINISHED</tspan>}</text>
+  <rect x="30" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="200" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task1</text>
+  <line x1="46" y1="324" x2="354" y2="324" class="divider"/>
+  <text x="200" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="200" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="390" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="560" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task2</text>
+  <line x1="406" y1="324" x2="714" y2="324" class="divider"/>
+  <text x="560" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="560" y="372" font-size="15" class="text" font-weight="600" text-anchor="middle">FINISHED</text>
+  <rect x="750" y="280" width="340" height="170" rx="6" class="box"/>
+  <text x="920" y="310" font-size="17" class="text" font-weight="600" text-anchor="middle">Task3</text>
+  <line x1="766" y1="324" x2="1074" y2="324" class="divider"/>
+  <text x="920" y="343" font-size="13" class="text-muted" text-anchor="middle">attempt = 0</text>
+  <text x="920" y="372" font-size="15" class="text-change" font-weight="600" text-anchor="middle">FINISHED</text>
+  <text x="920" y="400" font-size="13" class="text-change" text-anchor="middle">Processed 0 splits</text>
+  <rect x="30" y="540" width="1060" height="90" rx="6" class="box-out"/>
+  <text x="46" y="564" font-size="14" class="text" font-weight="600" text-anchor="start">Output</text>
+  <line x1="42" y1="574" x2="1078" y2="574" class="divider"/>
+  <rect x="495" y="585" width="130" height="30" rx="4" class="row-box"/>
+  <text x="560" y="605" font-size="14" class="text" font-weight="600" text-anchor="middle">Split2 rows</text>
+  <line x1="200" y1="278" x2="200" y2="172" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="80.0" y="215" width="240" height="20" rx="3" class="label-bg"/>
+  <text x="200" y="229" font-size="12" class="text-accent" text-anchor="middle">1. TaskNotRunningException</text>
+  <line x1="380" y1="170" x2="380" y2="540" class="arrow-bad-dot" marker-end="url(#arrow-bad)"/>
+  <rect x="280.0" y="190" width="200" height="20" rx="3" class="label-bg"/>
+  <text x="380" y="204" font-size="12" class="text-accent" text-anchor="middle">2. Discard (Split1, Split3 rows)</text>
+  <line x1="270" y1="172" x2="270" y2="278" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="215" y="250" width="110" height="20" rx="3" class="label-bg"/>
+  <text x="270" y="264" font-size="12" class="text-change" text-anchor="middle">3. Restart Task</text>
+  <line x1="920" y1="278" x2="920" y2="172" class="arrow-change-dot" marker-end="url(#arrow-change)"/>
+  <rect x="875" y="215" width="90" height="20" rx="3" class="label-bg"/>
+  <text x="920" y="229" font-size="12" class="text-change" text-anchor="middle">4. Finished</text>
+</svg>

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -96,7 +96,11 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void addSplitsBack(List<BigQuerySourceSplit> splits, int subtaskId) {
-        LOG.debug("BigQuery Source Enumerator adds splits back: {}", splits);
+        LOG.info(
+                "BigQuery Source Enumerator adds {} splits back from subtask {}: {}",
+                splits.size(),
+                subtaskId,
+                splits);
         splitAssigner.addSplitsBack(splits);
     }
 
@@ -136,8 +140,9 @@ public class BigQuerySourceEnumerator
                 LOG.info("Assign split {} to subtask {}", bqSplit, nextAwaiting);
                 break;
             } else if (splitAssigner.noMoreSplits() && boundedness == Boundedness.BOUNDED) {
-                LOG.info("All splits have been assigned");
-                context.registeredReaders().keySet().forEach(context::signalNoMoreSplits);
+                LOG.info("Signal NoMoreSplits to subtask {}", nextAwaiting);
+                context.signalNoMoreSplits(nextAwaiting);
+                awaitingReader.remove();
                 break;
             } else {
                 LOG.info("All splits have been assigned, will check later on.");

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.source.enumerator;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+
+import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
+import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
+import com.google.cloud.flink.bigquery.source.split.BigQuerySourceSplit;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Tests for {@link BigQuerySourceEnumerator}. */
+public class BigQuerySourceEnumeratorTest {
+
+    private BigQueryReadOptions readOptions;
+
+    @Before
+    public void beforeTest() throws IOException {
+        this.readOptions =
+                StorageClientFaker.createReadOptions(
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
+                        .toBuilder()
+                        .setParallelism(1)
+                        .build();
+    }
+
+    @Test
+    public void noMoreSplitsIsOnlySentToTheRequestingReader() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(Boundedness.BOUNDED, ctx, readOptions, seed);
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+
+            // Reader 0 picks up the only available split.
+            enumerator.handleSplitRequest(0, host(0));
+            // Reader 1 asks while reader 0 is still processing stream-0.
+            enumerator.handleSplitRequest(1, host(1));
+
+            // The requesting reader is told no-more-splits.
+            assertThat(ctx.hasNoMoreSplits(1)).isTrue();
+
+            // The reader that is still processing a split must NOT be signaled until it requests a
+            // split
+            assertThat(ctx.hasNoMoreSplits(0)).isFalse();
+            enumerator.handleSplitRequest(0, host(0));
+            assertThat(ctx.hasNoMoreSplits(0)).isTrue();
+        }
+    }
+
+    @Test
+    public void readerSignaledNoMoreSplitsIsNotAssignedOnPoolRefill() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(Boundedness.BOUNDED, ctx, readOptions, seed);
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+
+            // Reader 0 picks up the only split; reader 1 then requests and gets no-more-splits.
+            enumerator.handleSplitRequest(0, host(0));
+            SplitsAssignment<BigQuerySourceSplit> firstAssignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            List<BigQuerySourceSplit> splitsAssignedToReader0 = firstAssignment.assignment().get(0);
+            assertThat(splitsAssignedToReader0).hasSize(1);
+            BigQuerySourceSplit returnedSplit = splitsAssignedToReader0.get(0);
+
+            enumerator.handleSplitRequest(1, host(1));
+            assertThat(ctx.hasNoMoreSplits(1)).isTrue();
+            int assignmentsBeforeRefill = ctx.getSplitsAssignmentSequence().size();
+
+            // Reader 0's subtask fails; its split comes back to the pool.
+            enumerator.addSplitsBack(Collections.singletonList(returnedSplit), 0);
+
+            // Next split-discovery tick runs assignSplits with a refilled pool.
+            enumerator.notifySplits();
+
+            // Reader 1 never re-requested, so it must not be assigned the returned split.
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(assignmentsBeforeRefill);
+        }
+    }
+
+    private static String host(int subtaskId) {
+        return "host-" + subtaskId;
+    }
+
+    private BigQuerySourceEnumState seedWithOneRemainingStream() {
+        return new BigQuerySourceEnumState(
+                Collections.emptyList(),
+                Collections.singletonList("stream-0"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                true);
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -96,7 +96,11 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void addSplitsBack(List<BigQuerySourceSplit> splits, int subtaskId) {
-        LOG.debug("BigQuery Source Enumerator adds splits back: {}", splits);
+        LOG.info(
+                "BigQuery Source Enumerator adds {} splits back from subtask {}: {}",
+                splits.size(),
+                subtaskId,
+                splits);
         splitAssigner.addSplitsBack(splits);
     }
 
@@ -136,8 +140,9 @@ public class BigQuerySourceEnumerator
                 LOG.info("Assign split {} to subtask {}", bqSplit, nextAwaiting);
                 break;
             } else if (splitAssigner.noMoreSplits() && boundedness == Boundedness.BOUNDED) {
-                LOG.info("All splits have been assigned");
-                context.registeredReaders().keySet().forEach(context::signalNoMoreSplits);
+                LOG.info("Signal NoMoreSplits to subtask {}", nextAwaiting);
+                context.signalNoMoreSplits(nextAwaiting);
+                awaitingReader.remove();
                 break;
             } else {
                 LOG.info("All splits have been assigned, will check later on.");

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.source.enumerator;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+
+import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
+import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
+import com.google.cloud.flink.bigquery.source.split.BigQuerySourceSplit;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Tests for {@link BigQuerySourceEnumerator}. */
+public class BigQuerySourceEnumeratorTest {
+
+    private BigQueryReadOptions readOptions;
+
+    @Before
+    public void beforeTest() throws IOException {
+        this.readOptions =
+                StorageClientFaker.createReadOptions(
+                                0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
+                        .toBuilder()
+                        .setParallelism(1)
+                        .build();
+    }
+
+    @Test
+    public void noMoreSplitsIsOnlySentToTheRequestingReader() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(Boundedness.BOUNDED, ctx, readOptions, seed);
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+
+            // Reader 0 picks up the only available split.
+            enumerator.handleSplitRequest(0, host(0));
+            // Reader 1 asks while reader 0 is still processing stream-0.
+            enumerator.handleSplitRequest(1, host(1));
+
+            // The requesting reader is told no-more-splits.
+            assertThat(ctx.hasNoMoreSplits(1)).isTrue();
+
+            // The reader that is still processing a split must NOT be signaled until it requests a
+            // split
+            assertThat(ctx.hasNoMoreSplits(0)).isFalse();
+            enumerator.handleSplitRequest(0, host(0));
+            assertThat(ctx.hasNoMoreSplits(0)).isTrue();
+        }
+    }
+
+    @Test
+    public void readerSignaledNoMoreSplitsIsNotAssignedOnPoolRefill() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(Boundedness.BOUNDED, ctx, readOptions, seed);
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+
+            // Reader 0 picks up the only split; reader 1 then requests and gets no-more-splits.
+            enumerator.handleSplitRequest(0, host(0));
+            SplitsAssignment<BigQuerySourceSplit> firstAssignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            List<BigQuerySourceSplit> splitsAssignedToReader0 = firstAssignment.assignment().get(0);
+            assertThat(splitsAssignedToReader0).hasSize(1);
+            BigQuerySourceSplit returnedSplit = splitsAssignedToReader0.get(0);
+
+            enumerator.handleSplitRequest(1, host(1));
+            assertThat(ctx.hasNoMoreSplits(1)).isTrue();
+            int assignmentsBeforeRefill = ctx.getSplitsAssignmentSequence().size();
+
+            // Reader 0's subtask fails; its split comes back to the pool.
+            enumerator.addSplitsBack(Collections.singletonList(returnedSplit), 0);
+
+            // Next split-discovery tick runs assignSplits with a refilled pool.
+            enumerator.notifySplits();
+
+            // Reader 1 never re-requested, so it must not be assigned the returned split.
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(assignmentsBeforeRefill);
+        }
+    }
+
+    private static String host(int subtaskId) {
+        return "host-" + subtaskId;
+    }
+
+    private BigQuerySourceEnumState seedWithOneRemainingStream() {
+        return new BigQuerySourceEnumState(
+                Collections.emptyList(),
+                Collections.singletonList("stream-0"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                true);
+    }
+}


### PR DESCRIPTION
TLDR; Two (race condition) bugs in BigQuerySourceEnumerator.assignSplits compound to produce silent row loss:

- Bug 1 fails already-finishing reader tasks and returns their splits to the pool.
- Bug 2 then reassigns those returned splits to reader tasks that have since terminated. The reassigned splits sit booked to dead tasks and are never re-read.

Actual code changes is only ~10 lines. Rest is just docs. 

Note: the docs in the PR are slightly wrong and were removed in a later PR. See [this](https://github.com/user-attachments/files/27139875/pr_description.html) for an indepth and accurate explanation of how the bug manifests. 