### PR TITLE
Add indirect write mode for flink 1.17 and 2.1

### DIFF
--- a/cloudbuild/nightly/cloudbuild.yaml
+++ b/cloudbuild/nightly/cloudbuild.yaml
@@ -109,6 +109,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_nested_schema_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -127,6 +128,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_nested_schema_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -145,6 +147,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_all_datatypes_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -163,6 +166,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_large_table_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -181,6 +185,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_large_table_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -199,6 +204,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_indirect_bounded_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -218,6 +224,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_unbounded_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'
@@ -237,6 +244,7 @@ steps:
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_table_api_unbounded_test']
     env:
+      - 'FLINK_VERSION=${_FLINK_VERSION}'
       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
       - 'PROJECT_ID=${_PROJECT_ID}'
       - 'PROJECT_NAME=${_PROJECT_NAME}'

--- a/cloudbuild/nightly/cloudbuild.yaml
+++ b/cloudbuild/nightly/cloudbuild.yaml
@@ -252,7 +252,7 @@ steps:
 # 12.1 Delete the dataproc cluster - for small bounded tests
   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
     id: 'delete-clusters-bounded-small-table'
-    waitFor: ['e2e-bounded-table-api-all-datatypes-test']
+    waitFor: ['e2e-bounded-nested-schema-test', 'e2e-bounded-table-api-nested-schema-test', 'e2e-bounded-table-api-all-datatypes-test', 'e2e-indirect-bounded-test']
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
     env:

--- a/cloudbuild/nightly/cloudbuild.yaml
+++ b/cloudbuild/nightly/cloudbuild.yaml
@@ -34,163 +34,163 @@ steps:
       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
       - 'WORKER_MACHINE_TYPE_SMALL_BOUNDED=${_WORKER_MACHINE_TYPE_SMALL_BOUNDED}'
 
-# 3.2 Create the dataproc cluster - for large table bounded test
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'create-clusters-bounded-large-table'
-    waitFor: ['init']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_bounded_large_table']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-      - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
-      - 'CLUSTER_NAME_LARGE_TABLE_TEST=${_CLUSTER_NAME_LARGE_TABLE_TEST}'
-      - 'REGION_ARRAY_STRING_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_LARGE_TABLE_TEST}'
-      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-      - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-      - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
-
-# 3.3 Create the dataproc cluster - for unbounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'create-clusters-unbounded-table'
-    waitFor: ['init']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_unbounded_table']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-      - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
-      - 'CLUSTER_NAME_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_UNBOUNDED_TABLE_TEST}'
-      - 'REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST}'
-      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-      - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
-
-# 3.4 Create the dataproc cluster - for table api large table bounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'create-clusters-table-api-bounded-large-table'
-    waitFor: ['init']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_bounded_large_table']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-      - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
-      - 'CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST}'
-      - 'REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST}'
-      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-      - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-      - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
-
-# 3.5 Create the dataproc cluster - for table api unbounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'create-clusters-table-api-unbounded-table'
-    waitFor: ['init']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_unbounded_table']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-      - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
-      - 'CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST}'
-      - 'REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST}'
-      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-      - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
-
-# 4. Nested schema e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-bounded-nested-schema-test'
-    waitFor: ['create-clusters-bounded-small-table']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_nested_schema_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-      - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-
-# 5. Table API nested schema e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-bounded-table-api-nested-schema-test'
-    waitFor: ['e2e-bounded-nested-schema-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_nested_schema_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-      - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-
-# 6. Table API all data types e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-bounded-table-api-all-datatypes-test'
-    waitFor: ['e2e-bounded-table-api-nested-schema-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_all_datatypes_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'TABLE_NAME_SOURCE_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
-      - 'TABLE_NAME_DESTINATION_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
-      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-
-# 8. Large table e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-bounded-large-table-test'
-    waitFor: ['create-clusters-bounded-large-table']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_large_table_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'TABLE_NAME_SOURCE_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-      - 'TABLE_NAME_DESTINATION_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-      - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
-      - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-      - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
-
-# 9. Table API large table e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-bounded-table-api-large-table-test'
-    waitFor: ['create-clusters-table-api-bounded-large-table']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_large_table_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'TABLE_NAME_SOURCE_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-      - 'TABLE_NAME_DESTINATION_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-      - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
-      - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-      - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
+# # 3.2 Create the dataproc cluster - for large table bounded test
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'create-clusters-bounded-large-table'
+#     waitFor: ['init']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_bounded_large_table']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+#       - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
+#       - 'CLUSTER_NAME_LARGE_TABLE_TEST=${_CLUSTER_NAME_LARGE_TABLE_TEST}'
+#       - 'REGION_ARRAY_STRING_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_LARGE_TABLE_TEST}'
+#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+#       - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+#       - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
+# 
+# # 3.3 Create the dataproc cluster - for unbounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'create-clusters-unbounded-table'
+#     waitFor: ['init']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_unbounded_table']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+#       - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
+#       - 'CLUSTER_NAME_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_UNBOUNDED_TABLE_TEST}'
+#       - 'REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST}'
+#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+#       - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
+# 
+# # 3.4 Create the dataproc cluster - for table api large table bounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'create-clusters-table-api-bounded-large-table'
+#     waitFor: ['init']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_bounded_large_table']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+#       - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
+#       - 'CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST}'
+#       - 'REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST}'
+#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+#       - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+#       - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
+# 
+# # 3.5 Create the dataproc cluster - for table api unbounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'create-clusters-table-api-unbounded-table'
+#     waitFor: ['init']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_unbounded_table']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+#       - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
+#       - 'CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST}'
+#       - 'REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST}'
+#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+#       - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
+# 
+# # 4. Nested schema e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-bounded-nested-schema-test'
+#     waitFor: ['create-clusters-bounded-small-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_nested_schema_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+#       - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+# 
+# # 5. Table API nested schema e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-bounded-table-api-nested-schema-test'
+#     waitFor: ['create-clusters-bounded-small-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_nested_schema_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+#       - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+# 
+# # 6. Table API all data types e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-bounded-table-api-all-datatypes-test'
+#     waitFor: ['create-clusters-bounded-small-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_all_datatypes_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'TABLE_NAME_SOURCE_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
+#       - 'TABLE_NAME_DESTINATION_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
+#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+# 
+# # 8. Large table e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-bounded-large-table-test'
+#     waitFor: ['create-clusters-bounded-large-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_large_table_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'TABLE_NAME_SOURCE_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+#       - 'TABLE_NAME_DESTINATION_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+#       - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
+#       - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+#       - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
+# 
+# # 9. Table API large table e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-bounded-table-api-large-table-test'
+#     waitFor: ['create-clusters-table-api-bounded-large-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_large_table_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'TABLE_NAME_SOURCE_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+#       - 'TABLE_NAME_DESTINATION_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+#       - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
+#       - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+#       - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
 
 # 9.5. Indirect write bounded e2e test.
   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
@@ -211,98 +211,98 @@ steps:
       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
       - 'GCS_TEMPORARY_LOCATION=${_GCS_TEMPORARY_LOCATION}'
 
-# 10. Unbounded e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-unbounded-test'
-    waitFor: ['create-clusters-unbounded-table']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_unbounded_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
-      - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
-      - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
-      - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
-      - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
+# # 10. Unbounded e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-unbounded-test'
+#     waitFor: ['create-clusters-unbounded-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_unbounded_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
+#       - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
+#       - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
+#       - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
+#       - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
 
-# 11. Table API unbounded e2e test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'e2e-table-api-unbounded-test'
-    waitFor: ['create-clusters-table-api-unbounded-table']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_table_api_unbounded_test']
-    env:
-      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'PROJECT_NAME=${_PROJECT_NAME}'
-      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-      - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
-      - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
-      - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
-      - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
-      - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
-
-# 12.1 Delete the dataproc cluster - for small bounded tests
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'delete-clusters-bounded-small-table'
-    waitFor: ['e2e-bounded-table-api-all-datatypes-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'REGION_FILE=${_REGION_SMALL_TEST_FILE}'
-      - 'CLUSTER_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-
-# 12.2 Delete the dataproc cluster - for large table bounded test
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'delete-clusters-bounded-large-table'
-    waitFor: ['e2e-bounded-large-table-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'REGION_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-
-# 12.3 Delete the dataproc cluster - for unbounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'delete-clusters-unbounded-table'
-    waitFor: ['e2e-unbounded-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'REGION_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-
-# 12.4 Delete the dataproc cluster - for table api large table bounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'delete-clusters-table-api-bounded-large-table'
-    waitFor: ['e2e-bounded-table-api-large-table-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'REGION_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-      - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-
-# 12.5 Delete the dataproc cluster - for table api unbounded test.
-  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-    id: 'delete-clusters-table-api-unbounded-table'
-    waitFor: ['e2e-table-api-unbounded-test']
-    entrypoint: 'bash'
-    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-    env:
-      - 'PROJECT_ID=${_PROJECT_ID}'
-      - 'REGION_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-      - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+# # 11. Table API unbounded e2e test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'e2e-table-api-unbounded-test'
+#     waitFor: ['create-clusters-table-api-unbounded-table']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_table_api_unbounded_test']
+#     env:
+#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'PROJECT_NAME=${_PROJECT_NAME}'
+#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+#       - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
+#       - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
+#       - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
+#       - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
+#       - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
+# 
+# # 12.1 Delete the dataproc cluster - for small bounded tests
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'delete-clusters-bounded-small-table'
+#     waitFor: ['e2e-bounded-table-api-all-datatypes-test']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'REGION_FILE=${_REGION_SMALL_TEST_FILE}'
+#       - 'CLUSTER_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+# 
+# # 12.2 Delete the dataproc cluster - for large table bounded test
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'delete-clusters-bounded-large-table'
+#     waitFor: ['e2e-bounded-large-table-test']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'REGION_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+# 
+# # 12.3 Delete the dataproc cluster - for unbounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'delete-clusters-unbounded-table'
+#     waitFor: ['e2e-unbounded-test']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'REGION_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+# 
+# # 12.4 Delete the dataproc cluster - for table api large table bounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'delete-clusters-table-api-bounded-large-table'
+#     waitFor: ['e2e-bounded-table-api-large-table-test']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'REGION_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+#       - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+# 
+# # 12.5 Delete the dataproc cluster - for table api unbounded test.
+#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+#     id: 'delete-clusters-table-api-unbounded-table'
+#     waitFor: ['e2e-table-api-unbounded-test']
+#     entrypoint: 'bash'
+#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+#     env:
+#       - 'PROJECT_ID=${_PROJECT_ID}'
+#       - 'REGION_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+#       - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
 
 # Maximum tolerance 75 minutes.
 timeout: 4500s

--- a/cloudbuild/nightly/cloudbuild.yaml
+++ b/cloudbuild/nightly/cloudbuild.yaml
@@ -192,6 +192,25 @@ steps:
       - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
       - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
 
+# 9.5. Indirect write bounded e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-indirect-bounded-test'
+    waitFor: ['create-clusters-bounded-small-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_indirect_bounded_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+      - 'GCS_TEMPORARY_LOCATION=${_GCS_TEMPORARY_LOCATION}'
+
 # 10. Unbounded e2e test.
   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
     id: 'e2e-unbounded-test'

--- a/cloudbuild/nightly/cloudbuild.yaml
+++ b/cloudbuild/nightly/cloudbuild.yaml
@@ -34,163 +34,163 @@ steps:
       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
       - 'WORKER_MACHINE_TYPE_SMALL_BOUNDED=${_WORKER_MACHINE_TYPE_SMALL_BOUNDED}'
 
-# # 3.2 Create the dataproc cluster - for large table bounded test
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'create-clusters-bounded-large-table'
-#     waitFor: ['init']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_bounded_large_table']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-#       - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
-#       - 'CLUSTER_NAME_LARGE_TABLE_TEST=${_CLUSTER_NAME_LARGE_TABLE_TEST}'
-#       - 'REGION_ARRAY_STRING_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_LARGE_TABLE_TEST}'
-#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-#       - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-#       - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
-# 
-# # 3.3 Create the dataproc cluster - for unbounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'create-clusters-unbounded-table'
-#     waitFor: ['init']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_unbounded_table']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-#       - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
-#       - 'CLUSTER_NAME_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_UNBOUNDED_TABLE_TEST}'
-#       - 'REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST}'
-#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-#       - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
-# 
-# # 3.4 Create the dataproc cluster - for table api large table bounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'create-clusters-table-api-bounded-large-table'
-#     waitFor: ['init']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_bounded_large_table']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-#       - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
-#       - 'CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST}'
-#       - 'REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST}'
-#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-#       - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-#       - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
-# 
-# # 3.5 Create the dataproc cluster - for table api unbounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'create-clusters-table-api-unbounded-table'
-#     waitFor: ['init']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_unbounded_table']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
-#       - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
-#       - 'CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST}'
-#       - 'REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST}'
-#       - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
-#       - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
-# 
-# # 4. Nested schema e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-bounded-nested-schema-test'
-#     waitFor: ['create-clusters-bounded-small-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_nested_schema_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-#       - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-# 
-# # 5. Table API nested schema e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-bounded-table-api-nested-schema-test'
-#     waitFor: ['create-clusters-bounded-small-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_nested_schema_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-#       - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
-#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-# 
-# # 6. Table API all data types e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-bounded-table-api-all-datatypes-test'
-#     waitFor: ['create-clusters-bounded-small-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_all_datatypes_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'TABLE_NAME_SOURCE_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
-#       - 'TABLE_NAME_DESTINATION_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
-#       - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
-#       - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
-#       - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-#       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
-# 
-# # 8. Large table e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-bounded-large-table-test'
-#     waitFor: ['create-clusters-bounded-large-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_large_table_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'TABLE_NAME_SOURCE_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-#       - 'TABLE_NAME_DESTINATION_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-#       - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
-#       - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-#       - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
-# 
-# # 9. Table API large table e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-bounded-table-api-large-table-test'
-#     waitFor: ['create-clusters-table-api-bounded-large-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_large_table_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'TABLE_NAME_SOURCE_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-#       - 'TABLE_NAME_DESTINATION_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
-#       - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
-#       - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-#       - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
+# 3.2 Create the dataproc cluster - for large table bounded test
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'create-clusters-bounded-large-table'
+    waitFor: ['init']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_bounded_large_table']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+      - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
+      - 'CLUSTER_NAME_LARGE_TABLE_TEST=${_CLUSTER_NAME_LARGE_TABLE_TEST}'
+      - 'REGION_ARRAY_STRING_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_LARGE_TABLE_TEST}'
+      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+      - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+      - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
+
+# 3.3 Create the dataproc cluster - for unbounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'create-clusters-unbounded-table'
+    waitFor: ['init']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_unbounded_table']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+      - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
+      - 'CLUSTER_NAME_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_UNBOUNDED_TABLE_TEST}'
+      - 'REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_UNBOUNDED_TABLE_TEST}'
+      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+      - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
+
+# 3.4 Create the dataproc cluster - for table api large table bounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'create-clusters-table-api-bounded-large-table'
+    waitFor: ['init']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_bounded_large_table']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+      - 'NUM_WORKERS_LARGE_TABLE_TEST=${_NUM_WORKERS_LARGE_TABLE_TEST}'
+      - 'CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_LARGE_TABLE_TEST}'
+      - 'REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_LARGE_TABLE_TEST}'
+      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+      - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+      - 'WORKER_MACHINE_TYPE_LARGE_BOUNDED=${_WORKER_MACHINE_TYPE_LARGE_BOUNDED}'
+
+# 3.5 Create the dataproc cluster - for table api unbounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'create-clusters-table-api-unbounded-table'
+    waitFor: ['init']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'create_clusters_table_api_unbounded_table']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'DATAPROC_IMAGE_VERSION=${_DATAPROC_IMAGE_VERSION}'
+      - 'NUM_WORKERS_UNBOUNDED_TABLE_TEST=${_NUM_WORKERS_UNBOUNDED_TABLE_TEST}'
+      - 'CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST=${_CLUSTER_NAME_TABLE_API_UNBOUNDED_TABLE_TEST}'
+      - 'REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST=${_REGION_ARRAY_STRING_TABLE_API_UNBOUNDED_TABLE_TEST}'
+      - 'INITIALISATION_ACTION_SCRIPT_URI=${_INITIALISATION_ACTION_SCRIPT_URI}'
+      - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'WORKER_MACHINE_TYPE_UNBOUNDED=${_WORKER_MACHINE_TYPE_UNBOUNDED}'
+
+# 4. Nested schema e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-bounded-nested-schema-test'
+    waitFor: ['create-clusters-bounded-small-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_nested_schema_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+
+# 5. Table API nested schema e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-bounded-table-api-nested-schema-test'
+    waitFor: ['create-clusters-bounded-small-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_nested_schema_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE=${_TABLE_NAME_COMPLEX_SCHEMA_TABLE}'
+      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+
+# 6. Table API all data types e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-bounded-table-api-all-datatypes-test'
+    waitFor: ['create-clusters-bounded-small-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_all_datatypes_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
+      - 'TABLE_NAME_DESTINATION_ALL_DATATYPES_TABLE=${_TABLE_NAME_ALL_DATATYPES_TABLE}'
+      - 'PROPERTIES_SMALL_BOUNDED_JOB=${_PROPERTIES_SMALL_BOUNDED_JOB}'
+      - 'REGION_SMALL_TEST_FILE=${_REGION_SMALL_TEST_FILE}'
+      - 'CLUSTER_SMALL_TEST_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+      - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
+
+# 8. Large table e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-bounded-large-table-test'
+    waitFor: ['create-clusters-bounded-large-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_large_table_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+      - 'TABLE_NAME_DESTINATION_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+      - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
+      - 'REGION_LARGE_TABLE_TEST_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_LARGE_TABLE_TEST_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+      - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
+
+# 9. Table API large table e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-bounded-table-api-large-table-test'
+    waitFor: ['create-clusters-table-api-bounded-large-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_bounded_table_api_large_table_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'TABLE_NAME_SOURCE_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+      - 'TABLE_NAME_DESTINATION_TABLE_API_LARGE_TABLE=${_TABLE_NAME_LARGE_TABLE}'
+      - 'PROPERTIES_LARGE_BOUNDED_JOB=${_PROPERTIES_LARGE_BOUNDED_JOB}'
+      - 'REGION_TABLE_API_LARGE_TABLE_TEST_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+      - 'SINK_PARALLELISM_LARGE_BOUNDED_JOB=${_SINK_PARALLELISM_LARGE_BOUNDED_JOB}'
 
 # 9.5. Indirect write bounded e2e test.
   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
@@ -211,98 +211,98 @@ steps:
       - 'SINK_PARALLELISM_SMALL_BOUNDED_JOB=${_SINK_PARALLELISM_SMALL_BOUNDED_JOB}'
       - 'GCS_TEMPORARY_LOCATION=${_GCS_TEMPORARY_LOCATION}'
 
-# # 10. Unbounded e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-unbounded-test'
-#     waitFor: ['create-clusters-unbounded-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_unbounded_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
-#       - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
-#       - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
-#       - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
-#       - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
+# 10. Unbounded e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-unbounded-test'
+    waitFor: ['create-clusters-unbounded-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_unbounded_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
+      - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
+      - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
+      - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
+      - 'REGION_UNBOUNDED_TABLE_TEST_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
 
-# # 11. Table API unbounded e2e test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'e2e-table-api-unbounded-test'
-#     waitFor: ['create-clusters-table-api-unbounded-table']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_table_api_unbounded_test']
-#     env:
-#       - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'PROJECT_NAME=${_PROJECT_NAME}'
-#       - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
-#       - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
-#       - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
-#       - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
-#       - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
-#       - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
-# 
-# # 12.1 Delete the dataproc cluster - for small bounded tests
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'delete-clusters-bounded-small-table'
-#     waitFor: ['e2e-bounded-table-api-all-datatypes-test']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'REGION_FILE=${_REGION_SMALL_TEST_FILE}'
-#       - 'CLUSTER_FILE=${_CLUSTER_SMALL_TEST_FILE}'
-# 
-# # 12.2 Delete the dataproc cluster - for large table bounded test
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'delete-clusters-bounded-large-table'
-#     waitFor: ['e2e-bounded-large-table-test']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'REGION_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
-# 
-# # 12.3 Delete the dataproc cluster - for unbounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'delete-clusters-unbounded-table'
-#     waitFor: ['e2e-unbounded-test']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'REGION_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
-# 
-# # 12.4 Delete the dataproc cluster - for table api large table bounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'delete-clusters-table-api-bounded-large-table'
-#     waitFor: ['e2e-bounded-table-api-large-table-test']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'REGION_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
-#       - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
-# 
-# # 12.5 Delete the dataproc cluster - for table api unbounded test.
-#   - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
-#     id: 'delete-clusters-table-api-unbounded-table'
-#     waitFor: ['e2e-table-api-unbounded-test']
-#     entrypoint: 'bash'
-#     args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
-#     env:
-#       - 'PROJECT_ID=${_PROJECT_ID}'
-#       - 'REGION_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
-#       - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+# 11. Table API unbounded e2e test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'e2e-table-api-unbounded-test'
+    waitFor: ['create-clusters-table-api-unbounded-table']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'e2e_table_api_unbounded_test']
+    env:
+      - 'GCS_JAR_LOCATION_FILE=${_GCS_JAR_LOCATION_FILE}'
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'PROJECT_NAME=${_PROJECT_NAME}'
+      - 'DATASET_NAME=${_WRITE_DATASET_NAME}'
+      - 'GCS_SOURCE_URI=${_GCS_SOURCE_URI}'
+      - 'TABLE_NAME_DESTINATION_UNBOUNDED_TABLE=${_TABLE_NAME_UNBOUNDED_TABLE}'
+      - 'FILE_DISCOVERY_INTERVAL=${_FILE_DISCOVERY_INTERVAL}'
+      - 'PROPERTIES_UNBOUNDED_JOB=${_PROPERTIES_UNBOUNDED_JOB}'
+      - 'REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'SINK_PARALLELISM_UNBOUNDED_JOB=${_SINK_PARALLELISM_UNBOUNDED_JOB}'
+
+# 12.1 Delete the dataproc cluster - for small bounded tests
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'delete-clusters-bounded-small-table'
+    waitFor: ['e2e-bounded-table-api-all-datatypes-test']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'REGION_FILE=${_REGION_SMALL_TEST_FILE}'
+      - 'CLUSTER_FILE=${_CLUSTER_SMALL_TEST_FILE}'
+
+# 12.2 Delete the dataproc cluster - for large table bounded test
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'delete-clusters-bounded-large-table'
+    waitFor: ['e2e-bounded-large-table-test']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'REGION_FILE=${_REGION_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_FILE=${_CLUSTER_LARGE_TABLE_TEST_FILE}'
+
+# 12.3 Delete the dataproc cluster - for unbounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'delete-clusters-unbounded-table'
+    waitFor: ['e2e-unbounded-test']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'REGION_FILE=${_REGION_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_FILE=${_CLUSTER_UNBOUNDED_TABLE_TEST_FILE}'
+
+# 12.4 Delete the dataproc cluster - for table api large table bounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'delete-clusters-table-api-bounded-large-table'
+    waitFor: ['e2e-bounded-table-api-large-table-test']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'REGION_FILE=${_REGION_TABLE_API_LARGE_TABLE_TEST_FILE}'
+      - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_LARGE_TABLE_TEST_FILE}'
+
+# 12.5 Delete the dataproc cluster - for table api unbounded test.
+  - name: 'gcr.io/$PROJECT_ID/dataproc-flink-bigquery-connector-nightly'
+    id: 'delete-clusters-table-api-unbounded-table'
+    waitFor: ['e2e-table-api-unbounded-test']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/nightly/nightly.sh', 'delete_cluster']
+    env:
+      - 'PROJECT_ID=${_PROJECT_ID}'
+      - 'REGION_FILE=${_REGION_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
+      - 'CLUSTER_FILE=${_CLUSTER_TABLE_API_UNBOUNDED_TABLE_TEST_FILE}'
 
 # Maximum tolerance 75 minutes.
 timeout: 4500s

--- a/cloudbuild/nightly/nightly.sh
+++ b/cloudbuild/nightly/nightly.sh
@@ -201,7 +201,7 @@ case $STEP in
   e2e_indirect_bounded_test)
     IS_EXACTLY_ONCE_ENABLED=False
     timestamp=$(date +"%Y%m%d%H%M%S")
-    GCS_TEMP_BUCKET_PATH="${_GCS_TEMPORARY_LOCATION}/${timestamp}"
+    GCS_TEMP_BUCKET_PATH="${GCS_TEMPORARY_LOCATION}/${timestamp}"
     
     export TEMP_GCS_BUCKET="$GCS_TEMP_BUCKET_PATH"
     export PERSISTENT_GCS_BUCKET="true"

--- a/cloudbuild/nightly/nightly.sh
+++ b/cloudbuild/nightly/nightly.sh
@@ -197,6 +197,19 @@ case $STEP in
     exit
     ;;
 
+  # Run the indirect bounded e2e test.
+  e2e_indirect_bounded_test)
+    IS_EXACTLY_ONCE_ENABLED=False
+    timestamp=$(date +"%Y%m%d%H%M%S")
+    GCS_TEMP_BUCKET_PATH="${_GCS_TEMPORARY_LOCATION}/${timestamp}"
+    
+    export TEMP_GCS_BUCKET="$GCS_TEMP_BUCKET_PATH"
+    export PERSISTENT_GCS_BUCKET="true"
+    
+    run_read_write_test "$PROJECT_ID" "$REGION_SMALL_TEST_FILE" "$CLUSTER_SMALL_TEST_FILE" "$PROJECT_NAME" "$DATASET_NAME" "$TABLE_NAME_SOURCE_COMPLEX_SCHEMA_TABLE" "$TABLE_NAME_DESTINATION_COMPLEX_SCHEMA_TABLE" "$IS_EXACTLY_ONCE_ENABLED" "bounded" "$PROPERTIES_SMALL_BOUNDED_JOB" "$SINK_PARALLELISM_SMALL_BOUNDED_JOB"
+    exit
+    ;;
+
   # Relinquish the underlying infra running these tests.
   delete_cluster)
     delete_cluster "$PROJECT_ID" "$REGION_FILE" "$CLUSTER_FILE"

--- a/cloudbuild/nightly/scripts/bounded_table_write.sh
+++ b/cloudbuild/nightly/scripts/bounded_table_write.sh
@@ -29,4 +29,25 @@ then
   bq update --expiration 3600 "$DATASET_NAME"."$DESTINATION_TABLE_NAME"
 fi
 # Run the sink JAR JOB
-gcloud dataproc jobs submit flink --id "$JOB_ID" --jar="$GCS_JAR_LOCATION" --cluster="$CLUSTER_NAME" --region="$REGION" --properties="$PROPERTIES" -- --gcp-source-project "$PROJECT_NAME" --bq-source-dataset "$DATASET_NAME" --bq-source-table "$SOURCE" --gcp-dest-project "$PROJECT_NAME" --bq-dest-dataset "$DATASET_NAME" --bq-dest-table "$DESTINATION_TABLE_NAME" --sink-parallelism "$BOUNDED_JOB_SINK_PARALLELISM" --is-sql "$IS_SQL" --exactly-once "$IS_EXACTLY_ONCE_ENABLED" --enable-table-creation "$ENABLE_TABLE_CREATION"
+FLINK_ARGS=(
+  "--gcp-source-project" "$PROJECT_NAME"
+  "--bq-source-dataset" "$DATASET_NAME"
+  "--bq-source-table" "$SOURCE"
+  "--gcp-dest-project" "$PROJECT_NAME"
+  "--bq-dest-dataset" "$DATASET_NAME"
+  "--bq-dest-table" "$DESTINATION_TABLE_NAME"
+  "--sink-parallelism" "$BOUNDED_JOB_SINK_PARALLELISM"
+  "--is-sql" "$IS_SQL"
+  "--exactly-once" "$IS_EXACTLY_ONCE_ENABLED"
+  "--enable-table-creation" "$ENABLE_TABLE_CREATION"
+)
+
+if [ -n "${TEMP_GCS_BUCKET:-}" ]; then
+  FLINK_ARGS+=("--temporary-gcs-bucket" "$TEMP_GCS_BUCKET")
+fi
+
+if [ -n "${PERSISTENT_GCS_BUCKET:-}" ]; then
+  FLINK_ARGS+=("--persistent-gcs-bucket" "$PERSISTENT_GCS_BUCKET")
+fi
+
+gcloud dataproc jobs submit flink --id "$JOB_ID" --jar="$GCS_JAR_LOCATION" --cluster="$CLUSTER_NAME" --region="$REGION" --properties="$PROPERTIES" -- "${FLINK_ARGS[@]}"

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -57,7 +57,7 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
             # 'lifecycle_config': {'auto_delete_ttl': '5400s'},
             'gce_cluster_config': {'internal_ip_only': False},
             'endpoint_config': {
-                'enable_component_gateway': True
+                'enable_http_port_access': True
             },
         }
     }

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -53,7 +53,7 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
             'software_config': {
                 'image_version': dataproc_image_version,
                 'optional_components': ['FLINK', 'JUPYTER']},
-            'initialization_actions': [{'executable_file': initialisation_action_script_uri}],
+            'initialization_actions': [{'executable_file': initialisation_action_script_uri, 'execution_timeout': '1200s'}],
             'lifecycle_config': {'auto_delete_ttl': '5400s'},
             'gce_cluster_config': {'internal_ip_only': False},
             'endpoint_config': {

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -52,10 +52,13 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
                               'disk_config': {'boot_disk_size_gb': 500}},
             'software_config': {
                 'image_version': dataproc_image_version,
-                'optional_components': ['FLINK']},
+                'optional_components': ['FLINK', 'JUPYTER']},
             'initialization_actions': [{'executable_file': initialisation_action_script_uri}],
             # 'lifecycle_config': {'auto_delete_ttl': '5400s'},
             'gce_cluster_config': {'internal_ip_only': False},
+            'endpoint_config': {
+                'enable_component_gateway': True
+            },
         }
     }
     try:

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -54,7 +54,7 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
                 'image_version': dataproc_image_version,
                 'optional_components': ['FLINK']},
             'initialization_actions': [{'executable_file': initialisation_action_script_uri}],
-            'lifecycle_config': {'auto_delete_ttl': '5400s'},
+            # 'lifecycle_config': {'auto_delete_ttl': '5400s'},
             'gce_cluster_config': {'internal_ip_only': False},
         }
     }

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -54,7 +54,7 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
                 'image_version': dataproc_image_version,
                 'optional_components': ['FLINK', 'JUPYTER']},
             'initialization_actions': [{'executable_file': initialisation_action_script_uri}],
-            # 'lifecycle_config': {'auto_delete_ttl': '5400s'},
+            'lifecycle_config': {'auto_delete_ttl': '5400s'},
             'gce_cluster_config': {'internal_ip_only': False},
             'endpoint_config': {
                 'enable_http_port_access': True

--- a/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
+++ b/cloudbuild/nightly/scripts/python-scripts/create_cluster.py
@@ -69,8 +69,8 @@ def create_cluster(project_id, region, cluster_name, num_workers, dataproc_image
         result = operation.result()
         logging.info(result)
         return True
-    except Exception as _:
-        logging.info(f'Could not create cluster {cluster} in {region}')
+    except Exception as e:
+        logging.exception(f'Could not create cluster {cluster} in {region}')
         return False
 
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -531,13 +531,17 @@ public class BigQueryIntegrationTest {
                             try {
                                 env.execute(jobName);
                             } catch (Exception e) {
-                                LOG.error(e.getMessage());
+                                LOG.error("Flink job execution failed", e);
+                                throw new RuntimeException("Flink job execution failed", e);
                             }
                         });
         try {
             handle.get(timeoutTimePeriod, TimeUnit.MINUTES);
         } catch (TimeoutException e) {
             LOG.info("Job Cancelled!");
+        } catch (java.util.concurrent.ExecutionException e) {
+            LOG.error("Job execution failed!", e);
+            throw new RuntimeException("Job execution failed!", e);
         }
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -43,7 +43,6 @@ import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
-import org.apache.flink.table.api.TablePipeline;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.TableFunction;
@@ -746,8 +745,7 @@ public class BigQueryIntegrationTest {
                 BigQueryTableSchemaProvider.getTableDescriptor(sinkTableConfig));
 
         // Insert the table sourceTable to the registered sinkTable
-        TablePipeline pipeline = sourceTable.insertInto("bigQuerySinkTable");
-        TableResult res = pipeline.execute();
+        TableResult res = sourceTable.executeInsert("bigQuerySinkTable");
         try {
             res.await(timeoutTimePeriod, TimeUnit.MINUTES);
         } catch (InterruptedException | TimeoutException e) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -271,6 +271,9 @@ public class BigQueryIntegrationTest {
                     case "bounded":
                         sourceDatasetName = parameterTool.getRequired("bq-source-dataset");
                         sourceTableName = parameterTool.getRequired("bq-source-table");
+                        String tempGcsBucket = parameterTool.get("temporary-gcs-bucket");
+                        boolean persistentGcsBucket =
+                                parameterTool.getBoolean("persistent-gcs-bucket", false);
                         runBoundedFlinkJobWithSink(
                                 sourceGcpProjectName,
                                 sourceDatasetName,
@@ -280,7 +283,9 @@ public class BigQueryIntegrationTest {
                                 destTableName,
                                 isExactlyOnceEnabled,
                                 sinkParallelism,
-                                enableTableCreation);
+                                enableTableCreation,
+                                tempGcsBucket,
+                                persistentGcsBucket);
                         break;
                     case "unbounded":
                         gcsSourceUri = parameterTool.getRequired("gcs-source-uri");
@@ -331,7 +336,9 @@ public class BigQueryIntegrationTest {
             String destTableName,
             boolean exactlyOnce,
             Integer sinkParallelism,
-            boolean enableTableCreation)
+            boolean enableTableCreation,
+            String tempGcsBucket,
+            boolean persistentGcsBucket)
             throws Exception {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -366,6 +373,12 @@ public class BigQueryIntegrationTest {
                                         ? DeliveryGuarantee.EXACTLY_ONCE
                                         : DeliveryGuarantee.AT_LEAST_ONCE)
                         .streamExecutionEnvironment(env);
+
+        if (tempGcsBucket != null && !tempGcsBucket.isEmpty()) {
+            sinkConfigBuilder.temporaryGcsBucket(tempGcsBucket);
+        }
+
+        sinkConfigBuilder.persistentGcsBucket(persistentGcsBucket);
 
         if (enableTableCreation) {
             sinkConfigBuilder

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -363,9 +363,13 @@ public class BigQueryIntegrationTest {
                         .setTable(destTableName)
                         .build();
 
+        BigQuerySchemaProvider destSchemaProvider =
+                new BigQuerySchemaProviderImpl(sinkConnectOptions);
+
         BigQuerySinkConfig.Builder<GenericRecord> sinkConfigBuilder =
                 BigQuerySinkConfig.<GenericRecord>newBuilder()
                         .connectOptions(sinkConnectOptions)
+                        .schemaProvider(destSchemaProvider)
                         .serializer(new AvroToProtoSerializer())
                         .deliveryGuarantee(
                                 exactlyOnce

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -47,6 +47,10 @@ under the License.
     <dependencies>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -100,6 +100,11 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
 
         <!-- Table ecosystem -->
         <!-- Projects depending on this project won't depend on flink-table-*. -->
@@ -170,6 +175,20 @@ under the License.
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                            <version>1.11.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.formats.avro.AvroWriters;
+import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -55,8 +56,12 @@ class BigQueryIndirectSink<IN>
         Path outputPath = new Path(tempGcsBucket);
         Schema schema = sinkConfig.getSchemaProvider().getAvroSchema();
 
+        OutputFileConfig config = OutputFileConfig.builder().withPartSuffix(".avro").build();
+
         this.gcsAvroSink =
-                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema)).build();
+                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema))
+                        .withOutputFileConfig(config)
+                        .build();
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -70,7 +70,7 @@ class BigQueryIndirectSink<IN>
     @Override
     public Committer<FileSinkCommittable> createCommitter() throws IOException {
         Committer<FileSinkCommittable> fileSinkCommitter = gcsAvroSink.createCommitter();
-        return new IndirectSinkCommitter(fileSinkCommitter);
+        return new IndirectSinkCommitter(fileSinkCommitter, sinkConfig);
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.formats.avro.AvroWriters;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Sink to write data into BigQuery indirectly by staging data in GCS and then loading via Load Job.
+ *
+ * @param <IN> Type of input to sink.
+ */
+class BigQueryIndirectSink<IN>
+        implements Sink<IN>, TwoPhaseCommittingSink<IN, FileSinkCommittable> {
+
+    private final BigQuerySinkConfig<IN> sinkConfig;
+    private final FileSink<GenericRecord> gcsAvroSink;
+
+    BigQueryIndirectSink(BigQuerySinkConfig<IN> sinkConfig) {
+        this.sinkConfig = sinkConfig;
+
+        String tempGcsBucket = sinkConfig.getTemporaryGcsBucket();
+        if (tempGcsBucket == null || tempGcsBucket.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "temporaryGcsBucket option must be specified for indirect write mode.");
+        }
+
+        Path outputPath = new Path(tempGcsBucket);
+        Schema schema = sinkConfig.getSchemaProvider().getAvroSchema();
+
+        this.gcsAvroSink =
+                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema)).build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TwoPhaseCommittingSink.PrecommittingSinkWriter<IN, FileSinkCommittable> createWriter(
+            InitContext context) throws IOException {
+        return new BigQueryPrecommittingSinkWriter<>(
+                (SinkWriter<GenericRecord>) gcsAvroSink.createWriter(context));
+    }
+
+    @Override
+    public Committer<FileSinkCommittable> createCommitter() throws IOException {
+        Committer<FileSinkCommittable> fileSinkCommitter = gcsAvroSink.createCommitter();
+        return new IndirectSinkCommitter(fileSinkCommitter);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileSinkCommittable> getCommittableSerializer() {
+        return gcsAvroSink.getCommittableSerializer();
+    }
+
+    private static class BigQueryPrecommittingSinkWriter<IN>
+            implements TwoPhaseCommittingSink.PrecommittingSinkWriter<IN, FileSinkCommittable> {
+
+        private final SinkWriter<GenericRecord> innerWriter;
+
+        public BigQueryPrecommittingSinkWriter(SinkWriter<GenericRecord> innerWriter) {
+            this.innerWriter = innerWriter;
+        }
+
+        @Override
+        public void write(IN element, Context context) throws IOException, InterruptedException {
+            innerWriter.write((GenericRecord) element, context);
+        }
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            innerWriter.flush(endOfInput);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Collection<FileSinkCommittable> prepareCommit()
+                throws IOException, InterruptedException {
+            if (innerWriter instanceof TwoPhaseCommittingSink.PrecommittingSinkWriter) {
+                return ((TwoPhaseCommittingSink.PrecommittingSinkWriter<?, FileSinkCommittable>)
+                                innerWriter)
+                        .prepareCommit();
+            }
+            throw new IllegalStateException(
+                    "Localized FileSink writer does not implement PrecommittingSinkWriter.");
+        }
+
+        @Override
+        public void close() throws Exception {
+            innerWriter.close();
+        }
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,17 +47,16 @@ public class BigQuerySink {
             validateCdcConfiguration(sinkConfig);
         }
 
-        if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.AT_LEAST_ONCE) {
-            return new BigQueryDefaultSink<>(sinkConfig);
+        if (!StringUtils.isNullOrWhitespaceOnly(sinkConfig.getTemporaryGcsBucket())) {
+            return new BigQueryIndirectSink<>(sinkConfig);
         }
         if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.EXACTLY_ONCE) {
             return new BigQueryExactlyOnceSink<>(sinkConfig);
+        } else if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.NONE) {
+            throw new UnsupportedOperationException("Delivery Guarantee NONE is not supported.");
+        } else {
+            return new BigQueryDefaultSink<>(sinkConfig);
         }
-        LOG.error(
-                "BigQuery sink does not support {} delivery guarantee. Use AT_LEAST_ONCE or EXACTLY_ONCE.",
-                sinkConfig.getDeliveryGuarantee());
-        throw new UnsupportedOperationException(
-                String.format("%s is not supported", sinkConfig.getDeliveryGuarantee()));
     }
 
     /**

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -70,6 +70,8 @@ public class BigQuerySinkConfig<IN> {
     private final boolean cdcEnabled;
     private final String cdcSequenceField;
     private final CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
+    private final String temporaryGcsBucket;
+    private final boolean persistentGcsBucket;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -91,7 +93,9 @@ public class BigQuerySinkConfig<IN> {
                 fatalizeSerializer,
                 cdcEnabled,
                 cdcSequenceField,
-                cdcChangeTypeProvider);
+                cdcChangeTypeProvider,
+                temporaryGcsBucket,
+                persistentGcsBucket);
     }
 
     @Override
@@ -121,7 +125,9 @@ public class BigQuerySinkConfig<IN> {
                 && (this.isCdcEnabled() == object.isCdcEnabled())
                 && (Objects.equals(this.getCdcSequenceField(), object.getCdcSequenceField()))
                 && (Objects.equals(
-                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider())));
+                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider()))
+                && (Objects.equals(this.temporaryGcsBucket, object.temporaryGcsBucket))
+                && (this.persistentGcsBucket == object.persistentGcsBucket));
     }
 
     private BigQuerySinkConfig(
@@ -138,7 +144,9 @@ public class BigQuerySinkConfig<IN> {
             boolean fatalizeSerializer,
             boolean cdcEnabled,
             String cdcSequenceField,
-            CdcChangeTypeProvider<IN> cdcChangeTypeProvider) {
+            CdcChangeTypeProvider<IN> cdcChangeTypeProvider,
+            String temporaryGcsBucket,
+            boolean persistentGcsBucket) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -153,6 +161,8 @@ public class BigQuerySinkConfig<IN> {
         this.cdcEnabled = cdcEnabled;
         this.cdcSequenceField = cdcSequenceField;
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
+        this.temporaryGcsBucket = temporaryGcsBucket;
+        this.persistentGcsBucket = persistentGcsBucket;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -211,6 +221,14 @@ public class BigQuerySinkConfig<IN> {
         return cdcChangeTypeProvider;
     }
 
+    public String getTemporaryGcsBucket() {
+        return temporaryGcsBucket;
+    }
+
+    public boolean isPersistentGcsBucket() {
+        return persistentGcsBucket;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -234,6 +252,8 @@ public class BigQuerySinkConfig<IN> {
         private boolean cdcEnabled;
         private String cdcSequenceField;
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
+        private String temporaryGcsBucket;
+        private boolean persistentGcsBucket;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -311,6 +331,16 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> temporaryGcsBucket(String temporaryGcsBucket) {
+            this.temporaryGcsBucket = temporaryGcsBucket;
+            return this;
+        }
+
+        public Builder<IN> persistentGcsBucket(boolean persistentGcsBucket) {
+            this.persistentGcsBucket = persistentGcsBucket;
+            return this;
+        }
+
         public BigQuerySinkConfig<IN> build() {
             if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
                 validateStreamExecutionEnvironment(env);
@@ -329,7 +359,9 @@ public class BigQuerySinkConfig<IN> {
                     fatalizeSerializer,
                     cdcEnabled,
                     cdcSequenceField,
-                    cdcChangeTypeProvider);
+                    cdcChangeTypeProvider,
+                    temporaryGcsBucket,
+                    persistentGcsBucket);
         }
     }
 
@@ -363,7 +395,9 @@ public class BigQuerySinkConfig<IN> {
                 fatalizeSerializer,
                 false, // CDC not supported for Table API yet
                 null,
-                null);
+                null,
+                null,
+                false);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -38,6 +38,7 @@ import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,7 +49,7 @@ import java.util.Objects;
  *
  * @param <IN> Type of input to sink.
  */
-public class BigQuerySinkConfig<IN> {
+public class BigQuerySinkConfig<IN> implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
     private static final long MILLISECONDS_PER_SECOND = 1000L;

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
@@ -18,17 +18,36 @@ package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.core.fs.Path;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.flink.bigquery.services.BigQueryServices;
+import com.google.cloud.flink.bigquery.services.BigQueryServicesImpl;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /** Custom Committer that wraps FileSink's committer and triggers a BigQuery Load Job. */
 class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
 
     private final Committer<FileSinkCommittable> fileSinkCommitter;
+    private final BigQuerySinkConfig<?> sinkConfig;
+    private final BigQueryServices.QueryDataClient queryDataClient;
 
-    public IndirectSinkCommitter(Committer<FileSinkCommittable> fileSinkCommitter) {
+    public IndirectSinkCommitter(
+            Committer<FileSinkCommittable> fileSinkCommitter, BigQuerySinkConfig<?> sinkConfig) {
         this.fileSinkCommitter = fileSinkCommitter;
+        this.sinkConfig = sinkConfig;
+        this.queryDataClient =
+                new BigQueryServicesImpl()
+                        .createQueryDataClient(
+                                sinkConfig.getConnectOptions().getCredentialsOptions());
     }
 
     @Override
@@ -38,13 +57,48 @@ class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
         fileSinkCommitter.commit(requests);
 
         // 2. Scan GCS bucket to find produced specific files.
-        // TODO: Implement directory listing resolving specific file URIs.
+        String tempGcsBucket = sinkConfig.getTemporaryGcsBucket();
+        Path path = new Path(tempGcsBucket);
+        String bucketName = path.toUri().getHost();
+        String prefix = path.toUri().getPath();
+        if (prefix.startsWith("/")) {
+            prefix = prefix.substring(1);
+        }
+
+        Storage storage =
+                StorageOptions.newBuilder()
+                        .setCredentials(
+                                sinkConfig
+                                        .getConnectOptions()
+                                        .getCredentialsOptions()
+                                        .getCredentials())
+                        .build()
+                        .getService();
+
+        Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(prefix));
+        List<String> sourceUris = new ArrayList<>();
+        for (Blob blob : blobs.iterateAll()) {
+            if (blob.getName().endsWith(".avro")) {
+                sourceUris.add("gs://" + bucketName + "/" + blob.getName());
+            }
+        }
 
         // 3. Trigger BigQuery Load Job.
-        // TODO: Use BigQueryServices to submit load job.
+        if (!sourceUris.isEmpty()) {
+            queryDataClient.submitLoadJob(
+                    sinkConfig.getConnectOptions().getProjectId(),
+                    sinkConfig.getConnectOptions().getDataset(),
+                    sinkConfig.getConnectOptions().getTable(),
+                    sourceUris,
+                    FormatOptions.avro());
+        }
 
         // 4. Perform conditional file cleanup.
-        // TODO: Based on persistentGcsBucket flag.
+        if (!sinkConfig.isPersistentGcsBucket()) {
+            for (Blob blob : blobs.iterateAll()) {
+                storage.delete(blob.getBlobId());
+            }
+        }
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/** Custom Committer that wraps FileSink's committer and triggers a BigQuery Load Job. */
+class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
+
+    private final Committer<FileSinkCommittable> fileSinkCommitter;
+
+    public IndirectSinkCommitter(Committer<FileSinkCommittable> fileSinkCommitter) {
+        this.fileSinkCommitter = fileSinkCommitter;
+    }
+
+    @Override
+    public void commit(Collection<CommitRequest<FileSinkCommittable>> requests)
+            throws IOException, InterruptedException {
+        // 1. Delegate to FileSink's committer to finalize files.
+        fileSinkCommitter.commit(requests);
+
+        // 2. Scan GCS bucket to find produced specific files.
+        // TODO: Implement directory listing resolving specific file URIs.
+
+        // 3. Trigger BigQuery Load Job.
+        // TODO: Use BigQueryServices to submit load job.
+
+        // 4. Perform conditional file cleanup.
+        // TODO: Based on persistentGcsBucket flag.
+    }
+
+    @Override
+    public void close() throws Exception {
+        fileSinkCommitter.close();
+    }
+}

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -229,4 +229,18 @@ public class BigQueryConnectorOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Fail if serializer cannot convert record to proto");
+
+    /** [OPTIONAL, Sink Configuration] The GCS bucket to stage data before loading into BigQuery. */
+    public static final ConfigOption<String> TEMPORARY_GCS_BUCKET =
+            ConfigOptions.key("temporaryGcsBucket")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The GCS bucket to stage data before loading into BigQuery.");
+
+    /** [OPTIONAL, Sink Configuration] Keep the temporary GCS bucket folder after full load. */
+    public static final ConfigOption<Boolean> PERSISTENT_GCS_BUCKET =
+            ConfigOptions.key("persistentGcsBucket")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Keep the temporary GCS bucket folder after full load.");
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -186,6 +186,16 @@ public class StorageClientFaker {
             }
 
             @Override
+            public void submitLoadJob(
+                    String project,
+                    String dataset,
+                    String table,
+                    List<String> sourceUris,
+                    com.google.cloud.bigquery.FormatOptions formatOptions) {
+                // Mock implementation doing nothing for tests.
+            }
+
+            @Override
             public List<String> retrieveTablePartitions(
                     String project, String dataset, String table) {
                 DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHH");

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -83,6 +83,7 @@ public class BigQuerySinkConfigTest {
                         .clusteredFields(Arrays.asList("foo", "bar", "qux"))
                         .region("LaLaLand")
                         .fatalizeSerializer(true)
+                        .temporaryGcsBucket("gs://temp-bucket")
                         .build();
         assertEquals(connectOptions, sinkConfig.getConnectOptions());
         assertEquals(schemaProvider, sinkConfig.getSchemaProvider());
@@ -95,6 +96,7 @@ public class BigQuerySinkConfigTest {
         assertEquals(Arrays.asList("foo", "bar", "qux"), sinkConfig.getClusteredFields());
         assertEquals("LaLaLand", sinkConfig.getRegion());
         assertTrue(sinkConfig.fatalizeSerializer());
+        assertEquals("gs://temp-bucket", sinkConfig.getTemporaryGcsBucket());
     }
 
     @Test
@@ -113,6 +115,7 @@ public class BigQuerySinkConfigTest {
         assertNull(sinkConfig.getClusteredFields());
         assertNull(sinkConfig.getRegion());
         assertFalse(sinkConfig.fatalizeSerializer());
+        assertNull(sinkConfig.getTemporaryGcsBucket());
     }
 
     @Test

--- a/flink-1.17-connector-bigquery/pom.xml
+++ b/flink-1.17-connector-bigquery/pom.xml
@@ -243,6 +243,9 @@ under the License.
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>
+                    <systemPropertyVariables>
+                        <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/pom.xml
@@ -50,6 +50,11 @@ under the License.
             <version>${revision}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud.flink</groupId>
+            <artifactId>flink-connector-bigquery-common</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-api-java-bridge</artifactId>
             <scope>provided</scope>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -349,6 +349,9 @@ public class BigQueryIntegrationTest {
                     case "bounded":
                         sourceDatasetName = parameterTool.getRequired("bq-source-dataset");
                         sourceTableName = parameterTool.getRequired("bq-source-table");
+                        String tempGcsBucket = parameterTool.get("temporary-gcs-bucket");
+                        boolean persistentGcsBucket =
+                                parameterTool.getBoolean("persistent-gcs-bucket", false);
                         runBoundedFlinkJobWithSink(
                                 sourceGcpProjectName,
                                 sourceDatasetName,
@@ -358,7 +361,9 @@ public class BigQueryIntegrationTest {
                                 destTableName,
                                 isExactlyOnceEnabled,
                                 sinkParallelism,
-                                enableTableCreation);
+                                enableTableCreation,
+                                tempGcsBucket,
+                                persistentGcsBucket);
                         break;
                     case "unbounded":
                         gcsSourceUri = parameterTool.getRequired("gcs-source-uri");
@@ -409,7 +414,9 @@ public class BigQueryIntegrationTest {
             String destTableName,
             boolean exactlyOnce,
             Integer sinkParallelism,
-            boolean enableTableCreation)
+            boolean enableTableCreation,
+            String tempGcsBucket,
+            boolean persistentGcsBucket)
             throws Exception {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -444,6 +451,12 @@ public class BigQueryIntegrationTest {
                                         ? DeliveryGuarantee.EXACTLY_ONCE
                                         : DeliveryGuarantee.AT_LEAST_ONCE)
                         .streamExecutionEnvironment(env);
+
+        if (tempGcsBucket != null && !tempGcsBucket.isEmpty()) {
+            sinkConfigBuilder.temporaryGcsBucket(tempGcsBucket);
+        }
+
+        sinkConfigBuilder.persistentGcsBucket(persistentGcsBucket);
 
         if (enableTableCreation) {
             sinkConfigBuilder

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -442,9 +442,13 @@ public class BigQueryIntegrationTest {
                         .setTable(destTableName)
                         .build();
 
+        BigQuerySchemaProvider destSchemaProvider =
+                new BigQuerySchemaProviderImpl(sinkConnectOptions);
+
         BigQuerySinkConfig.Builder<GenericRecord> sinkConfigBuilder =
                 BigQuerySinkConfig.<GenericRecord>newBuilder()
                         .connectOptions(sinkConnectOptions)
+                        .schemaProvider(destSchemaProvider)
                         .serializer(new AvroToProtoSerializer())
                         .deliveryGuarantee(
                                 exactlyOnce

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -47,6 +47,10 @@ under the License.
     <dependencies>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -100,6 +100,11 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
 
         <!-- Table ecosystem -->
         <!-- Projects depending on this project won't depend on flink-table-*. -->
@@ -172,8 +177,22 @@ under the License.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                            <version>1.11.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-				<version>3.6.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>shade-flink</id>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -16,11 +16,16 @@
 
 package com.google.cloud.flink.bigquery.sink;
 
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.formats.avro.AvroWriters;
 
 import org.apache.avro.Schema;
@@ -33,17 +38,14 @@ import java.io.IOException;
  *
  * @param <IN> Type of input to sink.
  */
-class BigQueryIndirectSink<IN> implements Sink<IN> {
+class BigQueryIndirectSink<IN> implements Sink<IN>, SupportsCommitter<FileSinkCommittable> {
 
     private final BigQuerySinkConfig<IN> sinkConfig;
+    private final FileSink<GenericRecord> gcsAvroSink;
 
     BigQueryIndirectSink(BigQuerySinkConfig<IN> sinkConfig) {
         this.sinkConfig = sinkConfig;
-    }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public SinkWriter<IN> createWriter(WriterInitContext context) throws IOException {
         String tempGcsBucket = sinkConfig.getTemporaryGcsBucket();
         if (tempGcsBucket == null || tempGcsBucket.isEmpty()) {
             throw new IllegalArgumentException(
@@ -53,9 +55,25 @@ class BigQueryIndirectSink<IN> implements Sink<IN> {
         Path outputPath = new Path(tempGcsBucket);
         Schema schema = sinkConfig.getSchemaProvider().getAvroSchema();
 
-        FileSink<GenericRecord> gcsAvroSink =
+        this.gcsAvroSink =
                 FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema)).build();
+    }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public SinkWriter<IN> createWriter(WriterInitContext context) throws IOException {
         return (SinkWriter<IN>) gcsAvroSink.createWriter(context);
+    }
+
+    @Override
+    public Committer<FileSinkCommittable> createCommitter(CommitterInitContext context)
+            throws IOException {
+        Committer<FileSinkCommittable> fileSinkCommitter = gcsAvroSink.createCommitter(context);
+        return new IndirectSinkCommitter(fileSinkCommitter, sinkConfig);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileSinkCommittable> getCommittableSerializer() {
+        return gcsAvroSink.getCommittableSerializer();
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -27,6 +27,7 @@ import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.formats.avro.AvroWriters;
+import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -55,8 +56,12 @@ class BigQueryIndirectSink<IN> implements Sink<IN>, SupportsCommitter<FileSinkCo
         Path outputPath = new Path(tempGcsBucket);
         Schema schema = sinkConfig.getSchemaProvider().getAvroSchema();
 
+        OutputFileConfig config = OutputFileConfig.builder().withPartSuffix(".avro").build();
+
         this.gcsAvroSink =
-                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema)).build();
+                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema))
+                        .withOutputFileConfig(config)
+                        .build();
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.avro.AvroWriters;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.IOException;
+
+/**
+ * Sink to write data into BigQuery indirectly by staging data in GCS and then loading via Load Job.
+ *
+ * @param <IN> Type of input to sink.
+ */
+class BigQueryIndirectSink<IN> implements Sink<IN> {
+
+    private final BigQuerySinkConfig<IN> sinkConfig;
+
+    BigQueryIndirectSink(BigQuerySinkConfig<IN> sinkConfig) {
+        this.sinkConfig = sinkConfig;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public SinkWriter<IN> createWriter(WriterInitContext context) throws IOException {
+        String tempGcsBucket = sinkConfig.getTemporaryGcsBucket();
+        if (tempGcsBucket == null || tempGcsBucket.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "temporaryGcsBucket option must be specified for indirect write mode.");
+        }
+
+        Path outputPath = new Path(tempGcsBucket);
+        Schema schema = sinkConfig.getSchemaProvider().getAvroSchema();
+
+        FileSink<GenericRecord> gcsAvroSink =
+                FileSink.forBulkFormat(outputPath, AvroWriters.forGenericRecord(schema)).build();
+
+        return (SinkWriter<IN>) gcsAvroSink.createWriter(context);
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -45,6 +45,9 @@ public class BigQuerySink {
         if (sinkConfig.isCdcEnabled()) {
             validateCdcConfiguration(sinkConfig);
         }
+        if (!StringUtils.isNullOrWhitespaceOnly(sinkConfig.getTemporaryGcsBucket())) {
+            return new BigQueryIndirectSink<>(sinkConfig);
+        }
         if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.AT_LEAST_ONCE) {
             return new BigQueryDefaultSink<>(sinkConfig);
         }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -76,6 +76,7 @@ public class BigQuerySinkConfig<IN> {
     private final String cdcMaxStaleness;
     private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
     private final String temporaryGcsBucket;
+    private final boolean persistentGcsBucket;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -100,7 +101,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
                 cdcChangeTypeProvider,
-                temporaryGcsBucket);
+                temporaryGcsBucket,
+                persistentGcsBucket);
     }
 
     @Override
@@ -134,7 +136,8 @@ public class BigQuerySinkConfig<IN> {
                 && (Objects.equals(this.getCdcMaxStaleness(), object.getCdcMaxStaleness()))
                 && (Objects.equals(
                         this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider()))
-                && (Objects.equals(this.temporaryGcsBucket, object.temporaryGcsBucket)));
+                && (Objects.equals(this.temporaryGcsBucket, object.temporaryGcsBucket))
+                && (this.persistentGcsBucket == object.persistentGcsBucket));
     }
 
     private BigQuerySinkConfig(
@@ -154,7 +157,8 @@ public class BigQuerySinkConfig<IN> {
             List<String> cdcPrimaryKeyColumns,
             String cdcMaxStaleness,
             CdcChangeTypeProvider<?> cdcChangeTypeProvider,
-            String temporaryGcsBucket) {
+            String temporaryGcsBucket,
+            boolean persistentGcsBucket) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -172,6 +176,7 @@ public class BigQuerySinkConfig<IN> {
         this.cdcMaxStaleness = cdcMaxStaleness;
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
         this.temporaryGcsBucket = temporaryGcsBucket;
+        this.persistentGcsBucket = persistentGcsBucket;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -242,6 +247,10 @@ public class BigQuerySinkConfig<IN> {
         return temporaryGcsBucket;
     }
 
+    public boolean getPersistentGcsBucket() {
+        return persistentGcsBucket;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -268,6 +277,7 @@ public class BigQuerySinkConfig<IN> {
         private String cdcMaxStaleness;
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
         private String temporaryGcsBucket;
+        private boolean persistentGcsBucket;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -360,6 +370,11 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> persistentGcsBucket(boolean persistentGcsBucket) {
+            this.persistentGcsBucket = persistentGcsBucket;
+            return this;
+        }
+
         public BigQuerySinkConfig<IN> build() {
             if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
                 validateStreamExecutionEnvironment(env);
@@ -381,7 +396,8 @@ public class BigQuerySinkConfig<IN> {
                     cdcPrimaryKeyColumns,
                     cdcMaxStaleness,
                     cdcChangeTypeProvider,
-                    temporaryGcsBucket);
+                    temporaryGcsBucket,
+                    persistentGcsBucket);
         }
     }
 
@@ -454,7 +470,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
                 cdcChangeTypeProvider,
-                null);
+                null,
+                false);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -35,6 +35,7 @@ import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -47,7 +48,7 @@ import java.util.Optional;
  *
  * @param <IN> Type of input to sink.
  */
-public class BigQuerySinkConfig<IN> {
+public class BigQuerySinkConfig<IN> implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
     private static final long MILLISECONDS_PER_SECOND = 1000L;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -75,6 +75,7 @@ public class BigQuerySinkConfig<IN> {
     private final List<String> cdcPrimaryKeyColumns;
     private final String cdcMaxStaleness;
     private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
+    private final String temporaryGcsBucket;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -98,7 +99,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcSequenceField,
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
-                cdcChangeTypeProvider);
+                cdcChangeTypeProvider,
+                temporaryGcsBucket);
     }
 
     @Override
@@ -131,7 +133,8 @@ public class BigQuerySinkConfig<IN> {
                         this.getCdcPrimaryKeyColumns(), object.getCdcPrimaryKeyColumns()))
                 && (Objects.equals(this.getCdcMaxStaleness(), object.getCdcMaxStaleness()))
                 && (Objects.equals(
-                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider())));
+                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider()))
+                && (Objects.equals(this.temporaryGcsBucket, object.temporaryGcsBucket)));
     }
 
     private BigQuerySinkConfig(
@@ -150,7 +153,8 @@ public class BigQuerySinkConfig<IN> {
             String cdcSequenceField,
             List<String> cdcPrimaryKeyColumns,
             String cdcMaxStaleness,
-            CdcChangeTypeProvider<?> cdcChangeTypeProvider) {
+            CdcChangeTypeProvider<?> cdcChangeTypeProvider,
+            String temporaryGcsBucket) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -167,6 +171,7 @@ public class BigQuerySinkConfig<IN> {
         this.cdcPrimaryKeyColumns = cdcPrimaryKeyColumns;
         this.cdcMaxStaleness = cdcMaxStaleness;
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
+        this.temporaryGcsBucket = temporaryGcsBucket;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -233,6 +238,10 @@ public class BigQuerySinkConfig<IN> {
         return cdcChangeTypeProvider;
     }
 
+    public String getTemporaryGcsBucket() {
+        return temporaryGcsBucket;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -258,6 +267,7 @@ public class BigQuerySinkConfig<IN> {
         private List<String> cdcPrimaryKeyColumns;
         private String cdcMaxStaleness;
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
+        private String temporaryGcsBucket;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -345,6 +355,11 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> temporaryGcsBucket(String temporaryGcsBucket) {
+            this.temporaryGcsBucket = temporaryGcsBucket;
+            return this;
+        }
+
         public BigQuerySinkConfig<IN> build() {
             if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
                 validateStreamExecutionEnvironment(env);
@@ -365,7 +380,8 @@ public class BigQuerySinkConfig<IN> {
                     cdcSequenceField,
                     cdcPrimaryKeyColumns,
                     cdcMaxStaleness,
-                    cdcChangeTypeProvider);
+                    cdcChangeTypeProvider,
+                    temporaryGcsBucket);
         }
     }
 
@@ -437,7 +453,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcSequenceField,
                 cdcPrimaryKeyColumns,
                 cdcMaxStaleness,
-                cdcChangeTypeProvider);
+                cdcChangeTypeProvider,
+                null);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
@@ -18,17 +18,36 @@ package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.core.fs.Path;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.flink.bigquery.services.BigQueryServices;
+import com.google.cloud.flink.bigquery.services.BigQueryServicesImpl;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /** Custom Committer that wraps FileSink's committer and triggers a BigQuery Load Job. */
 class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
 
     private final Committer<FileSinkCommittable> fileSinkCommitter;
+    private final BigQuerySinkConfig<?> sinkConfig;
+    private final BigQueryServices.QueryDataClient queryDataClient;
 
-    public IndirectSinkCommitter(Committer<FileSinkCommittable> fileSinkCommitter) {
+    public IndirectSinkCommitter(
+            Committer<FileSinkCommittable> fileSinkCommitter, BigQuerySinkConfig<?> sinkConfig) {
         this.fileSinkCommitter = fileSinkCommitter;
+        this.sinkConfig = sinkConfig;
+        this.queryDataClient =
+                new BigQueryServicesImpl()
+                        .createQueryDataClient(
+                                sinkConfig.getConnectOptions().getCredentialsOptions());
     }
 
     @Override
@@ -38,13 +57,48 @@ class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
         fileSinkCommitter.commit(requests);
 
         // 2. Scan GCS bucket to find produced specific files.
-        // TODO: Implement directory listing resolving specific file URIs.
+        String tempGcsBucket = sinkConfig.getTemporaryGcsBucket();
+        Path path = new Path(tempGcsBucket);
+        String bucketName = path.toUri().getHost();
+        String prefix = path.toUri().getPath();
+        if (prefix.startsWith("/")) {
+            prefix = prefix.substring(1);
+        }
+
+        Storage storage =
+                StorageOptions.newBuilder()
+                        .setCredentials(
+                                sinkConfig
+                                        .getConnectOptions()
+                                        .getCredentialsOptions()
+                                        .getCredentials())
+                        .build()
+                        .getService();
+
+        Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(prefix));
+        List<String> sourceUris = new ArrayList<>();
+        for (Blob blob : blobs.iterateAll()) {
+            if (blob.getName().endsWith(".avro")) {
+                sourceUris.add("gs://" + bucketName + "/" + blob.getName());
+            }
+        }
 
         // 3. Trigger BigQuery Load Job.
-        // TODO: Use BigQueryServices to submit load job.
+        if (!sourceUris.isEmpty()) {
+            queryDataClient.submitLoadJob(
+                    sinkConfig.getConnectOptions().getProjectId(),
+                    sinkConfig.getConnectOptions().getDataset(),
+                    sinkConfig.getConnectOptions().getTable(),
+                    sourceUris,
+                    FormatOptions.avro());
+        }
 
         // 4. Perform conditional file cleanup.
-        // TODO: Based on persistentGcsBucket flag.
+        if (!sinkConfig.getPersistentGcsBucket()) {
+            for (Blob blob : blobs.iterateAll()) {
+                storage.delete(blob.getBlobId());
+            }
+        }
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/IndirectSinkCommitter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/** Custom Committer that wraps FileSink's committer and triggers a BigQuery Load Job. */
+class IndirectSinkCommitter implements Committer<FileSinkCommittable> {
+
+    private final Committer<FileSinkCommittable> fileSinkCommitter;
+
+    public IndirectSinkCommitter(Committer<FileSinkCommittable> fileSinkCommitter) {
+        this.fileSinkCommitter = fileSinkCommitter;
+    }
+
+    @Override
+    public void commit(Collection<CommitRequest<FileSinkCommittable>> requests)
+            throws IOException, InterruptedException {
+        // 1. Delegate to FileSink's committer to finalize files.
+        fileSinkCommitter.commit(requests);
+
+        // 2. Scan GCS bucket to find produced specific files.
+        // TODO: Implement directory listing resolving specific file URIs.
+
+        // 3. Trigger BigQuery Load Job.
+        // TODO: Use BigQueryServices to submit load job.
+
+        // 4. Perform conditional file cleanup.
+        // TODO: Based on persistentGcsBucket flag.
+    }
+
+    @Override
+    public void close() throws Exception {
+        fileSinkCommitter.close();
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -294,4 +294,11 @@ public class BigQueryConnectorOptions {
                                     + "persisted during table creation, so max_staleness remains "
                                     + "unset after create. Run ALTER TABLE ... SET OPTIONS "
                                     + "(max_staleness = INTERVAL ...) after creation.");
+
+    /** [OPTIONAL, Sink Configuration] The GCS bucket to stage data before loading into BigQuery. */
+    public static final ConfigOption<String> TEMPORARY_GCS_BUCKET =
+            ConfigOptions.key("temporaryGcsBucket")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The GCS bucket to stage data before loading into BigQuery.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -185,6 +185,16 @@ public class StorageClientFaker {
             }
 
             @Override
+            public void submitLoadJob(
+                    String project,
+                    String dataset,
+                    String table,
+                    List<String> sourceUris,
+                    com.google.cloud.bigquery.FormatOptions formatOptions) {
+                // Mock implementation doing nothing for tests.
+            }
+
+            @Override
             public List<String> retrieveTablePartitions(
                     String project, String dataset, String table) {
                 DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHH");

--- a/flink-2.1-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/pom.xml
@@ -243,6 +243,9 @@ under the License.
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>
+                    <systemPropertyVariables>
+                        <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
@@ -20,6 +20,7 @@ import org.apache.flink.annotation.Internal;
 
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamResponse;
@@ -244,5 +245,21 @@ public interface BigQueryServices extends Serializable {
          */
         void createTable(
                 String project, String dataset, String table, TableDefinition tableDefinition);
+
+        /**
+         * Function to submit a load job to BigQuery.
+         *
+         * @param project The GCP project.
+         * @param dataset The BigQuery dataset.
+         * @param table The BigQuery table.
+         * @param sourceUris List of GCS URIs containing data to load.
+         * @param formatOptions Format options (e.g., Parquet).
+         */
+        void submitLoadJob(
+                String project,
+                String dataset,
+                String table,
+                List<String> sourceUris,
+                FormatOptions formatOptions);
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
@@ -34,6 +34,9 @@ import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.LoadJobConfiguration;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableDefinition;
@@ -474,6 +477,23 @@ public class BigQueryServicesImpl implements BigQueryServices {
             TableId tableId = TableId.of(project, dataset, table);
             TableInfo tableInfo = TableInfo.of(tableId, tableDefinition);
             bigQuery.create(tableInfo);
+        }
+
+        @Override
+        public void submitLoadJob(
+                String project,
+                String dataset,
+                String table,
+                List<String> sourceUris,
+                FormatOptions formatOptions) {
+            TableId tableId = TableId.of(project, dataset, table);
+            LoadJobConfiguration loadJobConfig =
+                    LoadJobConfiguration.newBuilder(tableId, sourceUris)
+                            .setFormatOptions(formatOptions)
+                            .build();
+
+            LOG.info("BigQueryClient: Submitted job LoadJobConfiguration");
+            bigQuery.create(JobInfo.of(loadJobConfig));
         }
     }
 


### PR DESCRIPTION
###  Indirect Write Mode for Flink-BigQuery Connector

**Overview**
This Pull Request introduces an "indirect write" mode for the Flink-BigQuery connector, with support for Flink versions 1.17 and 2.1. Instead of writing directly to the BigQuery Storage Write API, this new feature stages data in Google Cloud Storage (GCS) and subsequently loads it into BigQuery using a BigQuery Load Job.

**Core Changes**
*   **New Sink Implementation (`BigQueryIndirectSink`)**: Added to both the Flink 1.17 and 2.1 modules. It leverages Flink's `FileSink` to write incoming records to a temporary GCS bucket in Avro format.
*   **BigQuery Load Job Integration (`IndirectSinkCommitter`)**: Introduces a custom committer that wraps the standard `FileSink` committer. Once files are finalized in GCS, it automatically triggers a BigQuery Load Job to ingest the data.
*   **Service Layer Enhancements (`BigQueryServices`)**: The interface and its implementation (`BigQueryServicesImpl`) have been expanded with a `submitLoadJob` method, which configures and submits a `LoadJobConfiguration` via the BigQuery Java SDK.
*   **Sink Selection Logic (`BigQuerySink.get()`)**: The factory method was updated to automatically route to the `BigQueryIndirectSink` if a temporary GCS bucket is provided in the job configuration.
**Configuration Updates**
Two new configuration options were added to `BigQueryConnectorOptions` to support the indirect write workflow:
*   `temporaryGcsBucket`: Specifies the GCS path where data should be staged before being loaded into BigQuery.
*   `persistentGcsBucket`: A boolean flag (defaulting to `false`) that determines whether the staged Avro files should be kept in the GCS bucket after the BigQuery load completes.

**Testing & Infrastructure**
*   **Dependencies**: Updated `pom.xml` files to include the necessary `flink-connector-files` and `flink-avro` dependencies.
*   **Unit Tests**: Expanded `BigQuerySinkConfigTest` to validate the new parameters and updated `StorageClientFaker` to mock the load job submissions.
*   **Integration Tests & CI**: Updated `BigQueryIntegrationTest.java` to support the new bucket parameters and modified `cloudbuild.yaml` along with its nightly scripts to run a dedicated `e2e-indirect-bounded-test`.