### PR TITLE
Nested projection pushdown support

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -88,51 +88,87 @@ public class AvroToRowDataConverters {
     // Runtime Converters
     // -------------------------------------------------------------------------------------
 
-    public static AvroToRowDataConverter createRowConverter(RowType rowType) {
+    public static AvroToRowDataConverter createRowConverter(
+            RowType rowType, String[][] nestedPaths) {
         final AvroToRowDataConverter[] fieldConverters =
                 rowType.getFields().stream()
                         .map(RowType.RowField::getType)
                         .map(AvroToRowDataConverters::createNullableConverter)
                         .toArray(AvroToRowDataConverter[]::new);
         final int arity = rowType.getFieldCount();
-        final String[] fieldNames =
-                rowType.getFields().stream().map(RowType.RowField::getName).toArray(String[]::new);
 
         return new AvroToRowDataConverter() {
-            private int[] indexMapping;
+            private int[][] indexMapping;
 
             @Override
             public Object convert(Object avroObject) {
                 GenericRecord record = (GenericRecord) avroObject;
                 if (indexMapping == null) {
-                    indexMapping = computeIndexMapping(record, fieldNames);
+                    indexMapping = computeIndexMapping(record, nestedPaths);
                 }
                 GenericRowData row = new GenericRowData(arity);
                 for (int i = 0; i < arity; ++i) {
-                    row.setField(i, fieldConverters[i].convert(record.get(indexMapping[i])));
+                    Object avroFieldValue = getNestedField(record, indexMapping[i]);
+                    row.setField(i, fieldConverters[i].convert(avroFieldValue));
                 }
                 return row;
             }
         };
     }
 
-    private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
-        int[] mapping = new int[fieldNames.length];
-        for (int i = 0; i < fieldNames.length; i++) {
-            org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
-            if (field == null) {
-                List<String> avroFieldNames = new java.util.ArrayList<>();
-                for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
-                    avroFieldNames.add(f.name());
-                }
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Field '%s' not found in Avro schema. Available fields: %s",
-                                fieldNames[i], avroFieldNames));
+    private static Object getNestedField(GenericRecord record, int[] positions) {
+        Object value = record;
+        for (int pos : positions) {
+            if (value == null) {
+                return null;
             }
-            mapping[i] = field.pos();
+            value = ((GenericRecord) value).get(pos);
+        }
+        return value;
+    }
+
+    private static int[][] computeIndexMapping(GenericRecord record, String[][] fieldNames) {
+        int[][] mapping = new int[fieldNames.length][];
+        for (int i = 0; i < fieldNames.length; i++) {
+            mapping[i] = new int[fieldNames[i].length];
+            org.apache.avro.Schema currentSchema = unwrapNullableUnion(record.getSchema());
+            for (int j = 0; j < fieldNames[i].length; j++) {
+                org.apache.avro.Schema.Field field = currentSchema.getField(fieldNames[i][j]);
+                if (field == null) {
+                    throw fieldNotFound(fieldNames[i], currentSchema);
+                }
+                mapping[i][j] = field.pos();
+                currentSchema = unwrapNullableUnion(field.schema());
+            }
         }
         return mapping;
+    }
+
+    // Check if nullable and take non-null path for schema unwrap
+    private static org.apache.avro.Schema unwrapNullableUnion(org.apache.avro.Schema schema) {
+        if (!schema.isUnion()) {
+            return schema;
+        }
+        return schema.getTypes().stream()
+                .filter(s -> s.getType() != org.apache.avro.Schema.Type.NULL)
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Nullable union schema contains only NULL type: "
+                                                + schema));
+    }
+
+    private static IllegalArgumentException fieldNotFound(
+            String[] path, org.apache.avro.Schema schemaAtFailure) {
+        List<String> avroFieldNames = new java.util.ArrayList<>();
+        for (org.apache.avro.Schema.Field f : schemaAtFailure.getFields()) {
+            avroFieldNames.add(f.name());
+        }
+        return new IllegalArgumentException(
+                String.format(
+                        "Field '%s' not found in Avro schema. Available fields: %s",
+                        String.join(".", path), avroFieldNames));
     }
 
     /** Creates a runtime converter which is null safe. */
@@ -196,7 +232,12 @@ public class AvroToRowDataConverters {
             case ARRAY:
                 return createArrayConverter((ArrayType) type);
             case ROW:
-                return createRowConverter((RowType) type);
+                return createRowConverter(
+                        (RowType) type,
+                        ((RowType) type)
+                                .getFields().stream()
+                                        .map(f -> new String[] {f.getName()})
+                                        .toArray(String[][]::new));
             case MAP:
             case MULTISET:
                 return createMapConverter(type);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -127,15 +127,16 @@ public class AvroToRowDataConverters {
         return value;
     }
 
-    private static int[][] computeIndexMapping(GenericRecord record, String[][] fieldNames) {
-        int[][] mapping = new int[fieldNames.length][];
-        for (int i = 0; i < fieldNames.length; i++) {
-            mapping[i] = new int[fieldNames[i].length];
-            org.apache.avro.Schema currentSchema = unwrapNullableUnion(record.getSchema());
-            for (int j = 0; j < fieldNames[i].length; j++) {
-                org.apache.avro.Schema.Field field = currentSchema.getField(fieldNames[i][j]);
+    private static int[][] computeIndexMapping(GenericRecord record, String[][] nestedPaths) {
+        int[][] mapping = new int[nestedPaths.length][];
+        org.apache.avro.Schema rootSchema = unwrapNullableUnion(record.getSchema());
+        for (int i = 0; i < nestedPaths.length; i++) {
+            mapping[i] = new int[nestedPaths[i].length];
+            org.apache.avro.Schema currentSchema = rootSchema;
+            for (int j = 0; j < nestedPaths[i].length; j++) {
+                org.apache.avro.Schema.Field field = currentSchema.getField(nestedPaths[i][j]);
                 if (field == null) {
-                    throw fieldNotFound(fieldNames[i], currentSchema);
+                    throw fieldNotFound(nestedPaths[i], currentSchema);
                 }
                 mapping[i][j] = field.pos();
                 currentSchema = unwrapNullableUnion(field.schema());

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataDeserializationSchema.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataDeserializationSchema.java
@@ -32,13 +32,16 @@ import org.slf4j.LoggerFactory;
 public class AvroToRowDataDeserializationSchema
         implements BigQueryDeserializationSchema<GenericRecord, RowData> {
     private final AvroToRowDataConverters.AvroToRowDataConverter converter;
-    private final TypeInformation<RowData> typeInfo;
+
     private static final Logger LOG =
             LoggerFactory.getLogger(AvroToRowDataDeserializationSchema.class);
 
-    public AvroToRowDataDeserializationSchema(RowType rowType, TypeInformation<RowData> typeInfo) {
-        this.converter = AvroToRowDataConverters.createRowConverter(rowType);
+    private final TypeInformation<RowData> typeInfo;
+
+    public AvroToRowDataDeserializationSchema(
+            RowType rowType, TypeInformation<RowData> typeInfo, String[][] fullyQualifiedPaths) {
         this.typeInfo = typeInfo;
+        this.converter = AvroToRowDataConverters.createRowConverter(rowType, fullyQualifiedPaths);
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
@@ -48,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,16 +71,41 @@ public class BigQueryDynamicTableSource
     private BigQueryReadOptions readOptions;
     private DataType producedDataType;
 
-    public BigQueryDynamicTableSource(BigQueryReadOptions readOptions, DataType producedDataType) {
-        if (readOptions.getColumnNames().isEmpty()) {
-            readOptions =
-                    readOptions
-                            .toBuilder()
-                            .setColumnNames(DataType.getFieldNames(producedDataType))
-                            .build();
-        }
+    private final RowType physicalDataType;
+    private String[][] fullyQualifiedPaths;
+
+    public BigQueryDynamicTableSource(BigQueryReadOptions readOptions, DataType physicalDataType) {
+        this(
+                ensureDefaultColumnNames(readOptions, physicalDataType),
+                (RowType) physicalDataType.getLogicalType(),
+                physicalDataType,
+                defaultFlatPaths((RowType) physicalDataType.getLogicalType()));
+    }
+
+    private BigQueryDynamicTableSource(
+            BigQueryReadOptions readOptions,
+            RowType physicalDataType,
+            DataType producedDataType,
+            String[][] fullyQualifiedPaths) {
         this.readOptions = readOptions;
+        this.physicalDataType = physicalDataType;
         this.producedDataType = producedDataType;
+        this.fullyQualifiedPaths = fullyQualifiedPaths;
+    }
+
+    private static BigQueryReadOptions ensureDefaultColumnNames(
+            BigQueryReadOptions readOptions, DataType physicalDataType) {
+        if (readOptions.getColumnNames().isEmpty()) {
+            return readOptions
+                    .toBuilder()
+                    .setColumnNames(DataType.getFieldNames(physicalDataType))
+                    .build();
+        }
+        return readOptions;
+    }
+
+    private static String[][] defaultFlatPaths(RowType rowType) {
+        return rowType.getFieldNames().stream().map(f -> new String[] {f}).toArray(String[][]::new);
     }
 
     @Override
@@ -92,12 +119,14 @@ public class BigQueryDynamicTableSource
         final TypeInformation<RowData> typeInfo =
                 runtimeProviderContext.createTypeInformation(producedDataType);
 
+        AvroToRowDataDeserializationSchema deserializationSchema =
+                new AvroToRowDataDeserializationSchema(rowType, typeInfo, fullyQualifiedPaths);
+
         BigQuerySource<RowData> bqSource =
                 BigQuerySource.<RowData>builder()
                         .setReadOptions(readOptions)
                         .setSourceBoundedness(Boundedness.BOUNDED)
-                        .setDeserializationSchema(
-                                new AvroToRowDataDeserializationSchema(rowType, typeInfo))
+                        .setDeserializationSchema(deserializationSchema)
                         .build();
 
         return SourceProvider.of(bqSource);
@@ -105,7 +134,8 @@ public class BigQueryDynamicTableSource
 
     @Override
     public DynamicTableSource copy() {
-        return new BigQueryDynamicTableSource(readOptions, producedDataType);
+        return new BigQueryDynamicTableSource(
+                readOptions, physicalDataType, producedDataType, fullyQualifiedPaths);
     }
 
     @Override
@@ -116,17 +146,46 @@ public class BigQueryDynamicTableSource
 
     @Override
     public boolean supportsNestedProjection() {
-        return false;
+        return true;
     }
 
     @Override
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.producedDataType = producedDataType;
+        // Single walk of the original DDL row tree. Produces the per-column Avro paths and
+        // leaf types the deserializer will use directly — no path-walking in the deserializer.
+        this.fullyQualifiedPaths = resolvePaths(projectedFields);
         this.readOptions =
                 this.readOptions
                         .toBuilder()
-                        .setColumnNames(DataType.getFieldNames(producedDataType))
+                        .setColumnNames(toDottedPaths(this.fullyQualifiedPaths))
                         .build();
+    }
+
+    // Walk through projected fields getting fully qualified names for each column
+    private String[][] resolvePaths(int[][] paths) {
+        return Arrays.stream(paths)
+                .map(indexPath -> toNamePath(indexPath, this.physicalDataType))
+                .toArray(String[][]::new);
+    }
+
+    private static String[] toNamePath(final int[] indexPath, final RowType rowType) {
+        final String[] namePath = new String[indexPath.length];
+        LogicalType currentType = rowType;
+        for (int i = 0; i < indexPath.length; i++) {
+            final RowType row = (RowType) currentType;
+            final RowType.RowField rowField = row.getFields().get(indexPath[i]);
+            namePath[i] = rowField.getName();
+            currentType = rowField.getType();
+        }
+        return namePath;
+    }
+
+    // Joins Avro field-name paths with "." to query BigQuery
+    private static List<String> toDottedPaths(String[][] namePaths) {
+        return Arrays.stream(namePaths)
+                .map(path -> String.join(".", path))
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -180,7 +239,11 @@ public class BigQueryDynamicTableSource
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.readOptions, this.producedDataType);
+        return Objects.hash(
+                this.readOptions,
+                this.producedDataType,
+                this.physicalDataType,
+                Arrays.deepHashCode(this.fullyQualifiedPaths));
     }
 
     @Override
@@ -196,7 +259,9 @@ public class BigQueryDynamicTableSource
         }
         final BigQueryDynamicTableSource other = (BigQueryDynamicTableSource) obj;
         return Objects.equals(this.readOptions, other.readOptions)
-                && Objects.equals(this.producedDataType, other.producedDataType);
+                && Objects.equals(this.producedDataType, other.producedDataType)
+                && Objects.equals(this.physicalDataType, other.physicalDataType)
+                && Arrays.deepEquals(this.fullyQualifiedPaths, other.fullyQualifiedPaths);
     }
 
     Optional<TablePartitionInfo> retrievePartitionInfo() {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -984,7 +984,7 @@ public class StorageClientFaker {
             this.queryDataClient = queryDataClient;
         }
 
-        static FakeBigQueryTableServices getInstance(
+        public static FakeBigQueryTableServices getInstance(
                 FakeBigQueryServices.FakeBigQueryStorageReadClient storageReadClient,
                 FakeBigQueryServices.FakeBigQueryStorageWriteClient storageWriteClient,
                 FakeBigQueryServices.FakeQueryDataClient queryDataClient) {
@@ -995,7 +995,7 @@ public class StorageClientFaker {
             return instance;
         }
 
-        static FakeBigQueryTableServices getInstance(
+        public static FakeBigQueryTableServices getInstance(
                 FakeBigQueryServices.FakeBigQueryStorageReadClient storageReadClient,
                 FakeBigQueryServices.FakeBigQueryStorageWriteClient storageWriteClient) {
             return getInstance(

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializerTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializerTest.java
@@ -412,8 +412,13 @@ public class RowDataToProtoSerializerTest {
                         .set("Json", "{\"FirstName\": \"John\", \"LastName\": \"Doe\"}")
                         .build();
 
+        RowType bqRowType = (RowType) logicalType;
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter((RowType) logicalType);
+                AvroToRowDataConverters.createRowConverter(
+                        bqRowType,
+                        bqRowType.getFieldNames().stream()
+                                .map(f -> new String[] {f})
+                                .toArray(String[][]::new));
         RowData row = (RowData) converter.convert(record);
 
         // Check the expected value.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceIntegrationTestCase.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceIntegrationTestCase.java
@@ -88,7 +88,12 @@ public class BigQuerySourceIntegrationTestCase {
         return BigQuerySource.<RowData>builder()
                 .setReadOptions(rOptions)
                 .setDeserializationSchema(
-                        new AvroToRowDataDeserializationSchema(rowType, typeInfo));
+                        new AvroToRowDataDeserializationSchema(
+                                rowType,
+                                typeInfo,
+                                rowType.getFieldNames().stream()
+                                        .map(f -> new String[] {f})
+                                        .toArray(String[][]::new)));
     }
 
     private static RowType defaultSourceRowType() {
@@ -178,7 +183,12 @@ public class BigQuerySourceIntegrationTestCase {
                                         // we want this to fail 10% of the time (1 in 10 times)
                                         10D))
                         .setDeserializationSchema(
-                                new AvroToRowDataDeserializationSchema(rowType, typeInfo))
+                                new AvroToRowDataDeserializationSchema(
+                                        rowType,
+                                        typeInfo,
+                                        rowType.getFieldNames().stream()
+                                                .map(f -> new String[] {f})
+                                                .toArray(String[][]::new)))
                         .build();
 
         List<RowData> results =

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
@@ -52,7 +52,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("null_field", new NullType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"null_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"null_field\", \"type\": \"null\"}]";
@@ -72,7 +73,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("tinyint_field", new TinyIntType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"tinyint_field"}});
 
         // Create the AvroRecord
         String fieldString =
@@ -95,7 +97,9 @@ public class AvroToRowDataConvertersTest {
         UnsupportedOperationException exception =
                 assertThrows(
                         UnsupportedOperationException.class,
-                        () -> AvroToRowDataConverters.createRowConverter(rowType));
+                        () ->
+                                AvroToRowDataConverters.createRowConverter(
+                                        rowType, new String[][] {{"time_field"}}));
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "The TIME type within the Avro schema uses a precision of '9', which is higher than the maximum supported TIME precision 6.");
@@ -113,7 +117,9 @@ public class AvroToRowDataConvertersTest {
         UnsupportedOperationException exception =
                 assertThrows(
                         UnsupportedOperationException.class,
-                        () -> AvroToRowDataConverters.createRowConverter(rowType));
+                        () ->
+                                AvroToRowDataConverters.createRowConverter(
+                                        rowType, new String[][] {{"datetime_field"}}));
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "The TIMESTAMP/DATETIME type within the Avro schema uses a precision of '9', which is higher than the maximum supported TIMESTAMP/DATETIME precision 6.");
@@ -127,7 +133,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("decimal_field", new DecimalType(34))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"decimal_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -164,7 +171,7 @@ public class AvroToRowDataConvertersTest {
                                         "map_field",
                                         new MapType(new VarCharType(), new VarCharType()))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(rowType, new String[][] {{"map_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -194,7 +201,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("datetime_field", new TimestampType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"datetime_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -222,7 +230,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("timestamp_field", new TimestampType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"timestamp_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -280,7 +289,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("date_field", new DateType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"date_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -322,7 +332,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("time_field", new TimeType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"time_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -361,7 +372,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("time_field", new TimeType(6))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"time_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -395,7 +407,8 @@ public class AvroToRowDataConvertersTest {
                 new RowType(
                         Collections.singletonList(new RowField("byte_field", new VarBinaryType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"byte_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"byte_field\", \"type\": \"bytes\"}]";
@@ -414,7 +427,8 @@ public class AvroToRowDataConvertersTest {
                 new RowType(
                         Collections.singletonList(new RowField("byte_field", new VarBinaryType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"byte_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"byte_field\", \"type\": \"bytes\"}]";
@@ -439,7 +453,9 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("third_field", new DoubleType()),
                                 new RowField("first_field", new IntType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType,
+                        new String[][] {{"second_field"}, {"third_field"}, {"first_field"}});
         // Create the AvroRecord — fields in original table order
         String fieldString =
                 " \"fields\": [\n"
@@ -467,7 +483,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("third_field", new BigIntType()),
                                 new RowField("second_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"third_field"}, {"second_field"}});
         // Create the AvroRecord — all 4 columns in table order
         String fieldString =
                 " \"fields\": [\n"
@@ -497,7 +514,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("second_field", new BigIntType()),
                                 new RowField("first_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"second_field"}, {"first_field"}});
         // Create the AvroRecord — Avro has first before second (opposite of RowType)
         String fieldString =
                 " \"fields\": [\n"
@@ -530,7 +548,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("second_field", innerRowType),
                                 new RowField("first_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(outerRowType);
+                AvroToRowDataConverters.createRowConverter(
+                        outerRowType, new String[][] {{"second_field"}, {"first_field"}});
         // Create the AvroRecord — first_field before second_field; first_inner before second_inner
         Schema innerAvroSchema =
                 org.apache.avro.SchemaBuilder.record("second_field")
@@ -570,5 +589,176 @@ public class AvroToRowDataConvertersTest {
         assertEquals(StringData.fromString("inner_b"), innerRow.getField(0));
         assertEquals(StringData.fromString("inner_a"), innerRow.getField(1));
         assertEquals(StringData.fromString("outer_a"), row.getField(1));
+    }
+
+    @Test
+    public void testNestedProjectionWalksAvroRecord() {
+        // Flat output type — what Flink's planner produces after nested projection.
+        RowType outputRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("event_name", new VarCharType()),
+                                new RowField("buyer_id", new VarCharType())));
+        String[][] paths = {{"payload", "event_name"}, {"payload", "buyer", "id"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        // Nested Avro record matching what BQ returns when given dotted-path selected_fields.
+        Schema buyerSchema =
+                org.apache.avro.SchemaBuilder.record("buyer")
+                        .fields()
+                        .requiredString("id")
+                        .endRecord();
+        Schema payloadSchema =
+                org.apache.avro.SchemaBuilder.record("payload")
+                        .fields()
+                        .requiredString("event_name")
+                        .name("buyer")
+                        .type(buyerSchema)
+                        .noDefault()
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("payload")
+                        .type(payloadSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord buyer = new GenericRecordBuilder(buyerSchema).set("id", "b-1").build();
+        GenericRecord payload =
+                new GenericRecordBuilder(payloadSchema)
+                        .set("event_name", "checkout")
+                        .set("buyer", buyer)
+                        .build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("payload", payload).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(
+                GenericRowData.of(StringData.fromString("checkout"), StringData.fromString("b-1")),
+                result);
+    }
+
+    @Test
+    public void testNestedProjectionTraversesNullableUnion() {
+        // Flat output for a path through a NULLABLE intermediate record.
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "city"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        // Inner address is nullable: ["null", record].
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(
+                                org.apache.avro.SchemaBuilder.unionOf()
+                                        .nullType()
+                                        .and()
+                                        .type(addressSchema)
+                                        .endUnion())
+                        .withDefault(null)
+                        .endRecord();
+        GenericRecord address =
+                new GenericRecordBuilder(addressSchema).set("city", "Toronto").build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", address).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(GenericRowData.of(StringData.fromString("Toronto")), result);
+    }
+
+    @Test
+    public void testNestedProjectionReturnsNullWhenIntermediateIsNull() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "city"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(
+                                org.apache.avro.SchemaBuilder.unionOf()
+                                        .nullType()
+                                        .and()
+                                        .type(addressSchema)
+                                        .endUnion())
+                        .withDefault(null)
+                        .endRecord();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", null).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(GenericRowData.of((Object) null), result);
+    }
+
+    @Test
+    public void testNestedProjectionThrowsOnIntermediateFieldNotFound() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("leaf", new VarCharType())));
+        String[][] paths = {{"missing_intermediate", "leaf"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .requiredString("present")
+                        .endRecord();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("present", "x").build();
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> converter.convert(outer));
+        Assertions.assertThat(ex.getMessage())
+                .contains("missing_intermediate.leaf")
+                .contains("present");
+    }
+
+    @Test
+    public void testNestedProjectionThrowsOnLeafFieldNotFound() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "missing_leaf"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .requiredString("zip")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(addressSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord address =
+                new GenericRecordBuilder(addressSchema)
+                        .set("city", "Toronto")
+                        .set("zip", "M5V")
+                        .build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", address).build();
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> converter.convert(outer));
+        Assertions.assertThat(ex.getMessage())
+                .contains("address.missing_leaf")
+                .contains("city")
+                .contains("zip");
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -137,6 +137,91 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testSupportsNestedProjection() throws IOException {
+        DynamicTableSource source = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+        assertThat(((BigQueryDynamicTableSource) source).supportsNestedProjection()).isTrue();
+    }
+
+    @Test
+    public void testApplyProjectionNestedFieldsProducesDottedPaths() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "payload",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                                DataTypes.FIELD(
+                                                        "buyer",
+                                                        DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "id", DataTypes.STRING()),
+                                                                DataTypes.FIELD(
+                                                                        "email",
+                                                                        DataTypes.STRING())))))));
+
+        source.applyProjection(
+                new int[][] {{0, 0}, {0, 1, 0}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                        DataTypes.FIELD("id", DataTypes.STRING())));
+
+        assertThat(source.getReadOptions().getColumnNames())
+                .containsExactly("payload.event_name", "payload.buyer.id")
+                .inOrder();
+    }
+
+    @Test
+    public void testApplyProjectionMixedFlatAndNestedPreservesOrder() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                DataTypes.FIELD(
+                                        "address",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("city", DataTypes.STRING()),
+                                                DataTypes.FIELD("zip", DataTypes.STRING())))));
+
+        source.applyProjection(
+                new int[][] {{1, 0}, {0}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("city", DataTypes.STRING()),
+                        DataTypes.FIELD("id", DataTypes.BIGINT())));
+
+        assertThat(source.getReadOptions().getColumnNames())
+                .containsExactly("address.city", "id")
+                .inOrder();
+    }
+
+    @Test
+    public void testCopyAfterApplyProjectionPreservesPaths() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "payload",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                                DataTypes.FIELD("buyer_id", DataTypes.STRING())))));
+
+        source.applyProjection(
+                new int[][] {{0, 0}, {0, 1}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                        DataTypes.FIELD("buyer_id", DataTypes.STRING())));
+
+        BigQueryDynamicTableSource copy = (BigQueryDynamicTableSource) source.copy();
+
+        assertThat(copy.getReadOptions().getColumnNames())
+                .containsExactly("payload.event_name", "payload.buyer_id")
+                .inOrder();
+    }
+
+    @Test
     public void testBigQuerySourceValidation() {
         // max num of streams should be positive
         assertSourceValidationRejects(

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSourceIntegrationTestCase.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSourceIntegrationTestCase.java
@@ -62,6 +62,8 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
     private static final int PARALLELISM = 1;
     private static final Integer TOTAL_ROW_COUNT_PER_STREAM = 10000;
     private static final Integer STREAM_COUNT = 2;
+    private static StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient
+            storageReadClient;
     private static final Schema AVRO_SCHEMA =
             SchemaBuilder.record("testRecord")
                     .fields()
@@ -159,14 +161,15 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
                                     .collect(Collectors.toList());
                         };
 
+        storageReadClient =
+                new StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient(
+                        StorageClientFaker.fakeReadSession(
+                                TOTAL_ROW_COUNT_PER_STREAM, STREAM_COUNT, AVRO_SCHEMA.toString()),
+                        dataGenerator);
         SerializableSupplier<BigQueryServices> testingServices =
-                StorageClientFaker.createTableReadOptions(
-                                TOTAL_ROW_COUNT_PER_STREAM,
-                                STREAM_COUNT,
-                                AVRO_SCHEMA.toString(),
-                                dataGenerator)
-                        .getBigQueryConnectOptions()
-                        .getTestingBigQueryServices();
+                () ->
+                        StorageClientFaker.FakeBigQueryTableServices.getInstance(
+                                storageReadClient, null);
 
         // init the testing services and inject them into the table factory
         BigQueryDynamicTableFactory.setTestingServices(testingServices);
@@ -228,6 +231,32 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
         List<String> expected = Stream.of("+I[0, 0.0, s0]").sorted().collect(Collectors.toList());
 
         Assertions.assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNestedProject() throws IOException {
+        tEnv.createTable("bigquery_source", createTestDDl(null));
+
+        Iterator<Row> collected =
+                tEnv.executeSql("SELECT reqSubRecord.reqBoolean FROM bigquery_source LIMIT 1")
+                        .collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        List<String> expected = Stream.of("+I[false]").sorted().collect(Collectors.toList());
+
+        Assertions.assertThat(result).isEqualTo(expected);
+        Assertions.assertThat(storageReadClient.getLastCreateReadSessionRequest()).isNotNull();
+        Assertions.assertThat(
+                        storageReadClient
+                                .getLastCreateReadSessionRequest()
+                                .getReadSession()
+                                .getReadOptions()
+                                .getSelectedFieldsList())
+                .containsExactly("reqSubRecord.reqBoolean");
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -127,15 +127,16 @@ public class AvroToRowDataConverters {
         return value;
     }
 
-    private static int[][] computeIndexMapping(GenericRecord record, String[][] fieldNames) {
-        int[][] mapping = new int[fieldNames.length][];
-        for (int i = 0; i < fieldNames.length; i++) {
-            mapping[i] = new int[fieldNames[i].length];
-            org.apache.avro.Schema currentSchema = unwrapNullableUnion(record.getSchema());
-            for (int j = 0; j < fieldNames[i].length; j++) {
-                org.apache.avro.Schema.Field field = currentSchema.getField(fieldNames[i][j]);
+    private static int[][] computeIndexMapping(GenericRecord record, String[][] nestedPaths) {
+        int[][] mapping = new int[nestedPaths.length][];
+        org.apache.avro.Schema rootSchema = unwrapNullableUnion(record.getSchema());
+        for (int i = 0; i < nestedPaths.length; i++) {
+            mapping[i] = new int[nestedPaths[i].length];
+            org.apache.avro.Schema currentSchema = rootSchema;
+            for (int j = 0; j < nestedPaths[i].length; j++) {
+                org.apache.avro.Schema.Field field = currentSchema.getField(nestedPaths[i][j]);
                 if (field == null) {
-                    throw fieldNotFound(fieldNames[i], currentSchema);
+                    throw fieldNotFound(nestedPaths[i], currentSchema);
                 }
                 mapping[i][j] = field.pos();
                 currentSchema = unwrapNullableUnion(field.schema());
@@ -152,7 +153,11 @@ public class AvroToRowDataConverters {
         return schema.getTypes().stream()
                 .filter(s -> s.getType() != org.apache.avro.Schema.Type.NULL)
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Nullable union schema contains only NULL type: "
+                                                + schema));
     }
 
     private static IllegalArgumentException fieldNotFound(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataConverters.java
@@ -88,51 +88,83 @@ public class AvroToRowDataConverters {
     // Runtime Converters
     // -------------------------------------------------------------------------------------
 
-    public static AvroToRowDataConverter createRowConverter(RowType rowType) {
+    public static AvroToRowDataConverter createRowConverter(
+            RowType rowType, String[][] nestedPaths) {
         final AvroToRowDataConverter[] fieldConverters =
                 rowType.getFields().stream()
                         .map(RowType.RowField::getType)
                         .map(AvroToRowDataConverters::createNullableConverter)
                         .toArray(AvroToRowDataConverter[]::new);
         final int arity = rowType.getFieldCount();
-        final String[] fieldNames =
-                rowType.getFields().stream().map(RowType.RowField::getName).toArray(String[]::new);
 
         return new AvroToRowDataConverter() {
-            private int[] indexMapping;
+            private int[][] indexMapping;
 
             @Override
             public Object convert(Object avroObject) {
                 GenericRecord record = (GenericRecord) avroObject;
                 if (indexMapping == null) {
-                    indexMapping = computeIndexMapping(record, fieldNames);
+                    indexMapping = computeIndexMapping(record, nestedPaths);
                 }
                 GenericRowData row = new GenericRowData(arity);
                 for (int i = 0; i < arity; ++i) {
-                    row.setField(i, fieldConverters[i].convert(record.get(indexMapping[i])));
+                    Object avroFieldValue = getNestedField(record, indexMapping[i]);
+                    row.setField(i, fieldConverters[i].convert(avroFieldValue));
                 }
                 return row;
             }
         };
     }
 
-    private static int[] computeIndexMapping(GenericRecord record, String[] fieldNames) {
-        int[] mapping = new int[fieldNames.length];
-        for (int i = 0; i < fieldNames.length; i++) {
-            org.apache.avro.Schema.Field field = record.getSchema().getField(fieldNames[i]);
-            if (field == null) {
-                List<String> avroFieldNames = new java.util.ArrayList<>();
-                for (org.apache.avro.Schema.Field f : record.getSchema().getFields()) {
-                    avroFieldNames.add(f.name());
-                }
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Field '%s' not found in Avro schema. Available fields: %s",
-                                fieldNames[i], avroFieldNames));
+    private static Object getNestedField(GenericRecord record, int[] positions) {
+        Object value = record;
+        for (int pos : positions) {
+            if (value == null) {
+                return null;
             }
-            mapping[i] = field.pos();
+            value = ((GenericRecord) value).get(pos);
+        }
+        return value;
+    }
+
+    private static int[][] computeIndexMapping(GenericRecord record, String[][] fieldNames) {
+        int[][] mapping = new int[fieldNames.length][];
+        for (int i = 0; i < fieldNames.length; i++) {
+            mapping[i] = new int[fieldNames[i].length];
+            org.apache.avro.Schema currentSchema = unwrapNullableUnion(record.getSchema());
+            for (int j = 0; j < fieldNames[i].length; j++) {
+                org.apache.avro.Schema.Field field = currentSchema.getField(fieldNames[i][j]);
+                if (field == null) {
+                    throw fieldNotFound(fieldNames[i], currentSchema);
+                }
+                mapping[i][j] = field.pos();
+                currentSchema = unwrapNullableUnion(field.schema());
+            }
         }
         return mapping;
+    }
+
+    // Check if nullable and take non-null path for schema unwrap
+    private static org.apache.avro.Schema unwrapNullableUnion(org.apache.avro.Schema schema) {
+        if (!schema.isUnion()) {
+            return schema;
+        }
+        return schema.getTypes().stream()
+                .filter(s -> s.getType() != org.apache.avro.Schema.Type.NULL)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static IllegalArgumentException fieldNotFound(
+            String[] path, org.apache.avro.Schema schemaAtFailure) {
+        List<String> avroFieldNames = new java.util.ArrayList<>();
+        for (org.apache.avro.Schema.Field f : schemaAtFailure.getFields()) {
+            avroFieldNames.add(f.name());
+        }
+        return new IllegalArgumentException(
+                String.format(
+                        "Field '%s' not found in Avro schema. Available fields: %s",
+                        String.join(".", path), avroFieldNames));
     }
 
     /** Creates a runtime converter which is null safe. */
@@ -196,7 +228,12 @@ public class AvroToRowDataConverters {
             case ARRAY:
                 return createArrayConverter((ArrayType) type);
             case ROW:
-                return createRowConverter((RowType) type);
+                return createRowConverter(
+                        (RowType) type,
+                        ((RowType) type)
+                                .getFields().stream()
+                                        .map(f -> new String[] {f.getName()})
+                                        .toArray(String[][]::new));
             case MAP:
             case MULTISET:
                 return createMapConverter(type);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataDeserializationSchema.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/reader/deserializer/AvroToRowDataDeserializationSchema.java
@@ -32,13 +32,16 @@ import org.slf4j.LoggerFactory;
 public class AvroToRowDataDeserializationSchema
         implements BigQueryDeserializationSchema<GenericRecord, RowData> {
     private final AvroToRowDataConverters.AvroToRowDataConverter converter;
-    private final TypeInformation<RowData> typeInfo;
+
     private static final Logger LOG =
             LoggerFactory.getLogger(AvroToRowDataDeserializationSchema.class);
 
-    public AvroToRowDataDeserializationSchema(RowType rowType, TypeInformation<RowData> typeInfo) {
-        this.converter = AvroToRowDataConverters.createRowConverter(rowType);
+    private final TypeInformation<RowData> typeInfo;
+
+    public AvroToRowDataDeserializationSchema(
+            RowType rowType, TypeInformation<RowData> typeInfo, String[][] fullyQualifiedPaths) {
         this.typeInfo = typeInfo;
+        this.converter = AvroToRowDataConverters.createRowConverter(rowType, fullyQualifiedPaths);
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
@@ -48,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,18 +72,45 @@ public class BigQueryDynamicTableSource
     private DataType producedDataType;
     private final Integer parallelism;
 
+    private final RowType physicalDataType;
+    private String[][] fullyQualifiedPaths;
+
     public BigQueryDynamicTableSource(
-            BigQueryReadOptions readOptions, DataType producedDataType, Integer parallelism) {
-        if (readOptions.getColumnNames().isEmpty()) {
-            readOptions =
-                    readOptions
-                            .toBuilder()
-                            .setColumnNames(DataType.getFieldNames(producedDataType))
-                            .build();
-        }
+            BigQueryReadOptions readOptions, DataType physicalDataType, Integer parallelism) {
+        this(
+                ensureDefaultColumnNames(readOptions, physicalDataType),
+                (RowType) physicalDataType.getLogicalType(),
+                physicalDataType,
+                defaultFlatPaths((RowType) physicalDataType.getLogicalType()),
+                parallelism);
+    }
+
+    private BigQueryDynamicTableSource(
+            BigQueryReadOptions readOptions,
+            RowType physicalDataType,
+            DataType producedDataType,
+            String[][] fullyQualifiedPaths,
+            Integer parallelism) {
         this.readOptions = readOptions;
+        this.physicalDataType = physicalDataType;
         this.producedDataType = producedDataType;
+        this.fullyQualifiedPaths = fullyQualifiedPaths;
         this.parallelism = parallelism;
+    }
+
+    private static BigQueryReadOptions ensureDefaultColumnNames(
+            BigQueryReadOptions readOptions, DataType physicalDataType) {
+        if (readOptions.getColumnNames().isEmpty()) {
+            return readOptions
+                    .toBuilder()
+                    .setColumnNames(DataType.getFieldNames(physicalDataType))
+                    .build();
+        }
+        return readOptions;
+    }
+
+    private static String[][] defaultFlatPaths(RowType rowType) {
+        return rowType.getFieldNames().stream().map(f -> new String[] {f}).toArray(String[][]::new);
     }
 
     @Override
@@ -95,12 +124,14 @@ public class BigQueryDynamicTableSource
         final TypeInformation<RowData> typeInfo =
                 runtimeProviderContext.createTypeInformation(producedDataType);
 
+        AvroToRowDataDeserializationSchema deserializationSchema =
+                new AvroToRowDataDeserializationSchema(rowType, typeInfo, fullyQualifiedPaths);
+
         BigQuerySource<RowData> bqSource =
                 BigQuerySource.<RowData>builder()
                         .setReadOptions(readOptions)
                         .setSourceBoundedness(Boundedness.BOUNDED)
-                        .setDeserializationSchema(
-                                new AvroToRowDataDeserializationSchema(rowType, typeInfo))
+                        .setDeserializationSchema(deserializationSchema)
                         .build();
 
         return SourceProvider.of(bqSource, parallelism);
@@ -108,7 +139,8 @@ public class BigQueryDynamicTableSource
 
     @Override
     public DynamicTableSource copy() {
-        return new BigQueryDynamicTableSource(readOptions, producedDataType, parallelism);
+        return new BigQueryDynamicTableSource(
+                readOptions, physicalDataType, producedDataType, fullyQualifiedPaths, parallelism);
     }
 
     @Override
@@ -119,17 +151,46 @@ public class BigQueryDynamicTableSource
 
     @Override
     public boolean supportsNestedProjection() {
-        return false;
+        return true;
     }
 
     @Override
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.producedDataType = producedDataType;
+        // Single walk of the original DDL row tree. Produces the per-column Avro paths and
+        // leaf types the deserializer will use directly — no path-walking in the deserializer.
+        this.fullyQualifiedPaths = resolvePaths(projectedFields);
         this.readOptions =
                 this.readOptions
                         .toBuilder()
-                        .setColumnNames(DataType.getFieldNames(producedDataType))
+                        .setColumnNames(toDottedPaths(this.fullyQualifiedPaths))
                         .build();
+    }
+
+    // Walk through projected fields getting fully qualified names for each column
+    private String[][] resolvePaths(int[][] paths) {
+        return Arrays.stream(paths)
+                .map(indexPath -> toNamePath(indexPath, this.physicalDataType))
+                .toArray(String[][]::new);
+    }
+
+    private static String[] toNamePath(final int[] indexPath, final RowType rowType) {
+        final String[] namePath = new String[indexPath.length];
+        LogicalType currentType = rowType;
+        for (int i = 0; i < indexPath.length; i++) {
+            final RowType row = (RowType) currentType;
+            final RowType.RowField rowField = row.getFields().get(indexPath[i]);
+            namePath[i] = rowField.getName();
+            currentType = rowField.getType();
+        }
+        return namePath;
+    }
+
+    // Joins Avro field-name paths with "." to query BigQuery
+    private static List<String> toDottedPaths(String[][] namePaths) {
+        return Arrays.stream(namePaths)
+                .map(path -> String.join(".", path))
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -183,7 +244,12 @@ public class BigQueryDynamicTableSource
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.readOptions, this.producedDataType, this.parallelism);
+        return Objects.hash(
+                this.readOptions,
+                this.producedDataType,
+                this.parallelism,
+                this.physicalDataType,
+                Arrays.deepHashCode(this.fullyQualifiedPaths));
     }
 
     @Override
@@ -200,7 +266,9 @@ public class BigQueryDynamicTableSource
         final BigQueryDynamicTableSource other = (BigQueryDynamicTableSource) obj;
         return Objects.equals(this.readOptions, other.readOptions)
                 && Objects.equals(this.producedDataType, other.producedDataType)
-                && Objects.equals(this.parallelism, other.parallelism);
+                && Objects.equals(this.parallelism, other.parallelism)
+                && Objects.equals(this.physicalDataType, other.physicalDataType)
+                && Arrays.deepEquals(this.fullyQualifiedPaths, other.fullyQualifiedPaths);
     }
 
     Optional<TablePartitionInfo> retrievePartitionInfo() {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -980,7 +980,7 @@ public class StorageClientFaker {
             this.queryDataClient = queryDataClient;
         }
 
-        static FakeBigQueryTableServices getInstance(
+        public static FakeBigQueryTableServices getInstance(
                 FakeBigQueryServices.FakeBigQueryStorageReadClient storageReadClient,
                 FakeBigQueryServices.FakeBigQueryStorageWriteClient storageWriteClient,
                 FakeBigQueryServices.FakeQueryDataClient queryDataClient) {
@@ -991,7 +991,7 @@ public class StorageClientFaker {
             return instance;
         }
 
-        static FakeBigQueryTableServices getInstance(
+        public static FakeBigQueryTableServices getInstance(
                 FakeBigQueryServices.FakeBigQueryStorageReadClient storageReadClient,
                 FakeBigQueryServices.FakeBigQueryStorageWriteClient storageWriteClient) {
             return getInstance(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializerTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializerTest.java
@@ -412,8 +412,13 @@ public class RowDataToProtoSerializerTest {
                         .set("Json", "{\"FirstName\": \"John\", \"LastName\": \"Doe\"}")
                         .build();
 
+        RowType bqRowType = (RowType) logicalType;
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter((RowType) logicalType);
+                AvroToRowDataConverters.createRowConverter(
+                        bqRowType,
+                        bqRowType.getFieldNames().stream()
+                                .map(f -> new String[] {f})
+                                .toArray(String[][]::new));
         RowData row = (RowData) converter.convert(record);
 
         // Check the expected value.

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceIntegrationTestCase.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceIntegrationTestCase.java
@@ -88,7 +88,12 @@ public class BigQuerySourceIntegrationTestCase {
         return BigQuerySource.<RowData>builder()
                 .setReadOptions(rOptions)
                 .setDeserializationSchema(
-                        new AvroToRowDataDeserializationSchema(rowType, typeInfo));
+                        new AvroToRowDataDeserializationSchema(
+                                rowType,
+                                typeInfo,
+                                rowType.getFieldNames().stream()
+                                        .map(f -> new String[] {f})
+                                        .toArray(String[][]::new)));
     }
 
     private static RowType defaultSourceRowType() {
@@ -178,7 +183,12 @@ public class BigQuerySourceIntegrationTestCase {
                                         // we want this to fail 10% of the time (1 in 10 times)
                                         10D))
                         .setDeserializationSchema(
-                                new AvroToRowDataDeserializationSchema(rowType, typeInfo))
+                                new AvroToRowDataDeserializationSchema(
+                                        rowType,
+                                        typeInfo,
+                                        rowType.getFieldNames().stream()
+                                                .map(f -> new String[] {f})
+                                                .toArray(String[][]::new)))
                         .build();
 
         List<RowData> results =

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/split/reader/deserializer/AvroToRowDataConvertersTest.java
@@ -52,7 +52,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("null_field", new NullType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"null_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"null_field\", \"type\": \"null\"}]";
@@ -72,7 +73,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("tinyint_field", new TinyIntType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"tinyint_field"}});
 
         // Create the AvroRecord
         String fieldString =
@@ -95,7 +97,9 @@ public class AvroToRowDataConvertersTest {
         UnsupportedOperationException exception =
                 assertThrows(
                         UnsupportedOperationException.class,
-                        () -> AvroToRowDataConverters.createRowConverter(rowType));
+                        () ->
+                                AvroToRowDataConverters.createRowConverter(
+                                        rowType, new String[][] {{"time_field"}}));
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "The TIME type within the Avro schema uses a precision of '9', which is higher than the maximum supported TIME precision 6.");
@@ -113,7 +117,9 @@ public class AvroToRowDataConvertersTest {
         UnsupportedOperationException exception =
                 assertThrows(
                         UnsupportedOperationException.class,
-                        () -> AvroToRowDataConverters.createRowConverter(rowType));
+                        () ->
+                                AvroToRowDataConverters.createRowConverter(
+                                        rowType, new String[][] {{"datetime_field"}}));
         Assertions.assertThat(exception)
                 .hasMessageContaining(
                         "The TIMESTAMP/DATETIME type within the Avro schema uses a precision of '9', which is higher than the maximum supported TIMESTAMP/DATETIME precision 6.");
@@ -127,7 +133,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("decimal_field", new DecimalType(34))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"decimal_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -164,7 +171,7 @@ public class AvroToRowDataConvertersTest {
                                         "map_field",
                                         new MapType(new VarCharType(), new VarCharType()))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(rowType, new String[][] {{"map_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -194,7 +201,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("datetime_field", new TimestampType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"datetime_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -222,7 +230,8 @@ public class AvroToRowDataConvertersTest {
                         Collections.singletonList(
                                 new RowField("timestamp_field", new TimestampType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"timestamp_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -280,7 +289,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("date_field", new DateType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"date_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -322,7 +332,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("time_field", new TimeType(3))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"time_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -361,7 +372,8 @@ public class AvroToRowDataConvertersTest {
         RowType rowType =
                 new RowType(Collections.singletonList(new RowField("time_field", new TimeType(6))));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"time_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n"
@@ -395,7 +407,8 @@ public class AvroToRowDataConvertersTest {
                 new RowType(
                         Collections.singletonList(new RowField("byte_field", new VarBinaryType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"byte_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"byte_field\", \"type\": \"bytes\"}]";
@@ -414,7 +427,8 @@ public class AvroToRowDataConvertersTest {
                 new RowType(
                         Collections.singletonList(new RowField("byte_field", new VarBinaryType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"byte_field"}});
         // Create the AvroRecord
         String fieldString =
                 " \"fields\": [\n" + "   {\"name\": \"byte_field\", \"type\": \"bytes\"}]";
@@ -439,7 +453,9 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("third_field", new DoubleType()),
                                 new RowField("first_field", new IntType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType,
+                        new String[][] {{"second_field"}, {"third_field"}, {"first_field"}});
         // Create the AvroRecord — fields in original table order
         String fieldString =
                 " \"fields\": [\n"
@@ -467,7 +483,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("third_field", new BigIntType()),
                                 new RowField("second_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"third_field"}, {"second_field"}});
         // Create the AvroRecord — all 4 columns in table order
         String fieldString =
                 " \"fields\": [\n"
@@ -497,7 +514,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("second_field", new BigIntType()),
                                 new RowField("first_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(rowType);
+                AvroToRowDataConverters.createRowConverter(
+                        rowType, new String[][] {{"second_field"}, {"first_field"}});
         // Create the AvroRecord — Avro has first before second (opposite of RowType)
         String fieldString =
                 " \"fields\": [\n"
@@ -530,7 +548,8 @@ public class AvroToRowDataConvertersTest {
                                 new RowField("second_field", innerRowType),
                                 new RowField("first_field", new VarCharType())));
         AvroToRowDataConverters.AvroToRowDataConverter converter =
-                AvroToRowDataConverters.createRowConverter(outerRowType);
+                AvroToRowDataConverters.createRowConverter(
+                        outerRowType, new String[][] {{"second_field"}, {"first_field"}});
         // Create the AvroRecord — first_field before second_field; first_inner before second_inner
         Schema innerAvroSchema =
                 org.apache.avro.SchemaBuilder.record("second_field")
@@ -570,5 +589,176 @@ public class AvroToRowDataConvertersTest {
         assertEquals(StringData.fromString("inner_b"), innerRow.getField(0));
         assertEquals(StringData.fromString("inner_a"), innerRow.getField(1));
         assertEquals(StringData.fromString("outer_a"), row.getField(1));
+    }
+
+    @Test
+    public void testNestedProjectionWalksAvroRecord() {
+        // Flat output type — what Flink's planner produces after nested projection.
+        RowType outputRowType =
+                new RowType(
+                        Arrays.asList(
+                                new RowField("event_name", new VarCharType()),
+                                new RowField("buyer_id", new VarCharType())));
+        String[][] paths = {{"payload", "event_name"}, {"payload", "buyer", "id"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        // Nested Avro record matching what BQ returns when given dotted-path selected_fields.
+        Schema buyerSchema =
+                org.apache.avro.SchemaBuilder.record("buyer")
+                        .fields()
+                        .requiredString("id")
+                        .endRecord();
+        Schema payloadSchema =
+                org.apache.avro.SchemaBuilder.record("payload")
+                        .fields()
+                        .requiredString("event_name")
+                        .name("buyer")
+                        .type(buyerSchema)
+                        .noDefault()
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("payload")
+                        .type(payloadSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord buyer = new GenericRecordBuilder(buyerSchema).set("id", "b-1").build();
+        GenericRecord payload =
+                new GenericRecordBuilder(payloadSchema)
+                        .set("event_name", "checkout")
+                        .set("buyer", buyer)
+                        .build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("payload", payload).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(
+                GenericRowData.of(StringData.fromString("checkout"), StringData.fromString("b-1")),
+                result);
+    }
+
+    @Test
+    public void testNestedProjectionTraversesNullableUnion() {
+        // Flat output for a path through a NULLABLE intermediate record.
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "city"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        // Inner address is nullable: ["null", record].
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(
+                                org.apache.avro.SchemaBuilder.unionOf()
+                                        .nullType()
+                                        .and()
+                                        .type(addressSchema)
+                                        .endUnion())
+                        .withDefault(null)
+                        .endRecord();
+        GenericRecord address =
+                new GenericRecordBuilder(addressSchema).set("city", "Toronto").build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", address).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(GenericRowData.of(StringData.fromString("Toronto")), result);
+    }
+
+    @Test
+    public void testNestedProjectionReturnsNullWhenIntermediateIsNull() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "city"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(
+                                org.apache.avro.SchemaBuilder.unionOf()
+                                        .nullType()
+                                        .and()
+                                        .type(addressSchema)
+                                        .endUnion())
+                        .withDefault(null)
+                        .endRecord();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", null).build();
+
+        Object result = converter.convert(outer);
+        assertEquals(GenericRowData.of((Object) null), result);
+    }
+
+    @Test
+    public void testNestedProjectionThrowsOnIntermediateFieldNotFound() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("leaf", new VarCharType())));
+        String[][] paths = {{"missing_intermediate", "leaf"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .requiredString("present")
+                        .endRecord();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("present", "x").build();
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> converter.convert(outer));
+        Assertions.assertThat(ex.getMessage())
+                .contains("missing_intermediate.leaf")
+                .contains("present");
+    }
+
+    @Test
+    public void testNestedProjectionThrowsOnLeafFieldNotFound() {
+        RowType outputRowType =
+                new RowType(Collections.singletonList(new RowField("city", new VarCharType())));
+        String[][] paths = {{"address", "missing_leaf"}};
+        AvroToRowDataConverters.AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(outputRowType, paths);
+
+        Schema addressSchema =
+                org.apache.avro.SchemaBuilder.record("address")
+                        .fields()
+                        .requiredString("city")
+                        .requiredString("zip")
+                        .endRecord();
+        Schema outerSchema =
+                org.apache.avro.SchemaBuilder.record("outer")
+                        .fields()
+                        .name("address")
+                        .type(addressSchema)
+                        .noDefault()
+                        .endRecord();
+        GenericRecord address =
+                new GenericRecordBuilder(addressSchema)
+                        .set("city", "Toronto")
+                        .set("zip", "M5V")
+                        .build();
+        GenericRecord outer = new GenericRecordBuilder(outerSchema).set("address", address).build();
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> converter.convert(outer));
+        Assertions.assertThat(ex.getMessage())
+                .contains("address.missing_leaf")
+                .contains("city")
+                .contains("zip");
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -16,14 +16,9 @@
 
 package com.google.cloud.flink.bigquery.table;
 
-import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -36,7 +31,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
-import com.google.cloud.flink.bigquery.sink.WriteMode;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroSchemaConvertor;
 import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -443,67 +437,6 @@ public class BigQueryDynamicTableFactoryTest {
 
         DataType dataType = SCHEMA.toPhysicalRowDataType();
         return new BigQueryDynamicTableSource(readOptions, dataType, null);
-    }
-
-    @Test
-    public void testIndirectWriteModeBatchModeCreatesSinkWithIndirectMode() {
-        Map<String, String> options = getRequiredOptions();
-        options.put(BigQueryConnectorOptions.WRITE_MODE.key(), "INDIRECT");
-        options.put(BigQueryConnectorOptions.GCS_TEMP_PATH.key(), "gs://bucket/tmp");
-
-        Configuration config = new Configuration();
-        config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
-
-        DynamicTableSink sink =
-                FactoryUtil.createDynamicTableSink(
-                        null,
-                        FactoryMocks.IDENTIFIER,
-                        new ResolvedCatalogTable(
-                                CatalogTable.newBuilder()
-                                        .schema(
-                                                org.apache.flink.table.api.Schema.newBuilder()
-                                                        .fromResolvedSchema(SCHEMA)
-                                                        .build())
-                                        .comment("mock sink")
-                                        .options(options)
-                                        .build(),
-                                SCHEMA),
-                        Collections.emptyMap(),
-                        config,
-                        getClass().getClassLoader(),
-                        false);
-
-        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
-        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
-        assertEquals(WriteMode.INDIRECT, dynamicSink.getSinkConfig().getWriteMode());
-        assertEquals("gs://bucket/tmp", dynamicSink.getSinkConfig().getGcsTempPath());
-    }
-
-    @Test
-    public void testDefaultWriteModeIsDirect() {
-        DynamicTableSink sink =
-                FactoryUtil.createDynamicTableSink(
-                        null,
-                        FactoryMocks.IDENTIFIER,
-                        new ResolvedCatalogTable(
-                                CatalogTable.newBuilder()
-                                        .schema(
-                                                org.apache.flink.table.api.Schema.newBuilder()
-                                                        .fromResolvedSchema(SCHEMA)
-                                                        .build())
-                                        .comment("mock sink")
-                                        .options(getRequiredOptions())
-                                        .build(),
-                                SCHEMA),
-                        Collections.emptyMap(),
-                        new Configuration(),
-                        getClass().getClassLoader(),
-                        false);
-
-        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
-        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
-        assertEquals(WriteMode.STORAGE_WRITE_API, dynamicSink.getSinkConfig().getWriteMode());
-        assertNull(dynamicSink.getSinkConfig().getGcsTempPath());
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -16,9 +16,14 @@
 
 package com.google.cloud.flink.bigquery.table;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -31,6 +36,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
+import com.google.cloud.flink.bigquery.sink.WriteMode;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroSchemaConvertor;
 import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -134,6 +140,94 @@ public class BigQueryDynamicTableFactoryTest {
 
         assertThat(bqSource.getReadOptions().getColumnNames())
                 .containsExactly("aaa", "ccc")
+                .inOrder();
+    }
+
+    @Test
+    public void testSupportsNestedProjection() throws IOException {
+        DynamicTableSource source = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
+        assertThat(((BigQueryDynamicTableSource) source).supportsNestedProjection()).isTrue();
+    }
+
+    @Test
+    public void testApplyProjectionNestedFieldsProducesDottedPaths() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "payload",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                                DataTypes.FIELD(
+                                                        "buyer",
+                                                        DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "id", DataTypes.STRING()),
+                                                                DataTypes.FIELD(
+                                                                        "email",
+                                                                        DataTypes.STRING())))))),
+                        null);
+
+        source.applyProjection(
+                new int[][] {{0, 0}, {0, 1, 0}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                        DataTypes.FIELD("id", DataTypes.STRING())));
+
+        assertThat(source.getReadOptions().getColumnNames())
+                .containsExactly("payload.event_name", "payload.buyer.id")
+                .inOrder();
+    }
+
+    @Test
+    public void testApplyProjectionMixedFlatAndNestedPreservesOrder() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                DataTypes.FIELD(
+                                        "address",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("city", DataTypes.STRING()),
+                                                DataTypes.FIELD("zip", DataTypes.STRING())))),
+                        null);
+
+        source.applyProjection(
+                new int[][] {{1, 0}, {0}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("city", DataTypes.STRING()),
+                        DataTypes.FIELD("id", DataTypes.BIGINT())));
+
+        assertThat(source.getReadOptions().getColumnNames())
+                .containsExactly("address.city", "id")
+                .inOrder();
+    }
+
+    @Test
+    public void testCopyAfterApplyProjectionPreservesPaths() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "payload",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                                DataTypes.FIELD("buyer_id", DataTypes.STRING())))),
+                        null);
+
+        source.applyProjection(
+                new int[][] {{0, 0}, {0, 1}},
+                DataTypes.ROW(
+                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                        DataTypes.FIELD("buyer_id", DataTypes.STRING())));
+
+        BigQueryDynamicTableSource copy = (BigQueryDynamicTableSource) source.copy();
+
+        assertThat(copy.getReadOptions().getColumnNames())
+                .containsExactly("payload.event_name", "payload.buyer_id")
                 .inOrder();
     }
 
@@ -349,6 +443,67 @@ public class BigQueryDynamicTableFactoryTest {
 
         DataType dataType = SCHEMA.toPhysicalRowDataType();
         return new BigQueryDynamicTableSource(readOptions, dataType, null);
+    }
+
+    @Test
+    public void testIndirectWriteModeBatchModeCreatesSinkWithIndirectMode() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigQueryConnectorOptions.WRITE_MODE.key(), "INDIRECT");
+        options.put(BigQueryConnectorOptions.GCS_TEMP_PATH.key(), "gs://bucket/tmp");
+
+        Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+
+        DynamicTableSink sink =
+                FactoryUtil.createDynamicTableSink(
+                        null,
+                        FactoryMocks.IDENTIFIER,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(
+                                                org.apache.flink.table.api.Schema.newBuilder()
+                                                        .fromResolvedSchema(SCHEMA)
+                                                        .build())
+                                        .comment("mock sink")
+                                        .options(options)
+                                        .build(),
+                                SCHEMA),
+                        Collections.emptyMap(),
+                        config,
+                        getClass().getClassLoader(),
+                        false);
+
+        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
+        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
+        assertEquals(WriteMode.INDIRECT, dynamicSink.getSinkConfig().getWriteMode());
+        assertEquals("gs://bucket/tmp", dynamicSink.getSinkConfig().getGcsTempPath());
+    }
+
+    @Test
+    public void testDefaultWriteModeIsDirect() {
+        DynamicTableSink sink =
+                FactoryUtil.createDynamicTableSink(
+                        null,
+                        FactoryMocks.IDENTIFIER,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(
+                                                org.apache.flink.table.api.Schema.newBuilder()
+                                                        .fromResolvedSchema(SCHEMA)
+                                                        .build())
+                                        .comment("mock sink")
+                                        .options(getRequiredOptions())
+                                        .build(),
+                                SCHEMA),
+                        Collections.emptyMap(),
+                        new Configuration(),
+                        getClass().getClassLoader(),
+                        false);
+
+        assertThat(sink).isInstanceOf(BigQueryDynamicTableSink.class);
+        BigQueryDynamicTableSink dynamicSink = (BigQueryDynamicTableSink) sink;
+        assertEquals(WriteMode.STORAGE_WRITE_API, dynamicSink.getSinkConfig().getWriteMode());
+        assertNull(dynamicSink.getSinkConfig().getGcsTempPath());
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSourceIntegrationTestCase.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSourceIntegrationTestCase.java
@@ -62,6 +62,8 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
     private static final int PARALLELISM = 1;
     private static final Integer TOTAL_ROW_COUNT_PER_STREAM = 10000;
     private static final Integer STREAM_COUNT = 2;
+    private static StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient
+            storageReadClient;
     private static final Schema AVRO_SCHEMA =
             SchemaBuilder.record("testRecord")
                     .fields()
@@ -159,14 +161,15 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
                                     .collect(Collectors.toList());
                         };
 
+        storageReadClient =
+                new StorageClientFaker.FakeBigQueryServices.FakeBigQueryStorageReadClient(
+                        StorageClientFaker.fakeReadSession(
+                                TOTAL_ROW_COUNT_PER_STREAM, STREAM_COUNT, AVRO_SCHEMA.toString()),
+                        dataGenerator);
         SerializableSupplier<BigQueryServices> testingServices =
-                StorageClientFaker.createTableReadOptions(
-                                TOTAL_ROW_COUNT_PER_STREAM,
-                                STREAM_COUNT,
-                                AVRO_SCHEMA.toString(),
-                                dataGenerator)
-                        .getBigQueryConnectOptions()
-                        .getTestingBigQueryServices();
+                () ->
+                        StorageClientFaker.FakeBigQueryTableServices.getInstance(
+                                storageReadClient, null);
 
         // init the testing services and inject them into the table factory
         BigQueryDynamicTableFactory.setTestingServices(testingServices);
@@ -228,6 +231,32 @@ public class BigQueryDynamicTableSourceIntegrationTestCase {
         List<String> expected = Stream.of("+I[0, 0.0, s0]").sorted().collect(Collectors.toList());
 
         Assertions.assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNestedProject() throws IOException {
+        tEnv.createTable("bigquery_source", createTestDDl(null));
+
+        Iterator<Row> collected =
+                tEnv.executeSql("SELECT reqSubRecord.reqBoolean FROM bigquery_source LIMIT 1")
+                        .collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        List<String> expected = Stream.of("+I[false]").sorted().collect(Collectors.toList());
+
+        Assertions.assertThat(result).isEqualTo(expected);
+        Assertions.assertThat(storageReadClient.getLastCreateReadSessionRequest()).isNotNull();
+        Assertions.assertThat(
+                        storageReadClient
+                                .getLastCreateReadSessionRequest()
+                                .getReadSession()
+                                .getReadOptions()
+                                .getSelectedFieldsList())
+                .containsExactly("reqSubRecord.reqBoolean");
     }
 
     @Test


### PR DESCRIPTION
Enables nested projection pushdown for the BigQuery connector by flipping `supportsNestedProjection()` to `true`. This will then cause our generated plans from the Flink table planner to include projected fields in its projection planning.

** Source Side**
This table plan is represented as `int[][] projectedFields` where `projectedFields[i]` represents the column, and `projectedFields[i][j]` represents the field index at level `j` in the row tree. We then build `String[][] fullyQualifiedPaths` which represents the same thing as projectedFields, but shows the full names of the path to the projected value. (This will then be saved and used later in the deserialization phase). Example mapping being `[0,1,0]` → `["payload","buyer","id"]`. Using this fullyQualifiedPaths, we then 'dot' separate and pass to BigQuery Storage API as `selected_fields` when creating a read session.            

** Deserializer Side**
We then get Avro records back with all fields from the projection in a nested structure. On the first record, as before we call `computeIndexMapping` to resolve where in each Avro message our field names exist. The only main difference is now on `createRowConverter` we can pass an optional arg `nestedPaths`. When present, `computeIndexMapping` walks each path through the Avro schema's nested records (transparently unwrapping ["null", T] nullable unions) and resolves it to an int[] of field positions per output column. Each path can either reach a leaf (returning a scalar via the appropriate converter) or stop at a parent struct, in which case BQ returns the whole sub-record and the converter walks it via its existing recursive ROW case.

*Note*: Chose to use the fully qualified names instead of indices on our deserialization because there isn't any explicit guarantee on our Avro field ordering we get back, so by using the qualified names (similar to how it was done before in flat case), we ensure we are indexing only after obtaining via field name.



*Top-hatting* 

``` java
/**
 * Schema:
 * id        INTEGER  NULLABLE
 * name      STRING   NULLABLE
 * address   RECORD   NULLABLE
 *   city      STRING   NULLABLE
 *   country   RECORD   NULLABLE
 *     code      STRING   NULLABLE
 *     name      STRING   NULLABLE
 *   current   BOOLEAN  NULLABLE
 */
  public static void main(String[] args) {                                                                                                                                                                                         
      var env = StreamExecutionEnvironment.createLocalEnvironment(new Configuration());                                                                                                                                            
      var t = StreamTableEnvironment.create(env);                                                                                                                                                                                  
                                                                                                                                                                                                                                   
      //   id BIGINT, name STRING,                                                                                                                                                                                                 
      //   address ROW<city STRING, country ROW<code STRING, name STRING>, `current` BOOLEAN>                                                                                                                                      
      t.executeSql(                                                                                                                                                                                                                
          "CREATE TABLE nested_tbl ("
              + "  id BIGINT, name STRING,"                                                                                                                                                                                        
              + "  address ROW<city STRING, country ROW<code STRING, name STRING>, `current` BOOLEAN>"                                                                                                                             
              + ") WITH ('connector'='bigquery',"                                                                                                                                                                                  
              + "        'project'='xxx',"                                                                                                                                                                         
              + "        'dataset'='xxx',"                                                                                                                                                                                      
              + "        'table'='xxx')");          

      // Mix: top-level scalar + 1-level nested leaf + 2-level nested leaf                                                                                                                                                         
      t.executeSql("EXPLAIN SELECT id, name, address.city, address.country.code FROM nested_tbl LIMIT 5").print();
      t.executeSql("SELECT id, name, address.city, address.country.code FROM nested_tbl LIMIT 5").print();                                                                                                                         
  } 
```