### PR TITLE
Populate default columns so never querying empty (all columns) from BQ

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -70,6 +70,13 @@ public class BigQueryDynamicTableSource
     private DataType producedDataType;
 
     public BigQueryDynamicTableSource(BigQueryReadOptions readOptions, DataType producedDataType) {
+        if (readOptions.getColumnNames().isEmpty()) {
+            readOptions =
+                    readOptions
+                            .toBuilder()
+                            .setColumnNames(DataType.getFieldNames(producedDataType))
+                            .build();
+        }
         this.readOptions = readOptions;
         this.producedDataType = producedDataType;
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -106,6 +106,37 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testDefaultColumnNamesAreAllDdlColumns() throws IOException {
+        DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+
+        // ensure that column names are used when not specified is all 'physical' columns
+        assertThat(((BigQueryDynamicTableSource) actual).getReadOptions().getColumnNames())
+                .containsExactly("aaa", "bbb", "ccc", "ddd", "eee")
+                .inOrder();
+    }
+
+    @Test
+    public void testApplyProjectionNarrowsSeededColumnNames() throws IOException {
+        DynamicTableSource source = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+        BigQueryDynamicTableSource bqSource = (BigQueryDynamicTableSource) source;
+
+        assertThat(bqSource.getReadOptions().getColumnNames())
+                .containsExactly("aaa", "bbb", "ccc", "ddd", "eee")
+                .inOrder();
+
+        // Narrower projection
+        bqSource.applyProjection(
+                new int[][] {{0}, {2}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("aaa", DataTypes.INT().notNull()),
+                        DataTypes.FIELD("ccc", DataTypes.DOUBLE())));
+
+        assertThat(bqSource.getReadOptions().getColumnNames())
+                .containsExactly("aaa", "ccc")
+                .inOrder();
+    }
+
+    @Test
     public void testBigQuerySourceValidation() {
         // max num of streams should be positive
         assertSourceValidationRejects(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -72,6 +72,13 @@ public class BigQueryDynamicTableSource
 
     public BigQueryDynamicTableSource(
             BigQueryReadOptions readOptions, DataType producedDataType, Integer parallelism) {
+        if (readOptions.getColumnNames().isEmpty()) {
+            readOptions =
+                    readOptions
+                            .toBuilder()
+                            .setColumnNames(DataType.getFieldNames(producedDataType))
+                            .build();
+        }
         this.readOptions = readOptions;
         this.producedDataType = producedDataType;
         this.parallelism = parallelism;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -107,6 +107,37 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testDefaultColumnNamesAreAllDdlColumns() throws IOException {
+        DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+
+        // ensure that column names are used when not specified is all 'physical' columns
+        assertThat(((BigQueryDynamicTableSource) actual).getReadOptions().getColumnNames())
+                .containsExactly("aaa", "bbb", "ccc", "ddd", "eee")
+                .inOrder();
+    }
+
+    @Test
+    public void testApplyProjectionNarrowsSeededColumnNames() throws IOException {
+        DynamicTableSource source = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+        BigQueryDynamicTableSource bqSource = (BigQueryDynamicTableSource) source;
+
+        assertThat(bqSource.getReadOptions().getColumnNames())
+                .containsExactly("aaa", "bbb", "ccc", "ddd", "eee")
+                .inOrder();
+
+        // Narrower projection
+        bqSource.applyProjection(
+                new int[][] {{0}, {2}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("aaa", DataTypes.INT().notNull()),
+                        DataTypes.FIELD("ccc", DataTypes.DOUBLE())));
+
+        assertThat(bqSource.getReadOptions().getColumnNames())
+                .containsExactly("aaa", "ccc")
+                .inOrder();
+    }
+
+    @Test
     public void testBigQuerySourceValidation() {
         // max num of streams should be positive
         assertSourceValidationRejects(


### PR DESCRIPTION
# Problem
Addresses identified issue where if you select all columns within the table you defined in Flink, the connector will send an empty projection request to BigQuery making it fetch all columns. This is a particularly big issue when your Flink defined table contains only a subset of the columns on the underlying BigQuery table. (i.e column level permissions infringed, data volume transfered is way higher etc).

# Context
This is because Flink will detect if your are attempting to select all columns within your table def and will see that as no projection to pushdown, causing no overwriting of the config set by `read.columns.projection`. Since this value defaults to empty, if not specified at creation time, the Big Query connector will prompt BQ to fetch all columns.

# The Fix
Default the `read.columns.projection` to be the columns set by the table DDL in Flink. This can be overwritten if the user sets `read.columns.projection` OR if there is an actual projection-pushdown (limited columns) requested by a query.

# More detailed explanation
When you query every column the Flink DDL declared (either SELECT * or by listing them all explicitly), Flink's table planner runs a check to decide whether there's any projection to push down [ref](https://github.com/apache/flink/blob/release-2.1/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java#L136-L140). Because the referenced field count equals the declared field count, it concludes there's nothing to prune and skips the pushdown step entirely. This decision is made purely from the Flink DDL, with no awareness of the actual BigQuery table's full schema. With the pushdown step skipped, the connector's column list stays at its previous value (empty, or what you set it to with `read.columns.projection` more on this in next paragraph [ref](https://github.com/Shopify/flink-bigquery-connector/blob/main//flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java#L119-L126)), and that empty list is what gets forwarded to BigQuery's Storage Read API which interprets "no columns selected" as "return every column in the underlying table." That's where the policy-tag permission errors come from: BQ ends up trying to read columns the DDL never declared. When the query references only a subset of the declared columns, Flink's planner does run pushdown, calls into the connector with the pruned list, and BQ only sees the columns actually needed.

For a more direct analog to what we did, in icberg they have an explicit check if the projected fields is null it will also just fall back to defined ddl columns [ref](https://github.com/apache/iceberg/blob/main/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java#L150C26-L150C44)

# Validated
- Added Unit tests + passing existing to ensure this minimal set of columns returned is respected
- Integration step-through code to ensure that we are now never passing empty filters to Big Query split assigner (insert line number)

# What to look for
- What impact would this make for existing queries
- Does this trace make sense to the Google engineers and is this solution applied at the best level
- Has this issue been seen before 