### PR TITLE
Indirect writes (3/8): BigQueryIndirectSink

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -103,6 +103,26 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-parquet</artifactId>
+        </dependency>
+
+        <!-- flink-parquet exposes org.apache.hadoop.conf.Configuration on its public API. -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+
+        <!-- parquet-mr's ParquetOutputFormat extends Hadoop's FileOutputFormat from
+             hadoop-mapreduce-client-core. -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-files</artifactId>
         </dependency>
 
@@ -114,6 +134,16 @@ under the License.
         </dependency>
 
         <!-- Tests -->
+        <!-- Hadoop 2.10 transitively brings commons-io 2.4, which lacks NullPrintStream
+             that Flink's MiniCluster needs at test time. Version matches what flink-*
+             ships transitively. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils</artifactId>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.StatefulSinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.SupportsWriterState;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.writer.FileWriterBucketState;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.BasePathBucketAssigner;
+
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.sink.indirect.BigQueryLoadJobOperator;
+import com.google.cloud.flink.bigquery.sink.indirect.SizeBasedCheckpointRollingPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * BigQuery sink using indirect writes (GCS files + load jobs).
+ *
+ * <p>This sink writes data as Parquet files to GCS using Flink's {@link FileSink} and then submits
+ * BigQuery load jobs in the post-commit topology to load the data into the destination table.
+ *
+ * <p>The pipeline is:
+ *
+ * <pre>
+ * RowData
+ *   -&gt; FileSink's FileWriter (BulkWriter.Factory uses RowDataParquetWriterFactory)
+ *   -&gt; [Checkpoint]
+ *   -&gt; FileSink's FileCommitter (finalizes .inprogress -&gt; final GCS files)
+ *   -&gt; PostCommitTopology: BigQueryLoadJobOperator
+ *        -&gt; Aggregates committed files per (subtask, checkpoint)
+ *        -&gt; Submits BigQuery load job(s) with deterministic job IDs
+ *        -&gt; Cleans up GCS files
+ * </pre>
+ *
+ * <p>The sink provides EXACTLY_ONCE delivery guarantee.
+ *
+ * <p>Requires the GCS Hadoop connector plugin ({@code flink-gs-fs-hadoop}) to be installed in the
+ * Flink cluster's {@code plugins/} directory.
+ */
+@Internal
+final class BigQueryIndirectSink<IN>
+        implements Sink<IN>,
+                SupportsWriterState<IN, FileWriterBucketState>,
+                SupportsCommitter<FileSinkCommittable>,
+                SupportsPostCommitTopology<FileSinkCommittable> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BigQueryIndirectSink.class);
+
+    private final BigQueryConnectOptions connectOptions;
+    private final UUID uuid;
+    private final Path gcsBasePath;
+    private final FormatOptions formatOptions;
+    private final FileSink<IN> fileSink;
+
+    BigQueryIndirectSink(final BigQuerySinkConfig<IN> config) {
+        this(config, UUID.randomUUID());
+    }
+
+    @VisibleForTesting
+    BigQueryIndirectSink(final BigQuerySinkConfig<IN> config, final UUID uuid) {
+        this.connectOptions = config.getConnectOptions();
+        this.uuid = uuid;
+        this.gcsBasePath = new Path(config.getTempGcsPath(), uuid.toString());
+        this.formatOptions = config.getFormatOptions();
+
+        LOG.info(
+                "Creating BigQueryIndirectSink: uuid={}, gcsBasePath={}, table={}.{}.{}",
+                uuid,
+                gcsBasePath,
+                connectOptions.getProjectId(),
+                connectOptions.getDataset(),
+                connectOptions.getTable());
+
+        this.fileSink =
+                FileSink.forBulkFormat(gcsBasePath, config.getBulkWriterFactory())
+                        .withRollingPolicy(new SizeBasedCheckpointRollingPolicy<>())
+                        .withBucketAssigner(new BasePathBucketAssigner<>())
+                        .build();
+    }
+
+    @Override
+    public SinkWriter<IN> createWriter(final WriterInitContext context) throws IOException {
+        return fileSink.createWriter(context);
+    }
+
+    @Override
+    public StatefulSinkWriter<IN, FileWriterBucketState> restoreWriter(
+            final WriterInitContext context, final Collection<FileWriterBucketState> recoveredState)
+            throws IOException {
+        return fileSink.restoreWriter(context, recoveredState);
+    }
+
+    @Override
+    public Committer<FileSinkCommittable> createCommitter(final CommitterInitContext context)
+            throws IOException {
+        return fileSink.createCommitter(context);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileSinkCommittable> getCommittableSerializer() {
+        return fileSink.getCommittableSerializer();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileWriterBucketState> getWriterStateSerializer() {
+        return fileSink.getWriterStateSerializer();
+    }
+
+    @Override
+    public void addPostCommitTopology(
+            final DataStream<CommittableMessage<FileSinkCommittable>> committables) {
+        if (committables
+                        .getExecutionEnvironment()
+                        .getConfiguration()
+                        .get(ExecutionOptions.RUNTIME_MODE)
+                != RuntimeExecutionMode.BATCH) {
+            throw new IllegalStateException(
+                    "INDIRECT write mode is only supported in BATCH execution mode");
+        }
+
+        committables
+                .global()
+                .flatMap(
+                        new BigQueryLoadJobOperator(
+                                connectOptions, uuid, gcsBasePath, formatOptions))
+                .name("BigQueryLoadJobOperator")
+                .forceNonParallel();
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -42,6 +42,15 @@ public class BigQuerySink {
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
 
     public static <IN> Sink<IN> get(BigQuerySinkConfig<IN> sinkConfig) {
+        if (sinkConfig.getWriteMode() == WriteMode.INDIRECT) {
+            BigQuerySinkConfig.validateIndirect(
+                    sinkConfig.getTempGcsPath(),
+                    sinkConfig.getBulkWriterFactory(),
+                    sinkConfig.getFormatOptions(),
+                    sinkConfig.isCdcEnabled(),
+                    sinkConfig.enableTableCreation());
+            return new BigQueryIndirectSink<>(sinkConfig);
+        }
         if (sinkConfig.isCdcEnabled()) {
             validateCdcConfiguration(sinkConfig);
         }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -129,7 +129,7 @@ public class BigQuerySinkConfig<IN> {
             return false;
         }
         BigQuerySinkConfig<IN> object = (BigQuerySinkConfig<IN>) obj;
-        return (this.getConnectOptions() == object.getConnectOptions()
+        return (Objects.equals(this.getConnectOptions(), object.getConnectOptions())
                 && Objects.equals(serializerClass(this), serializerClass(object))
                 && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())
                 && (this.enableTableCreation() == object.enableTableCreation())

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -17,15 +17,19 @@
 package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 
+import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.sink.indirect.RowDataParquetWriterFactory;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl;
@@ -75,6 +79,10 @@ public class BigQuerySinkConfig<IN> {
     private final List<String> cdcPrimaryKeyColumns;
     private final String cdcMaxStaleness;
     private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
+    private final WriteMode writeMode;
+    private final String tempGcsPath;
+    private final BulkWriter.Factory<IN> bulkWriterFactory;
+    private final FormatOptions formatOptions;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -98,7 +106,15 @@ public class BigQuerySinkConfig<IN> {
                 cdcSequenceField,
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
-                cdcChangeTypeProvider);
+                cdcChangeTypeProvider,
+                writeMode,
+                tempGcsPath,
+                bulkWriterFactory,
+                formatOptions);
+    }
+
+    private static Class<?> serializerClass(BigQuerySinkConfig<?> config) {
+        return config.getSerializer() == null ? null : config.getSerializer().getClass();
     }
 
     @Override
@@ -114,7 +130,7 @@ public class BigQuerySinkConfig<IN> {
         }
         BigQuerySinkConfig<IN> object = (BigQuerySinkConfig<IN>) obj;
         return (this.getConnectOptions() == object.getConnectOptions()
-                && (this.getSerializer().getClass() == object.getSerializer().getClass())
+                && Objects.equals(serializerClass(this), serializerClass(object))
                 && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())
                 && (this.enableTableCreation() == object.enableTableCreation())
                 && (Objects.equals(this.getPartitionField(), object.getPartitionField()))
@@ -131,7 +147,11 @@ public class BigQuerySinkConfig<IN> {
                         this.getCdcPrimaryKeyColumns(), object.getCdcPrimaryKeyColumns()))
                 && (Objects.equals(this.getCdcMaxStaleness(), object.getCdcMaxStaleness()))
                 && (Objects.equals(
-                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider())));
+                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider()))
+                && (this.writeMode == object.writeMode)
+                && (Objects.equals(this.tempGcsPath, object.tempGcsPath))
+                && (Objects.equals(this.bulkWriterFactory, object.bulkWriterFactory))
+                && (Objects.equals(this.formatOptions, object.formatOptions)));
     }
 
     private BigQuerySinkConfig(
@@ -150,7 +170,11 @@ public class BigQuerySinkConfig<IN> {
             String cdcSequenceField,
             List<String> cdcPrimaryKeyColumns,
             String cdcMaxStaleness,
-            CdcChangeTypeProvider<?> cdcChangeTypeProvider) {
+            CdcChangeTypeProvider<?> cdcChangeTypeProvider,
+            WriteMode writeMode,
+            String tempGcsPath,
+            BulkWriter.Factory<IN> bulkWriterFactory,
+            FormatOptions formatOptions) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -167,6 +191,10 @@ public class BigQuerySinkConfig<IN> {
         this.cdcPrimaryKeyColumns = cdcPrimaryKeyColumns;
         this.cdcMaxStaleness = cdcMaxStaleness;
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
+        this.writeMode = writeMode;
+        this.tempGcsPath = tempGcsPath;
+        this.bulkWriterFactory = bulkWriterFactory;
+        this.formatOptions = formatOptions;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -233,6 +261,22 @@ public class BigQuerySinkConfig<IN> {
         return cdcChangeTypeProvider;
     }
 
+    public WriteMode getWriteMode() {
+        return writeMode;
+    }
+
+    public String getTempGcsPath() {
+        return tempGcsPath;
+    }
+
+    public BulkWriter.Factory<IN> getBulkWriterFactory() {
+        return bulkWriterFactory;
+    }
+
+    public FormatOptions getFormatOptions() {
+        return formatOptions;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -258,6 +302,10 @@ public class BigQuerySinkConfig<IN> {
         private List<String> cdcPrimaryKeyColumns;
         private String cdcMaxStaleness;
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
+        private WriteMode writeMode = WriteMode.STORAGE_WRITE_API;
+        private String tempGcsPath;
+        private BulkWriter.Factory<IN> bulkWriterFactory;
+        private FormatOptions formatOptions;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -345,8 +393,35 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> writeMode(WriteMode writeMode) {
+            this.writeMode = writeMode;
+            return this;
+        }
+
+        public Builder<IN> tempGcsPath(String tempGcsPath) {
+            this.tempGcsPath = tempGcsPath;
+            return this;
+        }
+
+        public Builder<IN> bulkWriterFactory(BulkWriter.Factory<IN> bulkWriterFactory) {
+            this.bulkWriterFactory = bulkWriterFactory;
+            return this;
+        }
+
+        public Builder<IN> formatOptions(FormatOptions formatOptions) {
+            this.formatOptions = formatOptions;
+            return this;
+        }
+
         public BigQuerySinkConfig<IN> build() {
-            if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
+            if (writeMode == WriteMode.INDIRECT) {
+                validateIndirect(
+                        tempGcsPath,
+                        bulkWriterFactory,
+                        formatOptions,
+                        cdcEnabled,
+                        enableTableCreation);
+            } else if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
                 validateStreamExecutionEnvironment(env);
             }
             return new BigQuerySinkConfig<>(
@@ -365,7 +440,11 @@ public class BigQuerySinkConfig<IN> {
                     cdcSequenceField,
                     cdcPrimaryKeyColumns,
                     cdcMaxStaleness,
-                    cdcChangeTypeProvider);
+                    cdcChangeTypeProvider,
+                    writeMode,
+                    tempGcsPath,
+                    bulkWriterFactory,
+                    formatOptions);
         }
     }
 
@@ -383,49 +462,31 @@ public class BigQuerySinkConfig<IN> {
             Long partitionExpirationMillis,
             List<String> clusteredFields,
             String region,
-            boolean fatalizeSerializer) {
-        return forTable(
-                connectOptions,
-                deliveryGuarantee,
-                logicalType,
-                enableTableCreation,
-                partitionField,
-                partitionType,
-                partitionExpirationMillis,
-                clusteredFields,
-                region,
-                fatalizeSerializer,
-                false,
-                null,
-                null,
-                null,
-                null);
-    }
-
-    /** Table API overload with CDC support. */
-    @Internal
-    public static BigQuerySinkConfig<RowData> forTable(
-            BigQueryConnectOptions connectOptions,
-            DeliveryGuarantee deliveryGuarantee,
-            LogicalType logicalType,
-            boolean enableTableCreation,
-            String partitionField,
-            TimePartitioning.Type partitionType,
-            Long partitionExpirationMillis,
-            List<String> clusteredFields,
-            String region,
             boolean fatalizeSerializer,
             boolean cdcEnabled,
             String cdcSequenceField,
             List<String> cdcPrimaryKeyColumns,
             String cdcMaxStaleness,
-            CdcChangeTypeProvider<RowData> cdcChangeTypeProvider) {
+            CdcChangeTypeProvider<RowData> cdcChangeTypeProvider,
+            WriteMode writeMode,
+            String tempGcsPath) {
+        boolean indirect = writeMode == WriteMode.INDIRECT;
+        BulkWriter.Factory<RowData> bulkWriterFactory =
+                indirect ? RowDataParquetWriterFactory.create((RowType) logicalType) : null;
+        FormatOptions formatOptions = indirect ? FormatOptions.parquet() : null;
+        BigQuerySchemaProvider schemaProvider =
+                indirect
+                        ? null
+                        : new BigQuerySchemaProviderImpl(
+                                BigQueryTableSchemaProvider.getAvroSchemaFromLogicalSchema(
+                                        logicalType));
+        BigQueryProtoSerializer<RowData> serializer =
+                indirect ? null : new RowDataToProtoSerializer(logicalType);
         return new BigQuerySinkConfig<>(
                 connectOptions,
                 deliveryGuarantee,
-                new BigQuerySchemaProviderImpl(
-                        BigQueryTableSchemaProvider.getAvroSchemaFromLogicalSchema(logicalType)),
-                new RowDataToProtoSerializer(logicalType),
+                schemaProvider,
+                serializer,
                 enableTableCreation,
                 partitionField,
                 partitionType,
@@ -437,7 +498,41 @@ public class BigQuerySinkConfig<IN> {
                 cdcSequenceField,
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
-                cdcChangeTypeProvider);
+                cdcChangeTypeProvider,
+                writeMode,
+                tempGcsPath,
+                bulkWriterFactory,
+                formatOptions);
+    }
+
+    /**
+     * Validates INDIRECT-mode configuration. INDIRECT writes go through GCS-staged Parquet files +
+     * BigQuery load jobs. CDC and table-auto-creation are unsupported on that path; reject them
+     * eagerly so misconfigurations fail at job-graph build, not silently at runtime.
+     */
+    static void validateIndirect(
+            String tempGcsPath,
+            BulkWriter.Factory<?> bulkWriterFactory,
+            FormatOptions formatOptions,
+            boolean cdcEnabled,
+            boolean enableTableCreation) {
+        if (tempGcsPath == null || tempGcsPath.isEmpty()) {
+            throw new IllegalArgumentException("tempGcsPath is required for INDIRECT write mode");
+        }
+        if (bulkWriterFactory == null) {
+            throw new IllegalArgumentException(
+                    "bulkWriterFactory is required for INDIRECT write mode");
+        }
+        if (formatOptions == null) {
+            throw new IllegalArgumentException("formatOptions is required for INDIRECT write mode");
+        }
+        if (cdcEnabled) {
+            throw new IllegalArgumentException("CDC is not supported in INDIRECT write mode");
+        }
+        if (enableTableCreation) {
+            throw new IllegalArgumentException(
+                    "Table auto-creation is not supported in INDIRECT write mode");
+        }
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/WriteMode.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/WriteMode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+/** Write mode for the BigQuery sink. */
+public enum WriteMode {
+    /** Writes to BigQuery directly using BigQuery Storage Write API. */
+    STORAGE_WRITE_API,
+    /** Writes to BigQuery indirectly via GCS files + BigQuery load jobs. */
+    INDIRECT
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/RowDataParquetWriterFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/RowDataParquetWriterFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.indirect;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.formats.parquet.ParquetWriterFactory;
+import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Objects;
+
+/**
+ * Factory for Parquet bulk writers used by the indirect-write path.
+ *
+ * <p>Configures Parquet to encode timestamps as INT64 with microsecond precision so BigQuery's
+ * Parquet load reads them back as {@code TIMESTAMP} with full TIMESTAMP(6) fidelity. The default
+ * INT96 encoding would lose precision and is treated as a legacy Hive type by BigQuery.
+ *
+ * <p><b>Known limitation:</b> Flink's {@code ParquetSchemaConverter} emits identical {@code
+ * timestamp(isAdjustedToUTC=false, MICROS)} schemas for both Flink {@code
+ * TIMESTAMP_WITHOUT_TIME_ZONE} and {@code TIMESTAMP_WITH_LOCAL_TIME_ZONE}. BigQuery's Parquet
+ * reader interprets that pair the same way for both - so loading into a target table that has a
+ * {@code DATETIME} column from Flink {@code TIMESTAMP_WITHOUT_TIME_ZONE} fails with a schema
+ * mismatch ("changed type from DATETIME to TIMESTAMP"). DATETIME target columns aren't supported.
+ */
+@Internal
+public final class RowDataParquetWriterFactory extends ParquetWriterFactory<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RowType rowType;
+
+    private RowDataParquetWriterFactory(RowType rowType) {
+        // utcTimestamp=true: TIMESTAMP_LTZ values are written relative to UTC, matching BigQuery
+        // TIMESTAMP semantics.
+        super(new ParquetRowDataBuilder.FlinkParquetBuilder(rowType, buildConf(), true));
+        this.rowType = rowType;
+    }
+
+    public static RowDataParquetWriterFactory create(RowType rowType) {
+        return new RowDataParquetWriterFactory(rowType);
+    }
+
+    private static Configuration buildConf() {
+        Configuration conf = new Configuration();
+        // Force INT64-based timestamp encoding so logical types (TIMESTAMP_MICROS,
+        // LOCAL_TIMESTAMP_MICROS) are emitted instead of legacy INT96.
+        conf.setBoolean("parquet.write.int64.timestamp", true);
+        // Microsecond resolution matches BigQuery TIMESTAMP precision (6).
+        conf.set("parquet.timestamp.time.unit", "micros");
+        conf.set("parquet.compression", "SNAPPY");
+        return conf;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rowType);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RowDataParquetWriterFactory)) {
+            return false;
+        }
+        return Objects.equals(this.rowType, ((RowDataParquetWriterFactory) obj).rowType);
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/SizeBasedCheckpointRollingPolicy.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/SizeBasedCheckpointRollingPolicy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.indirect;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
+
+import java.io.IOException;
+
+/**
+ * A {@link CheckpointRollingPolicy} that also rolls files when they exceed a size threshold.
+ *
+ * <p>This prevents unbounded file growth in batch mode where a single checkpoint occurs at
+ * end-of-input. Without size-based rolling, each subtask would produce one file containing all its
+ * data, which can grow very large. Rolling at a size threshold gives BigQuery load-job parallelism
+ * and faster retries.
+ */
+@Internal
+public final class SizeBasedCheckpointRollingPolicy<IN, BucketID>
+        extends CheckpointRollingPolicy<IN, BucketID> {
+
+    // 1.5 GB: the size above which a part file will roll. With BigQuery's 15 TB per load job
+    // limit, that's 10,000 files, which matches the number of source URIs allowed per load job.
+    // This keeps the single-partition direct load path for the common case, avoiding the temp-table
+    // + copy overhead.
+    @VisibleForTesting static final long DEFAULT_MAX_FILE_SIZE = 1500L * 1000 * 1000; // 1.5 GB
+
+    @Override
+    public boolean shouldRollOnEvent(PartFileInfo<BucketID> partFileState, IN element)
+            throws IOException {
+        return partFileState.getSize() >= DEFAULT_MAX_FILE_SIZE;
+    }
+
+    @Override
+    public boolean shouldRollOnProcessingTime(
+            PartFileInfo<BucketID> partFileState, long currentTime) {
+        return false;
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -111,7 +111,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         cdcMaxStaleness,
                         cdcEnabled && cdcChangeTypeProvider == null
                                 ? RowDataCdcChangeTypeProvider.getInstance()
-                                : cdcChangeTypeProvider);
+                                : cdcChangeTypeProvider,
+                        null,
+                        null);
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
@@ -1,0 +1,483 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobConfiguration;
+import com.google.cloud.bigquery.JobStatus;
+import com.google.cloud.bigquery.LoadJobConfiguration;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
+import com.google.cloud.flink.bigquery.services.BigQueryServices;
+import com.google.cloud.flink.bigquery.services.TablePartitionInfo;
+import com.google.cloud.flink.bigquery.sink.indirect.RowDataParquetWriterFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link BigQueryIndirectSink}. */
+public class BigQueryIndirectSinkTest {
+
+    private static final String PROJECT = "test-project";
+    private static final String DATASET = "test-dataset";
+    private static final String TABLE = "test-table";
+
+    private static final RowType ROW_TYPE =
+            RowType.of(new BigIntType(), new VarCharType(VarCharType.MAX_LENGTH));
+
+    @Rule public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Before
+    public void resetCapturedState() {
+        CapturingQueryDataClient.reset();
+    }
+
+    private static String localPath() throws IOException {
+        return Files.createTempDirectory("bq-indirect-sink-test").toUri().toString();
+    }
+
+    private static BigQueryConnectOptions connectOptions() {
+        return BigQueryConnectOptions.builder()
+                .setProjectId(PROJECT)
+                .setDataset(DATASET)
+                .setTable(TABLE)
+                .setTestingBigQueryServices(CapturingBigQueryServices::new)
+                .build();
+    }
+
+    private static BigQuerySinkConfig<String> config(final BigQueryConnectOptions opts)
+            throws IOException {
+        return BigQuerySinkConfig.<String>newBuilder()
+                .writeMode(WriteMode.INDIRECT)
+                .connectOptions(opts)
+                .tempGcsPath(localPath())
+                .bulkWriterFactory(new DummyFactory())
+                .formatOptions(FormatOptions.parquet())
+                .build();
+    }
+
+    @Test
+    public void getCommittableSerializerDelegatesToFileSink() throws Exception {
+        final BigQueryIndirectSink<String> sink =
+                new BigQueryIndirectSink<>(config(connectOptions()));
+        final FileSink<String> reference =
+                FileSink.forBulkFormat(new Path(localPath()), new DummyFactory()).build();
+        assertEquals(
+                reference.getCommittableSerializer().getClass(),
+                sink.getCommittableSerializer().getClass());
+    }
+
+    @Test
+    public void getWriterStateSerializerDelegatesToFileSink() throws Exception {
+        final BigQueryIndirectSink<String> sink =
+                new BigQueryIndirectSink<>(config(connectOptions()));
+        final FileSink<String> reference =
+                FileSink.forBulkFormat(new Path(localPath()), new DummyFactory()).build();
+        assertEquals(
+                reference.getWriterStateSerializer().getClass(),
+                sink.getWriterStateSerializer().getClass());
+    }
+
+    @Test
+    public void sinkWriteFilesSubmitsLoadJobCleansUpFiles() throws Exception {
+        final File gcsRoot = tmp.newFolder("gcs");
+
+        try (StreamExecutionEnvironment env =
+                runFlinkJob(
+                        List.of(indirectSink(connectOptions(), UUID.randomUUID(), gcsRoot)),
+                        RuntimeExecutionMode.BATCH,
+                        1,
+                        GenericRowData.of(0L, StringData.fromString("hello")),
+                        GenericRowData.of(0L, StringData.fromString("world")))) {
+            env.execute("BigQueryIndirectSinkTest");
+        }
+
+        assertEquals(
+                "expected exactly one load job submission",
+                1,
+                CapturingQueryDataClient.submittedJobs.size());
+
+        final JobConfiguration submitted = CapturingQueryDataClient.submittedJobs.get(0);
+        assertTrue(
+                "submitted job must be a LoadJobConfiguration, was " + submitted.getClass(),
+                submitted instanceof LoadJobConfiguration);
+        final LoadJobConfiguration loadCfg = (LoadJobConfiguration) submitted;
+        assertEquals(TableId.of(PROJECT, DATASET, TABLE), loadCfg.getDestinationTable());
+        assertEquals(
+                "parallelism=1 with a tiny payload should produce one part file",
+                1,
+                loadCfg.getSourceUris().size());
+        final String sourceUri = loadCfg.getSourceUris().get(0);
+        assertTrue(
+                "source URI should sit under the configured tempGcsPath: " + sourceUri,
+                sourceUri.startsWith(gcsRoot.toURI().toString()));
+
+        final File written = new File(URI.create(sourceUri));
+        assertFalse(
+                "file should be cleaned up after successful load: " + written, written.exists());
+    }
+
+    @Test
+    public void sinkWriteFilesSubmitsLoadJobCleansUpFilesParallelism2() throws Exception {
+        final File gcsRoot = tmp.newFolder("gcs");
+
+        try (StreamExecutionEnvironment env =
+                runFlinkJob(
+                        List.of(indirectSink(connectOptions(), UUID.randomUUID(), gcsRoot)),
+                        RuntimeExecutionMode.BATCH,
+                        2,
+                        GenericRowData.of(0L, StringData.fromString("a")),
+                        GenericRowData.of(1L, StringData.fromString("b")))) {
+            env.execute("BigQueryIndirectSinkTest");
+        }
+
+        assertEquals(
+                "expected exactly one load job submission (post-commit operator is global)",
+                1,
+                CapturingQueryDataClient.submittedJobs.size());
+
+        final JobConfiguration submitted = CapturingQueryDataClient.submittedJobs.get(0);
+        assertTrue(
+                "submitted job must be a LoadJobConfiguration, was " + submitted.getClass(),
+                submitted instanceof LoadJobConfiguration);
+        final LoadJobConfiguration loadCfg = (LoadJobConfiguration) submitted;
+        assertEquals(TableId.of(PROJECT, DATASET, TABLE), loadCfg.getDestinationTable());
+        assertEquals(
+                "parallelism=2 with keys hitting both subtasks should produce two part files",
+                2,
+                loadCfg.getSourceUris().size());
+        for (final String sourceUri : loadCfg.getSourceUris()) {
+            assertTrue(
+                    "source URI should sit under the configured tempGcsPath: " + sourceUri,
+                    sourceUri.startsWith(gcsRoot.toURI().toString()));
+            final File written = new File(URI.create(sourceUri));
+            assertFalse(
+                    "file should be cleaned up after successful load: " + written,
+                    written.exists());
+        }
+    }
+
+    @Test
+    public void sinkRejectsStreamingMode() throws Exception {
+        final File gcsRoot = tmp.newFolder("gcs");
+        try (StreamExecutionEnvironment env =
+                runFlinkJob(
+                        List.of(indirectSink(connectOptions(), UUID.randomUUID(), gcsRoot)),
+                        RuntimeExecutionMode.STREAMING,
+                        1,
+                        GenericRowData.of(0L, StringData.fromString("hello")))) {
+
+            assertThatThrownBy(() -> env.execute("BigQueryIndirectSinkTest"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("INDIRECT write mode is only supported in BATCH");
+        }
+    }
+
+    @Test
+    public void twoSinksToSameTableSubmitDistinctLoadJobs() throws Exception {
+        final File gcsRoot = tmp.newFolder("gcs");
+        final UUID uuid1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        final UUID uuid2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        final JobID flinkJobId;
+        try (StreamExecutionEnvironment env =
+                runFlinkJob(
+                        List.of(
+                                indirectSink(connectOptions(), uuid1, gcsRoot),
+                                indirectSink(connectOptions(), uuid2, gcsRoot)),
+                        RuntimeExecutionMode.BATCH,
+                        1,
+                        GenericRowData.of(0L, StringData.fromString("hello")))) {
+            flinkJobId = env.execute("BigQueryIndirectSinkTest").getJobID();
+        }
+
+        // Two sinks share the Flink job ID and the (single, batch-mode) checkpoint ID, so the
+        // load job IDs differ only at the per-sink UUID component.
+        assertThat(CapturingQueryDataClient.submittedJobIds)
+                .containsExactlyInAnyOrder(
+                        "flink-bq-load_" + flinkJobId.toHexString() + "_" + uuid1 + "_c1",
+                        "flink-bq-load_" + flinkJobId.toHexString() + "_" + uuid2 + "_c1");
+
+        final TableId expectedTable = TableId.of(PROJECT, DATASET, TABLE);
+        final List<TableId> destinationTables =
+                CapturingQueryDataClient.submittedJobs.stream()
+                        .map(c -> ((LoadJobConfiguration) c).getDestinationTable())
+                        .collect(Collectors.toList());
+        assertThat(destinationTables).containsExactly(expectedTable, expectedTable);
+    }
+
+    @Test
+    public void twoSinksToDifferentTablesSubmitDistinctLoadJobs() throws Exception {
+        final File gcsRoot = tmp.newFolder("gcs");
+        final UUID uuid1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        final UUID uuid2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        final String otherTable = "other-table";
+        final BigQueryConnectOptions opts1 = connectOptions();
+        final BigQueryConnectOptions opts2 = opts1.toBuilder().setTable(otherTable).build();
+
+        final JobID flinkJobId;
+        try (StreamExecutionEnvironment env =
+                runFlinkJob(
+                        List.of(
+                                indirectSink(opts1, uuid1, gcsRoot),
+                                indirectSink(opts2, uuid2, gcsRoot)),
+                        RuntimeExecutionMode.BATCH,
+                        1,
+                        GenericRowData.of(0L, StringData.fromString("hello")))) {
+            flinkJobId = env.execute("BigQueryIndirectSinkTest").getJobID();
+        }
+
+        // Destination table is not part of the load job ID, so even with different tables the
+        // two job IDs differ only at the per-sink UUID component.
+        assertThat(CapturingQueryDataClient.submittedJobIds)
+                .containsExactlyInAnyOrder(
+                        "flink-bq-load_" + flinkJobId.toHexString() + "_" + uuid1 + "_c1",
+                        "flink-bq-load_" + flinkJobId.toHexString() + "_" + uuid2 + "_c1");
+
+        final List<TableId> destinationTables =
+                CapturingQueryDataClient.submittedJobs.stream()
+                        .map(c -> ((LoadJobConfiguration) c).getDestinationTable())
+                        .collect(Collectors.toList());
+        assertThat(destinationTables)
+                .containsExactlyInAnyOrder(
+                        TableId.of(PROJECT, DATASET, TABLE),
+                        TableId.of(PROJECT, DATASET, otherTable));
+    }
+
+    private static BigQueryIndirectSink<RowData> indirectSink(
+            final BigQueryConnectOptions opts, final UUID uuid, final File gcsRoot) {
+        final BigQuerySinkConfig<RowData> conf =
+                BigQuerySinkConfig.<RowData>newBuilder()
+                        .writeMode(WriteMode.INDIRECT)
+                        .connectOptions(opts)
+                        .tempGcsPath(gcsRoot.toURI().toString())
+                        .bulkWriterFactory(RowDataParquetWriterFactory.create(ROW_TYPE))
+                        .formatOptions(FormatOptions.parquet())
+                        .build();
+        return new BigQueryIndirectSink<>(conf, uuid);
+    }
+
+    private static StreamExecutionEnvironment runFlinkJob(
+            final List<BigQueryIndirectSink<RowData>> sinks,
+            final RuntimeExecutionMode mode,
+            final int parallelism,
+            final RowData... rows) {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.createLocalEnvironment(parallelism, new Configuration());
+        env.setRuntimeMode(mode);
+
+        final TypeInformation<RowData> rowTypeInfo = InternalTypeInfo.of(ROW_TYPE);
+        final DataStream<RowData> partitioned =
+                env.fromData(rowTypeInfo, rows)
+                        // The bigint column IS the target subtask - pick keys in [0, parallelism)
+                        .partitionCustom(
+                                (Partitioner<Long>) (key, parts) -> key.intValue(),
+                                (KeySelector<RowData, Long>) row -> row.getLong(0));
+
+        for (final BigQueryIndirectSink<RowData> sink : sinks) {
+            partitioned.sinkTo(sink).setParallelism(parallelism);
+        }
+
+        return env;
+    }
+
+    /** Minimal serializable BulkWriter.Factory - no-op, just exists to satisfy the builder. */
+    private static final class DummyFactory implements BulkWriter.Factory<String>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public BulkWriter<String> create(final FSDataOutputStream out) throws IOException {
+            throw new UnsupportedOperationException("not used in test");
+        }
+    }
+
+    /**
+     * Fake {@link BigQueryServices} that returns a {@link CapturingQueryDataClient}. Storage
+     * clients are not used by the indirect-writes post-commit topology, so they throw.
+     */
+    public static class CapturingBigQueryServices implements BigQueryServices, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public QueryDataClient createQueryDataClient(final CredentialsOptions credentialsOptions) {
+            return new CapturingQueryDataClient();
+        }
+
+        @Override
+        public StorageReadClient createStorageReadClient(
+                final CredentialsOptions credentialsOptions) {
+            throw new UnsupportedOperationException("not used in indirect-writes post-commit");
+        }
+
+        @Override
+        public StorageWriteClient createStorageWriteClient(
+                final CredentialsOptions credentialsOptions) {
+            throw new UnsupportedOperationException("not used in indirect-writes post-commit");
+        }
+    }
+
+    /**
+     * Captures load job submissions in static state - the operator runs in the same JVM as this
+     * test (local mini-cluster), so the static fields are shared across the supplier-created
+     * instances and the test assertions.
+     */
+    public static class CapturingQueryDataClient
+            implements BigQueryServices.QueryDataClient, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        // Synchronized - two sinks in one Flink job submit jobs from independent operator
+        // threads in the local mini-cluster.
+        private static final List<JobConfiguration> submittedJobs =
+                Collections.synchronizedList(new ArrayList<>());
+        private static final List<String> submittedJobIds =
+                Collections.synchronizedList(new ArrayList<>());
+
+        static void reset() {
+            submittedJobs.clear();
+            submittedJobIds.clear();
+        }
+
+        @Override
+        public Job submitJob(
+                final String project, final String jobId, final JobConfiguration jobConfiguration) {
+            submittedJobs.add(jobConfiguration);
+            submittedJobIds.add(jobId);
+            return successJob();
+        }
+
+        @Override
+        public Job getJob(final String project, final String jobId) {
+            return null;
+        }
+
+        @Override
+        public Job waitForJob(final Job job) {
+            return job;
+        }
+
+        @Override
+        public List<String> retrieveTablePartitions(
+                final String p, final String d, final String t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<TablePartitionInfo> retrievePartitionColumnInfo(
+                final String p, final String d, final String t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TableSchema getTableSchema(final String p, final String d, final String t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Dataset getDataset(final String p, final String d) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void createDataset(final String p, final String d, final String r) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean tableExists(final String p, final String d, final String t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void createTable(
+                final String p, final String d, final String t, final TableDefinition td) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean isView(final String p, final String d, final String t) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String materializeView(
+                final String p,
+                final String d,
+                final String t,
+                final List<String> selectedFields,
+                final String rowRestriction,
+                final Integer expirationHours,
+                final String materializationProject,
+                final String materializationDataset,
+                final String billingProject) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static Job successJob() {
+        final Job job = mock(Job.class);
+        final JobStatus status = mock(JobStatus.class);
+        when(status.getError()).thenReturn(null);
+        when(job.getStatus()).thenReturn(status);
+        return job;
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -1,26 +1,33 @@
 /*
- * Copyright 2024 The Apache Software Foundation.
+ * Copyright (C) 2024 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.cloud.flink.bigquery.sink;
 
+import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
 
+import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.sink.indirect.RowDataParquetWriterFactory;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroToProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
@@ -29,6 +36,8 @@ import com.google.cloud.flink.bigquery.sink.serializer.TestSchemaProvider;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Arrays;
 
@@ -40,7 +49,10 @@ import static com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig.validateSt
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link BigQuerySinkConfig}. */
@@ -359,6 +371,173 @@ public class BigQuerySinkConfigTest {
                     (CdcChangeTypeProvider<String>) sinkConfig.getCdcChangeTypeProvider();
             assertEquals("UPSERT", provider.getChangeType("INSERT:data"));
             assertEquals("DELETE", provider.getChangeType("DELETE:data"));
+        }
+    }
+
+    // ---------- INDIRECT Write Mode Tests ----------
+
+    private static final String GCS_PATH = "gs://bucket/tmp";
+
+    private static BigQueryConnectOptions indirectConnectOptions() {
+        return BigQueryConnectOptions.builder()
+                .setProjectId("p")
+                .setDataset("d")
+                .setTable("t")
+                .build();
+    }
+
+    private static BulkWriter.Factory<String> dummyBulkWriterFactory() {
+        return new DummyBulkWriterFactory();
+    }
+
+    @Test
+    public void buildIndirectHappyPathReturnsConfigWithGetters() {
+        BigQueryConnectOptions opts = indirectConnectOptions();
+        BulkWriter.Factory<String> factory = dummyBulkWriterFactory();
+
+        BigQuerySinkConfig<String> config =
+                BigQuerySinkConfig.<String>newBuilder()
+                        .writeMode(WriteMode.INDIRECT)
+                        .connectOptions(opts)
+                        .tempGcsPath(GCS_PATH)
+                        .bulkWriterFactory(factory)
+                        .formatOptions(FormatOptions.parquet())
+                        .build();
+
+        assertSame(opts, config.getConnectOptions());
+        assertEquals(GCS_PATH, config.getTempGcsPath());
+        assertSame(factory, config.getBulkWriterFactory());
+        assertEquals(FormatOptions.parquet(), config.getFormatOptions());
+        assertEquals(WriteMode.INDIRECT, config.getWriteMode());
+    }
+
+    @Test
+    public void equalsMethodHandlesBulkWriterFactoryCorrectly() {
+        RowType rowType = RowType.of(new BigIntType());
+        // BigQuerySinkConfig.equals compares connectOptions by reference, so share the instance.
+        BigQueryConnectOptions opts = indirectConnectOptions();
+        BigQuerySinkConfig<RowData> a =
+                BigQuerySinkConfig.<RowData>newBuilder()
+                        .writeMode(WriteMode.INDIRECT)
+                        .connectOptions(opts)
+                        .tempGcsPath(GCS_PATH)
+                        .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
+                        .formatOptions(FormatOptions.parquet())
+                        .build();
+        BigQuerySinkConfig<RowData> b =
+                BigQuerySinkConfig.<RowData>newBuilder()
+                        .writeMode(WriteMode.INDIRECT)
+                        .connectOptions(opts)
+                        .tempGcsPath(GCS_PATH)
+                        .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
+                        .formatOptions(FormatOptions.parquet())
+                        .build();
+
+        assertNotSame(a.getBulkWriterFactory(), b.getBulkWriterFactory());
+
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void buildIndirectNullTempGcsPathThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempGcsPath is required"));
+    }
+
+    @Test
+    public void buildIndirectEmptyTempGcsPathThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath("")
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempGcsPath is required"));
+    }
+
+    @Test
+    public void buildIndirectNullBulkWriterFactoryThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .build());
+        assertTrue(ex.getMessage().contains("bulkWriterFactory is required"));
+    }
+
+    @Test
+    public void buildIndirectNullFormatOptionsThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("formatOptions is required"));
+    }
+
+    @Test
+    public void buildIndirectWithCdcEnabledThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .formatOptions(FormatOptions.parquet())
+                                        .enableCdc(true)
+                                        .build());
+        assertTrue(ex.getMessage().contains("CDC is not supported in INDIRECT"));
+    }
+
+    @Test
+    public void buildIndirectWithTableCreationThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .formatOptions(FormatOptions.parquet())
+                                        .enableTableCreation(true)
+                                        .build());
+        assertTrue(ex.getMessage().contains("Table auto-creation is not supported in INDIRECT"));
+    }
+
+    /** Minimal serializable BulkWriter.Factory - no-op, just exists to satisfy the builder. */
+    private static final class DummyBulkWriterFactory
+            implements BulkWriter.Factory<String>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public BulkWriter<String> create(FSDataOutputStream out) throws IOException {
+            throw new UnsupportedOperationException("not used in test");
         }
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -414,12 +414,10 @@ public class BigQuerySinkConfigTest {
     @Test
     public void equalsMethodHandlesBulkWriterFactoryCorrectly() {
         RowType rowType = RowType.of(new BigIntType());
-        // BigQuerySinkConfig.equals compares connectOptions by reference, so share the instance.
-        BigQueryConnectOptions opts = indirectConnectOptions();
         BigQuerySinkConfig<RowData> a =
                 BigQuerySinkConfig.<RowData>newBuilder()
                         .writeMode(WriteMode.INDIRECT)
-                        .connectOptions(opts)
+                        .connectOptions(indirectConnectOptions())
                         .tempGcsPath(GCS_PATH)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())
@@ -427,7 +425,7 @@ public class BigQuerySinkConfigTest {
         BigQuerySinkConfig<RowData> b =
                 BigQuerySinkConfig.<RowData>newBuilder()
                         .writeMode(WriteMode.INDIRECT)
-                        .connectOptions(opts)
+                        .connectOptions(indirectConnectOptions())
                         .tempGcsPath(GCS_PATH)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/SizeBasedCheckpointRollingPolicyTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/SizeBasedCheckpointRollingPolicyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.indirect;
+
+import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link SizeBasedCheckpointRollingPolicy}. */
+public class SizeBasedCheckpointRollingPolicyTest {
+
+    @SuppressWarnings("unchecked")
+    private PartFileInfo<String> mockPartFileInfo(long size) throws IOException {
+        PartFileInfo<String> info = mock(PartFileInfo.class);
+        when(info.getSize()).thenReturn(size);
+        return info;
+    }
+
+    @Test
+    public void shouldRollOnEventWhenSizeExceedsMax() throws IOException {
+        SizeBasedCheckpointRollingPolicy<String, String> policy =
+                new SizeBasedCheckpointRollingPolicy<>();
+
+        assertTrue(
+                policy.shouldRollOnEvent(
+                        mockPartFileInfo(
+                                SizeBasedCheckpointRollingPolicy.DEFAULT_MAX_FILE_SIZE + 1),
+                        "element"));
+    }
+
+    @Test
+    public void shouldRollOnEventAtExactBoundary() throws IOException {
+        SizeBasedCheckpointRollingPolicy<String, String> policy =
+                new SizeBasedCheckpointRollingPolicy<>();
+
+        assertTrue(
+                policy.shouldRollOnEvent(
+                        mockPartFileInfo(SizeBasedCheckpointRollingPolicy.DEFAULT_MAX_FILE_SIZE),
+                        "element"));
+    }
+
+    @Test
+    public void shouldNotRollOnEventWhenSizeBelowMax() throws IOException {
+        SizeBasedCheckpointRollingPolicy<String, String> policy =
+                new SizeBasedCheckpointRollingPolicy<>();
+
+        assertFalse(
+                policy.shouldRollOnEvent(
+                        mockPartFileInfo(
+                                SizeBasedCheckpointRollingPolicy.DEFAULT_MAX_FILE_SIZE - 1),
+                        "element"));
+    }
+
+    @Test
+    public void shouldAlwaysRollOnCheckpoint() throws IOException {
+        SizeBasedCheckpointRollingPolicy<String, String> policy =
+                new SizeBasedCheckpointRollingPolicy<>();
+
+        assertTrue(policy.shouldRollOnCheckpoint(mockPartFileInfo(0)));
+    }
+
+    @Test
+    public void shouldNotRollOnProcessingTime() throws IOException {
+        SizeBasedCheckpointRollingPolicy<String, String> policy =
+                new SizeBasedCheckpointRollingPolicy<>();
+
+        assertFalse(
+                policy.shouldRollOnProcessingTime(mockPartFileInfo(0), System.currentTimeMillis()));
+    }
+}

--- a/flink-2.1-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/pom.xml
@@ -108,6 +108,12 @@ under the License.
 
             <dependency>
                 <groupId>org.apache.flink</groupId>
+                <artifactId>flink-parquet</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
                 <artifactId>flink-connector-files</artifactId>
                 <version>${flink.version}</version>
             </dependency>


### PR DESCRIPTION
Adds `BigQueryIndirectSink`, a `Sink<IN>` that writes data as Parquet to GCS via Flink's `FileSink` and then dispatches `BigQueryLoadJobOperator` in the post-commit topology to load the staged files into BigQuery. Provides `EXACTLY_ONCE` delivery.

New supporting classes:
- `WriteMode` enum `{STORAGE_WRITE_API, INDIRECT}`
- `RowDataParquetWriterFactory`: `ParquetWriterFactory<RowData>` with INT64 timestamp micros encoding so BigQuery `TIMESTAMP`s round-trip through Parquet with microsecond precision
- `SizeBasedCheckpointRollingPolicy`: rolls files at 1.5 GB

`BigQuerySink` dispatches to `BigQueryIndirectSink` when `config.getWriteMode() == INDIRECT`. `BigQuerySinkConfig` adds `writeMode`, `gcsTempPath`, and `bulkWriterFactory` fields plus `validateIndirect()`.

Pulls in `flink-parquet`, `hadoop-common 2.10.2`, and `hadoop-mapreduce-client-core 2.10.2`. The `commons-io 2.15.1` test override is forced because Hadoop 2.10 transitively brings `commons-io 2.4`, which lacks `NullPrintStream` that Flink's `MiniCluster` needs at test time.

---

This is (3/8) in the indirect-writes series:

- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/309
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/310
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/311
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/312
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/313
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/317
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/318
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/319
