### PR TITLE
Indirect writes (4/8): Table API support

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -473,7 +473,8 @@ public class BigQuerySinkConfig<IN> {
         boolean indirect = writeMode == WriteMode.INDIRECT;
         BulkWriter.Factory<RowData> bulkWriterFactory =
                 indirect ? RowDataParquetWriterFactory.create((RowType) logicalType) : null;
-        FormatOptions formatOptions = indirect ? FormatOptions.parquet() : null;
+        FormatOptions formatOptions =
+                indirect ? RowDataParquetWriterFactory.PARQUET_FORMAT_OPTIONS : null;
         BigQuerySchemaProvider schemaProvider =
                 indirect
                         ? null

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/RowDataParquetWriterFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/RowDataParquetWriterFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
+import com.google.cloud.bigquery.ParquetOptions;
 import org.apache.hadoop.conf.Configuration;
 
 import java.util.Objects;
@@ -44,6 +45,12 @@ import java.util.Objects;
 public final class RowDataParquetWriterFactory extends ParquetWriterFactory<RowData> {
 
     private static final long serialVersionUID = 1L;
+
+    // Load-side options paired with the writer config above: enableListInference=true tells
+    // BigQuery to map Parquet repeated groups (how this writer encodes ARRAY columns) to
+    // BigQuery REPEATED columns rather than nested STRUCTs.
+    public static final ParquetOptions PARQUET_FORMAT_OPTIONS =
+            ParquetOptions.newBuilder().setEnableListInference(true).build();
 
     private final RowType rowType;
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -87,6 +87,8 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
         additionalOptions.add(BigQueryConnectorOptions.CDC_PRIMARY_KEY_COLUMNS);
         additionalOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
+        additionalOptions.add(BigQueryConnectorOptions.WRITE_MODE);
+        additionalOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
 
         return additionalOptions;
     }
@@ -121,6 +123,8 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
         forwardOptions.add(BigQueryConnectorOptions.CDC_PRIMARY_KEY_COLUMNS);
         forwardOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
+        forwardOptions.add(BigQueryConnectorOptions.WRITE_MODE);
+        forwardOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
 
         return forwardOptions;
     }
@@ -180,6 +184,8 @@ public class BigQueryDynamicTableFactory
                 configProvider.getCdcSequenceField().orElse(null),
                 configProvider.getCdcPrimaryKeyColumns().orElse(null),
                 configProvider.getCdcMaxStaleness().orElse(null),
-                null);
+                null,
+                configProvider.getWriteMode(),
+                configProvider.getTempGcsPath().orElse(null));
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -22,12 +22,14 @@ import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.sink.BigQuerySink;
 import com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig;
+import com.google.cloud.flink.bigquery.sink.WriteMode;
 import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.RowDataCdcChangeTypeProvider;
 
@@ -71,6 +73,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -90,7 +94,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             String cdcSequenceField,
             List<String> cdcPrimaryKeyColumns,
             String cdcMaxStaleness,
-            CdcChangeTypeProvider<org.apache.flink.table.data.RowData> cdcChangeTypeProvider) {
+            CdcChangeTypeProvider<RowData> cdcChangeTypeProvider,
+            WriteMode writeMode,
+            String tempGcsPath) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
         this.sinkConfig =
@@ -112,8 +118,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         cdcEnabled && cdcChangeTypeProvider == null
                                 ? RowDataCdcChangeTypeProvider.getInstance()
                                 : cdcChangeTypeProvider,
-                        null,
-                        null);
+                        writeMode,
+                        tempGcsPath);
     }
 
     @Override
@@ -176,8 +182,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.getCdcSequenceField(),
                 this.sinkConfig.getCdcPrimaryKeyColumns(),
                 this.sinkConfig.getCdcMaxStaleness(),
-                (CdcChangeTypeProvider<org.apache.flink.table.data.RowData>)
-                        this.sinkConfig.getCdcChangeTypeProvider());
+                (CdcChangeTypeProvider<RowData>) sinkConfig.getCdcChangeTypeProvider(),
+                this.sinkConfig.getWriteMode(),
+                this.sinkConfig.getTempGcsPath());
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -294,4 +294,27 @@ public class BigQueryConnectorOptions {
                                     + "persisted during table creation, so max_staleness remains "
                                     + "unset after create. Run ALTER TABLE ... SET OPTIONS "
                                     + "(max_staleness = INTERVAL ...) after creation.");
+
+    /**
+     * [OPTIONAL, Sink Configuration] Write mode for the BigQuery sink. DIRECT uses the BigQuery
+     * Storage Write API. INDIRECT writes files to GCS and uses BigQuery load jobs. <br>
+     * Default: DIRECT
+     */
+    public static final ConfigOption<String> WRITE_MODE =
+            ConfigOptions.key("write.mode")
+                    .stringType()
+                    .defaultValue("STORAGE_WRITE_API")
+                    .withDescription(
+                            "Write mode: DIRECT (Storage Write API) or INDIRECT (GCS files + BigQuery load jobs)");
+
+    /**
+     * [REQUIRED for INDIRECT mode] GCS path for temporary files when using indirect writes. <br>
+     * Example: gs://my-bucket/flink-temp
+     */
+    public static final ConfigOption<String> TEMP_GCS_PATH =
+            ConfigOptions.key("write.indirect.temp-gcs-path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "GCS path for temporary files (required for INDIRECT write mode)");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.services.BigQueryServices;
+import com.google.cloud.flink.bigquery.sink.WriteMode;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
 
 import java.util.ArrayList;
@@ -123,6 +124,15 @@ public class BigQueryTableConfigurationProvider {
 
     public Optional<String> getCdcMaxStaleness() {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.CDC_MAX_STALENESS));
+    }
+
+    public WriteMode getWriteMode() {
+        String writeModeStr = config.get(BigQueryConnectorOptions.WRITE_MODE);
+        return WriteMode.valueOf(writeModeStr.toUpperCase());
+    }
+
+    public Optional<String> getTempGcsPath() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.TEMP_GCS_PATH));
     }
 
     public BigQueryReadOptions toBigQueryReadOptions() {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -16,9 +16,14 @@
 
 package com.google.cloud.flink.bigquery.table;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -31,6 +36,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
+import com.google.cloud.flink.bigquery.sink.WriteMode;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroSchemaConvertor;
 import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -349,6 +355,67 @@ public class BigQueryDynamicTableFactoryTest {
 
         DataType dataType = SCHEMA.toPhysicalRowDataType();
         return new BigQueryDynamicTableSource(readOptions, dataType, null);
+    }
+
+    @Test
+    public void testIndirectWriteModeBatchModeCreatesSinkWithIndirectMode() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigQueryConnectorOptions.WRITE_MODE.key(), "INDIRECT");
+        options.put(BigQueryConnectorOptions.TEMP_GCS_PATH.key(), "gs://bucket/tmp");
+
+        Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+
+        DynamicTableSink sink =
+                FactoryUtil.createDynamicTableSink(
+                        null,
+                        FactoryMocks.IDENTIFIER,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(
+                                                org.apache.flink.table.api.Schema.newBuilder()
+                                                        .fromResolvedSchema(SCHEMA)
+                                                        .build())
+                                        .comment("mock sink")
+                                        .options(options)
+                                        .build(),
+                                SCHEMA),
+                        Collections.emptyMap(),
+                        config,
+                        getClass().getClassLoader(),
+                        false);
+
+        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
+        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
+        assertEquals(WriteMode.INDIRECT, dynamicSink.getSinkConfig().getWriteMode());
+        assertEquals("gs://bucket/tmp", dynamicSink.getSinkConfig().getTempGcsPath());
+    }
+
+    @Test
+    public void testDefaultWriteModeIsDirect() {
+        DynamicTableSink sink =
+                FactoryUtil.createDynamicTableSink(
+                        null,
+                        FactoryMocks.IDENTIFIER,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(
+                                                org.apache.flink.table.api.Schema.newBuilder()
+                                                        .fromResolvedSchema(SCHEMA)
+                                                        .build())
+                                        .comment("mock sink")
+                                        .options(getRequiredOptions())
+                                        .build(),
+                                SCHEMA),
+                        Collections.emptyMap(),
+                        new Configuration(),
+                        getClass().getClassLoader(),
+                        false);
+
+        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
+        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
+        assertEquals(WriteMode.STORAGE_WRITE_API, dynamicSink.getSinkConfig().getWriteMode());
+        assertNull(dynamicSink.getSinkConfig().getTempGcsPath());
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.test.junit5.MiniClusterExtension;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig;
-import org.apache.avro.Schema;
+import com.google.cloud.flink.bigquery.sink.WriteMode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
@@ -37,9 +37,11 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Class to test {@link BigQueryDynamicTableSink}. */
 public class BigQueryDynamicTableSinkTest {
@@ -66,7 +68,14 @@ public class BigQueryDynamicTableSinkTest {
                     10000000000000L,
                     CLUSTERED_FIELDS,
                     REGION,
-                    true);
+                    true,
+                    false,
+                    null,
+                    null,
+                    null,
+                    null,
+                    WriteMode.STORAGE_WRITE_API,
+                    null);
 
     @RegisterExtension
     static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
@@ -77,24 +86,13 @@ public class BigQueryDynamicTableSinkTest {
 
     @Test
     public void testConstructor() {
-        Schema convertedAvroSchema =
-                new Schema.Parser()
-                        .parse(
-                                "{\"type\":\"record\",\"name\":\"record\","
-                                        + "\"namespace\":\"org.apache.flink.avro.generated\",\"fields\":"
-                                        + "[{\"name\":\"number\",\"type\":\"long\"}]}");
-        BigQuerySinkConfig<RowData> obtainedSinkConfig = TABLE_SINK.getSinkConfig();
-        assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, obtainedSinkConfig.getDeliveryGuarantee());
-        assertEquals(convertedAvroSchema, obtainedSinkConfig.getSchemaProvider().getAvroSchema());
-        assertTrue(obtainedSinkConfig.enableTableCreation());
-        assertEquals(PARTITIONING_FIELD, obtainedSinkConfig.getPartitionField());
-        assertEquals(TimePartitioning.Type.DAY, obtainedSinkConfig.getPartitionType());
-        assertTrue(obtainedSinkConfig.getPartitionExpirationMillis() == 10000000000000L);
-        assertEquals(CLUSTERED_FIELDS, obtainedSinkConfig.getClusteredFields());
-        assertEquals(REGION, obtainedSinkConfig.getRegion());
+        assertEquals(
+                DeliveryGuarantee.AT_LEAST_ONCE, TABLE_SINK.getSinkConfig().getDeliveryGuarantee());
         assertEquals(SCHEMA, TABLE_SINK.getLogicalType());
         assertEquals(PARALLELISM, TABLE_SINK.getSinkParallelism());
-        assertTrue(obtainedSinkConfig.fatalizeSerializer());
+        assertEquals(
+                StorageClientFaker.createConnectOptionsForWrite(null),
+                TABLE_SINK.getSinkConfig().getConnectOptions());
     }
 
     @Test
@@ -122,6 +120,199 @@ public class BigQueryDynamicTableSinkTest {
     }
 
     @Test
+    public void testSinkRuntimeProviderDirectModeReturnsDirectBigQuerySink() throws Exception {
+        // BigQuerySink.get() dispatches to BigQueryDefaultSink (package-private) for
+        // AT_LEAST_ONCE delivery. We assert on the class name to avoid exposing the
+        // package-private type from tests.
+        SinkV2Provider provider =
+                (SinkV2Provider)
+                        TABLE_SINK.getSinkRuntimeProvider(
+                                Mockito.mock(DynamicTableSink.Context.class));
+        assertTrue(
+                provider.createSink().getClass().getSimpleName().equals("BigQueryDefaultSink"),
+                "Expected a BigQueryDefaultSink for DIRECT/AT_LEAST_ONCE, got: "
+                        + provider.createSink().getClass().getName());
+    }
+
+    @Test
+    public void testSinkRuntimeProviderIndirectModeReturnsBigQueryIndirectSink() {
+        // INDIRECT rejects table-creation and CDC at runtime-provider time; pass false/false here.
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        false,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp");
+
+        SinkV2Provider provider =
+                (SinkV2Provider)
+                        indirectSink.getSinkRuntimeProvider(
+                                Mockito.mock(DynamicTableSink.Context.class));
+        // BigQueryIndirectSink is package-private; assert by simple name to avoid exposing it.
+        assertEquals("BigQueryIndirectSink", provider.createSink().getClass().getSimpleName());
+    }
+
+    @Test
+    public void testSinkRuntimeProviderIndirectModeNullTempGcsPathThrows() {
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        false,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        null);
+
+        assertThatThrownBy(
+                        () ->
+                                indirectSink.getSinkRuntimeProvider(
+                                        Mockito.mock(DynamicTableSink.Context.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tempGcsPath is required");
+    }
+
+    @Test
+    public void testCopyPreservesWriteModeAndTempGcsPath() {
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp");
+        assertEquals(indirectSink, indirectSink.copy());
+    }
+
+    @Test
+    public void testEqualsDiffersByWriteMode() {
+        BigQueryDynamicTableSink indirect =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp");
+        BigQueryDynamicTableSink direct =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.STORAGE_WRITE_API,
+                        "gs://bucket/tmp");
+        assertNotEquals(indirect, direct);
+    }
+
+    @Test
+    public void testEqualsDiffersByTempGcsPath() {
+        BigQueryDynamicTableSink a =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/a");
+        BigQueryDynamicTableSink b =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/b");
+        assertNotEquals(a, b);
+    }
+
+    @Test
     public void testCdcConstructor() {
         BigQueryDynamicTableSink cdcTableSink =
                 new BigQueryDynamicTableSink(
@@ -140,6 +331,8 @@ public class BigQueryDynamicTableSinkTest {
                         "event_ts",
                         Arrays.asList("shop_id", "event_date"),
                         "INTERVAL 10 MINUTE",
+                        null,
+                        WriteMode.STORAGE_WRITE_API,
                         null);
 
         BigQuerySinkConfig<RowData> obtainedSinkConfig = cdcTableSink.getSinkConfig();

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProviderTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.table.config;
+
+import org.apache.flink.configuration.Configuration;
+
+import com.google.cloud.flink.bigquery.sink.WriteMode;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Tests for {@link BigQueryTableConfigurationProvider}'s new write-mode methods. */
+public class BigQueryTableConfigurationProviderTest {
+
+    @Test
+    public void getWriteModeDefaultsToDirect() {
+        Configuration cfg = new Configuration();
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(WriteMode.STORAGE_WRITE_API, p.getWriteMode());
+    }
+
+    @Test
+    public void getWriteModeParsesIndirect() {
+        Configuration cfg = new Configuration();
+        cfg.setString(BigQueryConnectorOptions.WRITE_MODE.key(), "INDIRECT");
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(WriteMode.INDIRECT, p.getWriteMode());
+    }
+
+    @Test
+    public void getWriteModeParsesLowercaseIndirect() {
+        // getWriteMode() applies toUpperCase() so lowercase input is accepted.
+        Configuration cfg = new Configuration();
+        cfg.setString(BigQueryConnectorOptions.WRITE_MODE.key(), "indirect");
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(WriteMode.INDIRECT, p.getWriteMode());
+    }
+
+    @Test
+    public void getWriteModeParsesMixedCaseIndirect() {
+        Configuration cfg = new Configuration();
+        cfg.setString(BigQueryConnectorOptions.WRITE_MODE.key(), "Indirect");
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(WriteMode.INDIRECT, p.getWriteMode());
+    }
+
+    @Test
+    public void getWriteModeUnknownValueThrows() {
+        Configuration cfg = new Configuration();
+        cfg.setString(BigQueryConnectorOptions.WRITE_MODE.key(), "SIDEWAYS");
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertThrows(IllegalArgumentException.class, p::getWriteMode);
+    }
+
+    @Test
+    public void getTempGcsPathAbsentReturnsEmpty() {
+        Configuration cfg = new Configuration();
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(Optional.empty(), p.getTempGcsPath());
+    }
+
+    @Test
+    public void getTempGcsPathPresentReturnsValue() {
+        Configuration cfg = new Configuration();
+        cfg.setString(BigQueryConnectorOptions.TEMP_GCS_PATH.key(), "gs://bucket/tmp");
+        BigQueryTableConfigurationProvider p = new BigQueryTableConfigurationProvider(cfg);
+        assertEquals(Optional.of("gs://bucket/tmp"), p.getTempGcsPath());
+    }
+}


### PR DESCRIPTION
Exposes the indirect-write sink through the Table API:
- `BigQueryConnectorOptions` adds `WRITE_MODE` (default `STORAGE_WRITE_API`) and `GCS_TEMP_PATH` `ConfigOption`s
- `BigQueryTableConfigurationProvider` parses them via `getWriteMode()` and `getGcsTempPath()`
- `BigQueryDynamicTableFactory` wires both into the dynamic sink
- `BigQueryDynamicTableSink` propagates them through `copy()` and into `BigQuerySinkConfig`

---

This is (4/8) in the indirect-writes series:

- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/309
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/310
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/311
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/312
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/313
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/317
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/318
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/319
