### PR TITLE
Indirect writes (5/8): IndirectWriteExample

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/pom.xml
@@ -33,6 +33,10 @@ under the License.
     <name>Flink : Connectors : Google BigQuery Table API Example (Flink v2.1)</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <shade.skip>false</shade.skip>
+    </properties>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -77,20 +81,54 @@ under the License.
                         <configuration>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!-- Disable minimizeJar: parquet-mr loads bitpackers/codecs via
+                                 reflection, and Hadoop's JobConf static init reflectively
+                                 loads commons-logging's LogFactoryImpl. Static analysis can't
+                                 see these, so minimizeJar would strip them. -->
+                            <minimizeJar>false</minimizeJar>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.google.cloud.flink.bigquery.examples.BigQueryTableExample</mainClass>
                                 </transformer>
+                                <!-- Concatenate META-INF/services entries from parquet-mr,
+                                     hadoop, and friends instead of letting one overwrite the
+                                     others. -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
-                            <artifactSet>
+                            <!-- combine.self="override" prevents the parent pom's blanket
+                                 <exclude>org.apache.flink:*</exclude> from suppressing the
+                                 flink-parquet/flink-avro/flink-connector-files includes below. -->
+                            <artifactSet combine.self="override">
                                 <includes>
                                     <include>com.google.cloud.flink:flink-2.1-connector-bigquery</include>
+                                    <!-- Flink format/connector-files modules not in flink-dist -->
                                     <include>org.apache.flink:flink-avro</include>
-                                    <include>com.google.*:*</include>
-                                    <include>commons-codec:commons-codec</include>    
-                                    <include>dev.failsafe:*</include>                                
+                                    <include>org.apache.flink:flink-parquet</include>
+                                    <include>org.apache.flink:flink-connector-files</include>
+                                    <include>org.apache.flink:flink-file-sink-common</include>
+                                    <!-- Parquet runtime -->
+                                    <include>org.apache.parquet:*</include>
+                                    <include>com.github.luben:zstd-jni</include>
+                                    <include>io.airlift:aircompressor</include>
+                                    <include>commons-pool:commons-pool</include>
+                                    <!-- Hadoop runtime + transitive tree -->
+                                    <include>org.apache.hadoop:*</include>
+                                    <include>org.xerial.snappy:*</include>
+                                    <include>com.fasterxml.woodstox:*</include>
+                                    <include>org.codehaus.woodstox:*</include>
+                                    <include>commons-collections:*</include>
+                                    <include>commons-logging:*</include>
+                                    <include>commons-configuration:*</include>
+                                    <include>log4j:log4j</include>
+                                    <include>ch.qos.reload4j:*</include>
+                                    <!-- Other org.apache deps -->
+                                    <include>org.apache.commons:*</include>
                                     <include>org.apache.avro:*</include>
                                     <include>org.apache.httpcomponents:*</include>
+                                    <!-- Google + misc connector runtime -->
+                                    <include>com.google.*:*</include>
+                                    <include>commons-codec:commons-codec</include>
+                                    <include>dev.failsafe:*</include>
                                     <include>org.codehaus.mojo:animal-sniffer-annotations</include>
                                     <include>org.conscrypt:*</include>
                                     <include>com.fasterxml.jackson.*:*</include>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
@@ -1,0 +1,131 @@
+package com.google.cloud.flink.bigquery.examples;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.util.ParameterTool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A BigQuery indirect write example using Flink SQL that exercises every supported BigQuery
+ * datatype.
+ *
+ * <p>Inserts a small fixed set of rows with distinctive values for each column so that round-trip
+ * fidelity (especially microsecond-precision TIMESTAMP / DATETIME) can be verified by querying the
+ * destination table after the job finishes.
+ *
+ * <p>Expected target schema (created in BigQuery before running):
+ *
+ * <pre>
+ * CREATE TABLE `&lt;project&gt;.&lt;dataset&gt;.&lt;table&gt;` (
+ *   bool_col       BOOL,
+ *   bytes_col      BYTES,
+ *   string_col     STRING,
+ *   int64_col      INT64,
+ *   float64_col    FLOAT64,
+ *   numeric_col    NUMERIC,
+ *   bignumeric_col BIGNUMERIC,
+ *   date_col       DATE,
+ *   timestamp_col  TIMESTAMP,
+ *   timestamp3_col TIMESTAMP,
+ *   array_col      ARRAY&lt;INT64&gt;,
+ *   struct_col     STRUCT&lt;a INT64, b STRING&gt;
+ * );
+ * </pre>
+ *
+ * <p>Note: Parquet staging can't distinguish DATETIME from TIMESTAMP (Flink's
+ * ParquetSchemaConverter emits the same {@code timestamp(isAdjustedToUTC=false, MICROS)} for both
+ * {@code TIMESTAMP_WITHOUT_TIME_ZONE} and {@code TIMESTAMP_WITH_LOCAL_TIME_ZONE}), so a target
+ * DATETIME column would fail with a schema mismatch at load time.
+ *
+ * <ul>
+ *   <li>Flink command line format is: <br>
+ *       <code>flink run {additional runtime params} {path to this jar}/IndirectWriteExample.jar
+ *       </code> <br>
+ *       --project {required; GCP project ID} <br>
+ *       --dataset {required; BigQuery dataset name} <br>
+ *       --table {required; BigQuery table name} <br>
+ *       --temp-gcs-path {required; GCS path for staging files}
+ * </ul>
+ *
+ * <p>Requires the GCS Hadoop connector plugin ({@code flink-gs-fs-hadoop}) to be installed in the
+ * Flink cluster's {@code plugins/} directory.
+ */
+public class IndirectWriteExample {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IndirectWriteExample.class);
+
+    public static void main(String[] args) {
+        final ParameterTool params = ParameterTool.fromArgs(args);
+
+        if (params.getNumberOfParameters() < 4) {
+            LOG.error(
+                    "Missing parameters!\n"
+                            + "Usage: IndirectWriteExample"
+                            + " --project <GCP project>"
+                            + " --dataset <BigQuery dataset>"
+                            + " --table <BigQuery table>"
+                            + " --temp-gcs-path <GCS path for staging files>");
+            return;
+        }
+
+        String project = params.getRequired("project");
+        String dataset = params.getRequired("dataset");
+        String table = params.getRequired("table");
+        String tempGcsPath = params.getRequired("temp-gcs-path");
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.setParallelism(2);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE bigquery_sink ("
+                                + "    bool_col       BOOLEAN,"
+                                + "    bytes_col      BYTES,"
+                                + "    string_col     STRING,"
+                                + "    int64_col      BIGINT,"
+                                + "    float64_col    DOUBLE,"
+                                + "    numeric_col    DECIMAL(38, 9),"
+                                + "    bignumeric_col DECIMAL(38, 38),"
+                                + "    date_col       DATE,"
+                                + "    timestamp_col  TIMESTAMP_LTZ(6),"
+                                + "    timestamp3_col TIMESTAMP_LTZ(3),"
+                                + "    array_col      ARRAY<BIGINT>,"
+                                + "    struct_col     ROW<a BIGINT, b STRING>"
+                                + ") WITH ("
+                                + "    'connector' = 'bigquery',"
+                                + "    'project' = '%s',"
+                                + "    'dataset' = '%s',"
+                                + "    'table' = '%s',"
+                                + "    'write.mode' = 'INDIRECT',"
+                                + "    'write.indirect.temp-gcs-path' = '%s'"
+                                + ")",
+                        project, dataset, table, tempGcsPath));
+
+        String insertSql =
+                "INSERT INTO bigquery_sink VALUES"
+                        + "  (TRUE, X'cafebabe', 'hello world', 9223372036854775807,"
+                        + "   3.141592653589793,"
+                        + "   CAST('12345678901234567890123456789.123456789' AS DECIMAL(38, 9)),"
+                        + "   CAST('0.12345678901234567890123456789012345678' AS DECIMAL(38, 38)),"
+                        + "   DATE '2025-04-26',"
+                        + "   CAST(TIMESTAMP '2025-04-26 12:34:56.123456' AS TIMESTAMP_LTZ(6)),"
+                        + "   CAST(TIMESTAMP '2025-04-26 12:34:56.123' AS TIMESTAMP_LTZ(3)),"
+                        + "   ARRAY[CAST(1 AS BIGINT), CAST(2 AS BIGINT), CAST(3 AS BIGINT)],"
+                        + "   CAST(ROW(42, 'forty-two') AS ROW<a BIGINT, b STRING>)),"
+                        + "  (FALSE, X'00', '', 0, 0.0,"
+                        + "   CAST('0' AS DECIMAL(38, 9)),"
+                        + "   CAST('-0.99999999999999999999999999999999999999' AS DECIMAL(38, 38)),"
+                        + "   DATE '1970-01-01',"
+                        + "   CAST(TIMESTAMP '1970-01-01 00:00:00' AS TIMESTAMP_LTZ(6)),"
+                        + "   CAST(TIMESTAMP '1970-01-01 00:00:00' AS TIMESTAMP_LTZ(3)),"
+                        + "   CAST(NULL AS ARRAY<BIGINT>),"
+                        + "   CAST(NULL AS ROW<a BIGINT, b STRING>))";
+
+        tEnv.executeSql(insertSql);
+    }
+}


### PR DESCRIPTION
Adds `IndirectWriteExample`, which demonstrates an end-to-end Table API indirect write. The shade-plugin overhaul in the example pom is what ensures parquet/hadoop runtime ends up in the example uber-jar: `combine.self="override"` defeats the parent's blanket exclude of `org.apache.flink:*`, `ServicesResourceTransformer` merges `META-INF/services` from `parquet-mr`/`hadoop`, and `minimizeJar=false` keeps reflectively-loaded codecs in the jar.

---

This is (5/8) in the indirect-writes series:

- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/309
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/310
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/311
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/312
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/313
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/317
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/318
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/319
