### PR TITLE
Indirect writes (6/8): large-workload (>15 TB / >10K files) support

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.AvroRows;
 import com.google.cloud.bigquery.storage.v1.AvroSchema;
@@ -295,6 +296,12 @@ public class StorageClientFaker {
             public Job waitForJob(Job job) throws InterruptedException {
                 throw new UnsupportedOperationException(
                         "waitForJob not supported in flink-1.17 tests");
+            }
+
+            @Override
+            public boolean deleteTable(TableId tableId) {
+                throw new UnsupportedOperationException(
+                        "deleteTable not supported in flink-1.17 tests");
             }
         }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
@@ -47,7 +47,12 @@ import org.slf4j.LoggerFactory;
  *       --project {required; GCP project ID} <br>
  *       --dataset {required; BigQuery dataset name} <br>
  *       --table {required; BigQuery table name} <br>
- *       --temp-gcs-path {required; GCS path for staging files}
+ *       --temp-gcs-path {required; GCS path for staging files} <br>
+ *       --temp-project {required; GCP project that owns --temp-dataset} <br>
+ *       --temp-dataset {required; BigQuery dataset for temporary tables created during
+ *       multi-partition loads. Must exist in --temp-project. Recommended: configure a default
+ *       tableExpirationMs on this dataset so any temp tables left behind by failed jobs are
+ *       auto-deleted by BigQuery.}
  * </ul>
  *
  * <p>Requires the GCS Hadoop connector plugin ({@code flink-gs-fs-hadoop}) to be installed in the
@@ -60,14 +65,16 @@ public class IndirectWriteExample {
     public static void main(String[] args) {
         final ParameterTool params = ParameterTool.fromArgs(args);
 
-        if (params.getNumberOfParameters() < 4) {
+        if (params.getNumberOfParameters() < 6) {
             LOG.error(
                     "Missing parameters!\n"
                             + "Usage: IndirectWriteExample"
                             + " --project <GCP project>"
                             + " --dataset <BigQuery dataset>"
                             + " --table <BigQuery table>"
-                            + " --temp-gcs-path <GCS path for staging files>");
+                            + " --temp-gcs-path <GCS path for staging files>"
+                            + " --temp-project <GCP project for temp tables>"
+                            + " --temp-dataset <BigQuery dataset for temp tables>");
             return;
         }
 
@@ -75,6 +82,8 @@ public class IndirectWriteExample {
         String dataset = params.getRequired("dataset");
         String table = params.getRequired("table");
         String tempGcsPath = params.getRequired("temp-gcs-path");
+        String tempProject = params.getRequired("temp-project");
+        String tempDataset = params.getRequired("temp-dataset");
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
@@ -102,9 +111,11 @@ public class IndirectWriteExample {
                                 + "    'dataset' = '%s',"
                                 + "    'table' = '%s',"
                                 + "    'write.mode' = 'INDIRECT',"
-                                + "    'write.indirect.temp-gcs-path' = '%s'"
+                                + "    'write.indirect.temp-gcs-path' = '%s',"
+                                + "    'write.indirect.temp-bigquery-project' = '%s',"
+                                + "    'write.indirect.temp-bigquery-dataset' = '%s'"
                                 + ")",
-                        project, dataset, table, tempGcsPath));
+                        project, dataset, table, tempGcsPath, tempProject, tempDataset));
 
         String insertSql =
                 "INSERT INTO bigquery_sink VALUES"

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -84,6 +84,8 @@ final class BigQueryIndirectSink<IN>
 
     private final BigQueryConnectOptions connectOptions;
     private final UUID uuid;
+    private final String tempProject;
+    private final String tempDataset;
     private final Path gcsBasePath;
     private final FormatOptions formatOptions;
     private final FileSink<IN> fileSink;
@@ -96,12 +98,16 @@ final class BigQueryIndirectSink<IN>
     BigQueryIndirectSink(final BigQuerySinkConfig<IN> config, final UUID uuid) {
         this.connectOptions = config.getConnectOptions();
         this.uuid = uuid;
+        this.tempProject = config.getTempProject();
+        this.tempDataset = config.getTempDataset();
         this.gcsBasePath = new Path(config.getTempGcsPath(), uuid.toString());
         this.formatOptions = config.getFormatOptions();
 
         LOG.info(
-                "Creating BigQueryIndirectSink: uuid={}, gcsBasePath={}, table={}.{}.{}",
+                "Creating BigQueryIndirectSink: uuid={}, tempProject={}, tempDataset={}, gcsBasePath={}, table={}.{}.{}",
                 uuid,
+                tempProject,
+                tempDataset,
                 gcsBasePath,
                 connectOptions.getProjectId(),
                 connectOptions.getDataset(),
@@ -158,7 +164,12 @@ final class BigQueryIndirectSink<IN>
                 .global()
                 .flatMap(
                         new BigQueryLoadJobOperator(
-                                connectOptions, uuid, gcsBasePath, formatOptions))
+                                connectOptions,
+                                uuid,
+                                tempProject,
+                                tempDataset,
+                                gcsBasePath,
+                                formatOptions))
                 .name("BigQueryLoadJobOperator")
                 .forceNonParallel();
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -45,6 +45,8 @@ public class BigQuerySink {
         if (sinkConfig.getWriteMode() == WriteMode.INDIRECT) {
             BigQuerySinkConfig.validateIndirect(
                     sinkConfig.getTempGcsPath(),
+                    sinkConfig.getTempProject(),
+                    sinkConfig.getTempDataset(),
                     sinkConfig.getBulkWriterFactory(),
                     sinkConfig.getFormatOptions(),
                     sinkConfig.isCdcEnabled(),

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -81,6 +81,8 @@ public class BigQuerySinkConfig<IN> {
     private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
     private final WriteMode writeMode;
     private final String tempGcsPath;
+    private final String tempProject;
+    private final String tempDataset;
     private final BulkWriter.Factory<IN> bulkWriterFactory;
     private final FormatOptions formatOptions;
 
@@ -109,6 +111,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcChangeTypeProvider,
                 writeMode,
                 tempGcsPath,
+                tempProject,
+                tempDataset,
                 bulkWriterFactory,
                 formatOptions);
     }
@@ -150,6 +154,8 @@ public class BigQuerySinkConfig<IN> {
                         this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider()))
                 && (this.writeMode == object.writeMode)
                 && (Objects.equals(this.tempGcsPath, object.tempGcsPath))
+                && (Objects.equals(this.tempProject, object.tempProject))
+                && (Objects.equals(this.tempDataset, object.tempDataset))
                 && (Objects.equals(this.bulkWriterFactory, object.bulkWriterFactory))
                 && (Objects.equals(this.formatOptions, object.formatOptions)));
     }
@@ -173,6 +179,8 @@ public class BigQuerySinkConfig<IN> {
             CdcChangeTypeProvider<?> cdcChangeTypeProvider,
             WriteMode writeMode,
             String tempGcsPath,
+            String tempProject,
+            String tempDataset,
             BulkWriter.Factory<IN> bulkWriterFactory,
             FormatOptions formatOptions) {
         this.connectOptions = connectOptions;
@@ -193,6 +201,8 @@ public class BigQuerySinkConfig<IN> {
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
         this.writeMode = writeMode;
         this.tempGcsPath = tempGcsPath;
+        this.tempProject = tempProject;
+        this.tempDataset = tempDataset;
         this.bulkWriterFactory = bulkWriterFactory;
         this.formatOptions = formatOptions;
     }
@@ -269,6 +279,14 @@ public class BigQuerySinkConfig<IN> {
         return tempGcsPath;
     }
 
+    public String getTempProject() {
+        return tempProject;
+    }
+
+    public String getTempDataset() {
+        return tempDataset;
+    }
+
     public BulkWriter.Factory<IN> getBulkWriterFactory() {
         return bulkWriterFactory;
     }
@@ -304,6 +322,8 @@ public class BigQuerySinkConfig<IN> {
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
         private WriteMode writeMode = WriteMode.STORAGE_WRITE_API;
         private String tempGcsPath;
+        private String tempProject;
+        private String tempDataset;
         private BulkWriter.Factory<IN> bulkWriterFactory;
         private FormatOptions formatOptions;
 
@@ -403,6 +423,16 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> tempProject(String tempProject) {
+            this.tempProject = tempProject;
+            return this;
+        }
+
+        public Builder<IN> tempDataset(String tempDataset) {
+            this.tempDataset = tempDataset;
+            return this;
+        }
+
         public Builder<IN> bulkWriterFactory(BulkWriter.Factory<IN> bulkWriterFactory) {
             this.bulkWriterFactory = bulkWriterFactory;
             return this;
@@ -417,6 +447,8 @@ public class BigQuerySinkConfig<IN> {
             if (writeMode == WriteMode.INDIRECT) {
                 validateIndirect(
                         tempGcsPath,
+                        tempProject,
+                        tempDataset,
                         bulkWriterFactory,
                         formatOptions,
                         cdcEnabled,
@@ -443,6 +475,8 @@ public class BigQuerySinkConfig<IN> {
                     cdcChangeTypeProvider,
                     writeMode,
                     tempGcsPath,
+                    tempProject,
+                    tempDataset,
                     bulkWriterFactory,
                     formatOptions);
         }
@@ -469,7 +503,9 @@ public class BigQuerySinkConfig<IN> {
             String cdcMaxStaleness,
             CdcChangeTypeProvider<RowData> cdcChangeTypeProvider,
             WriteMode writeMode,
-            String tempGcsPath) {
+            String tempGcsPath,
+            String tempProject,
+            String tempDataset) {
         boolean indirect = writeMode == WriteMode.INDIRECT;
         BulkWriter.Factory<RowData> bulkWriterFactory =
                 indirect ? RowDataParquetWriterFactory.create((RowType) logicalType) : null;
@@ -502,6 +538,8 @@ public class BigQuerySinkConfig<IN> {
                 cdcChangeTypeProvider,
                 writeMode,
                 tempGcsPath,
+                tempProject,
+                tempDataset,
                 bulkWriterFactory,
                 formatOptions);
     }
@@ -513,12 +551,20 @@ public class BigQuerySinkConfig<IN> {
      */
     static void validateIndirect(
             String tempGcsPath,
+            String tempProject,
+            String tempDataset,
             BulkWriter.Factory<?> bulkWriterFactory,
             FormatOptions formatOptions,
             boolean cdcEnabled,
             boolean enableTableCreation) {
         if (tempGcsPath == null || tempGcsPath.isEmpty()) {
             throw new IllegalArgumentException("tempGcsPath is required for INDIRECT write mode");
+        }
+        if (tempProject == null || tempProject.isEmpty()) {
+            throw new IllegalArgumentException("tempProject is required for INDIRECT write mode");
+        }
+        if (tempDataset == null || tempDataset.isEmpty()) {
+            throw new IllegalArgumentException("tempDataset is required for INDIRECT write mode");
         }
         if (bulkWriterFactory == null) {
             throw new IllegalArgumentException(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperator.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperator.java
@@ -24,10 +24,11 @@ import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.PendingFileRecoverable;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.function.SerializableSupplier;
 
+import com.google.cloud.bigquery.CopyJobConfiguration;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
@@ -42,6 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,11 +70,40 @@ public class BigQueryLoadJobOperator
     private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 10L;
     private static final ThreadFactory EXECUTOR_THREAD_FACTORY = r -> new Thread(r, "bq-load");
 
+    /**
+     * Default maximum source URIs per BigQuery load job. See <a
+     * href="https://cloud.google.com/bigquery/quotas#load_jobs">BigQuery load job quotas</a>.
+     */
+    static final int DEFAULT_MAX_FILES_PER_LOAD_JOB = 10_000;
+
+    /**
+     * Default maximum data per BigQuery load job (15 TB). See <a
+     * href="https://cloud.google.com/bigquery/quotas#load_jobs">BigQuery load job quotas</a>.
+     */
+    static final long DEFAULT_MAX_BYTES_PER_LOAD_JOB = 15L * 1024 * 1024 * 1024 * 1024;
+
+    /**
+     * Format for per-checkpoint job/table IDs: {@code <prefix>_<jobIdHex>_<uuid>_c<checkpointId>}.
+     */
+    private static final String CHECKPOINT_ID_FORMAT = "%s_%s_%s_c%d";
+
+    /** Per-partition variant of {@link #CHECKPOINT_ID_FORMAT}: appends {@code _p<idx>}. */
+    private static final String PARTITION_ID_FORMAT = CHECKPOINT_ID_FORMAT + "_p%d";
+
+    private static final String LOAD_JOB_ID_PREFIX = "flink-bq-load";
+    private static final String TEMP_TABLE_NAME_PREFIX = "flink-bq-tmp";
+    private static final String TEMP_LOAD_JOB_ID_PREFIX = "flink-bq-tmp-load";
+    private static final String COPY_JOB_ID_PREFIX = "flink-bq-copy";
+
     private final BigQueryConnectOptions connectOptions;
     private final UUID uuid;
+    private final String tempProject;
+    private final String tempDataset;
     private final SerializableSupplier<ExecutorService> executorServiceSupplier;
     private final SerializableSupplier<FileSystem> fileSystemSupplier;
     private final FormatOptions formatOptions;
+    private final int maxFilesPerLoadJob;
+    private final long maxBytesPerLoadJob;
 
     private transient BigQueryServices.QueryDataClient queryClient;
     private transient String jobIdHex;
@@ -84,11 +116,15 @@ public class BigQueryLoadJobOperator
     public BigQueryLoadJobOperator(
             final BigQueryConnectOptions connectOptions,
             final UUID uuid,
+            final String tempProject,
+            final String tempDataset,
             final Path gcsBasePath,
             final FormatOptions formatOptions) {
         this(
                 connectOptions,
                 uuid,
+                tempProject,
+                tempDataset,
                 () -> Executors.newFixedThreadPool(EXECUTOR_PARALLELISM, EXECUTOR_THREAD_FACTORY),
                 () -> {
                     try {
@@ -98,21 +134,31 @@ public class BigQueryLoadJobOperator
                                 "Failed to resolve FileSystem for " + gcsBasePath, e);
                     }
                 },
-                formatOptions);
+                formatOptions,
+                DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                DEFAULT_MAX_BYTES_PER_LOAD_JOB);
     }
 
     @VisibleForTesting
     BigQueryLoadJobOperator(
             final BigQueryConnectOptions connectOptions,
             final UUID uuid,
+            final String tempProject,
+            final String tempDataset,
             final SerializableSupplier<ExecutorService> executorServiceSupplier,
             final SerializableSupplier<FileSystem> fileSystemSupplier,
-            final FormatOptions formatOptions) {
+            final FormatOptions formatOptions,
+            final int maxFilesPerLoadJob,
+            final long maxBytesPerLoadJob) {
         this.connectOptions = connectOptions;
         this.uuid = uuid;
+        this.tempProject = tempProject;
+        this.tempDataset = tempDataset;
         this.executorServiceSupplier = executorServiceSupplier;
         this.fileSystemSupplier = fileSystemSupplier;
         this.formatOptions = formatOptions;
+        this.maxFilesPerLoadJob = maxFilesPerLoadJob;
+        this.maxBytesPerLoadJob = maxBytesPerLoadJob;
     }
 
     @Override
@@ -155,64 +201,208 @@ public class BigQueryLoadJobOperator
         state.add(value);
 
         if (state.isComplete()) {
-            submitLoadJobForCheckpoint(checkpointId, state.collectFiles());
+            submitLoadJobsForCheckpoint(checkpointId, state.collectFiles());
             checkpoints.remove(checkpointId);
         }
     }
 
     /**
-     * Submits a load job for a single checkpoint's files. No-ops if {@code pendingFiles} is empty.
+     * Submits load job(s) for a single checkpoint's files. No-ops if {@code pendingFiles} is empty.
+     *
+     * <p>BigQuery load jobs cap at {@link #maxFilesPerLoadJob} source URIs and {@link
+     * #maxBytesPerLoadJob} bytes. When a single checkpoint exceeds either limit the files are
+     * partitioned, each partition is loaded into its own temp table, and a single COPY job appends
+     * all temp tables atomically into the final table.
      */
-    private void submitLoadJobForCheckpoint(
-            final long checkpointId,
-            final List<InProgressFileWriter.PendingFileRecoverable> pendingFiles)
+    private void submitLoadJobsForCheckpoint(
+            final long checkpointId, final List<PendingFileRecoverable> pendingFiles)
             throws InterruptedException, ExecutionException {
 
         if (pendingFiles.isEmpty()) {
             LOG.info("No files to load for checkpoint {}; skipping load job", checkpointId);
         } else {
             final long totalBytes =
-                    pendingFiles.stream()
-                            .mapToLong(InProgressFileWriter.PendingFileRecoverable::getSize)
-                            .sum();
+                    pendingFiles.stream().mapToLong(PendingFileRecoverable::getSize).sum();
             final TableId tableId =
                     TableId.of(
                             connectOptions.getProjectId(),
                             connectOptions.getDataset(),
                             connectOptions.getTable());
-            final String jobId = generateJobId(checkpointId);
-            final List<String> gcsUris =
-                    pendingFiles.stream()
-                            .map(file -> file.getPath().toUri().toString())
-                            .collect(Collectors.toList());
+
+            final List<List<PendingFileRecoverable>> partitions = partitionFiles(pendingFiles);
 
             LOG.info(
-                    "Load job {} for checkpoint {} into {}: {} files, {} bytes",
-                    jobId,
+                    "Checkpoint {} into {}: {} files, {} bytes, {} partition(s)",
                     checkpointId,
-                    tableId,
+                    formatTableId(tableId),
                     pendingFiles.size(),
-                    totalBytes);
+                    totalBytes,
+                    partitions.size());
 
-            final JobConfiguration config =
-                    LoadJobConfiguration.newBuilder(tableId, gcsUris)
-                            .setFormatOptions(formatOptions)
-                            // Parquet/Avro decimal logical types map to multiple BQ types
-                            // depending on (precision, scale). The default order
-                            // [NUMERIC, BIGNUMERIC, STRING] picks NUMERIC for any decimal with
-                            // precision ≤ 38, even when scale > 9, which mismatches a target
-                            // BIGNUMERIC column. Prefer BIGNUMERIC first so the column type is
-                            // preserved when source decimals have scale > 9.
-                            .setDecimalTargetTypes(List.of("BIGNUMERIC", "NUMERIC", "STRING"))
-                            // Indirect mode requires the destination table to exist
-                            // (validateIndirect rejects enableTableCreation); enforce server-side.
-                            .setCreateDisposition(JobInfo.CreateDisposition.CREATE_NEVER)
-                            .build();
-
-            submitAndAwaitJob(jobId, config);
+            if (partitions.size() == 1) {
+                submitDirectLoad(checkpointId, tableId, partitions.get(0));
+            } else {
+                submitMultiPartitionLoad(checkpointId, tableId, partitions);
+            }
 
             bestEffortCleanupGcsFiles(pendingFiles);
         }
+    }
+
+    /** Splits a list of files into partitions that respect both file-count and byte-size limits. */
+    private List<List<PendingFileRecoverable>> partitionFiles(
+            final List<PendingFileRecoverable> files) {
+
+        // Files are sorted by GCS path before partitioning so that retries of the same checkpoint
+        // produce the same partition shape. Without a stable order, a retry could place a file into
+        // a different partition than the original attempt did, and - because load jobs are
+        // idempotent on jobId, not on content - the COPY job would then double-count any file the
+        // first attempt had already loaded into a different partition's temp table.
+        final List<PendingFileRecoverable> sortedFiles =
+                files.stream()
+                        .sorted(Comparator.comparing(file -> file.getPath().toUri().toString()))
+                        .collect(Collectors.toList());
+
+        // bin-pack files into partition
+        final List<List<PendingFileRecoverable>> partitions = new ArrayList<>();
+        List<PendingFileRecoverable> currentPartition = new ArrayList<>();
+        long currentBytes = 0L;
+        for (final PendingFileRecoverable file : sortedFiles) {
+            if (shouldStartNewPartition(currentPartition, currentBytes, file.getSize())) {
+                partitions.add(currentPartition);
+                currentPartition = new ArrayList<>();
+                currentBytes = 0L;
+            }
+            currentPartition.add(file);
+            currentBytes += file.getSize();
+        }
+        partitions.add(currentPartition);
+
+        return partitions;
+    }
+
+    private boolean shouldStartNewPartition(
+            final List<PendingFileRecoverable> currentPartition,
+            final long currentBytes,
+            final long nextFileSize) {
+        return !currentPartition.isEmpty()
+                && (currentPartition.size() >= maxFilesPerLoadJob
+                        || currentBytes + nextFileSize > maxBytesPerLoadJob);
+    }
+
+    /** Single-partition path: load all files directly into the final table. */
+    private void submitDirectLoad(
+            final long checkpointId,
+            final TableId tableId,
+            final List<PendingFileRecoverable> partitionFiles) {
+
+        final String jobId = generateJobId(checkpointId);
+        final List<String> gcsUris = toGcsUris(partitionFiles);
+        final JobConfiguration config =
+                applyFormatOptions(LoadJobConfiguration.newBuilder(tableId, gcsUris))
+                        // Indirect mode requires the destination table to exist
+                        // (validateIndirect rejects enableTableCreation); enforce server-side.
+                        .setCreateDisposition(JobInfo.CreateDisposition.CREATE_NEVER)
+                        .build();
+
+        submitAndAwaitJob(jobId, config);
+    }
+
+    /**
+     * Multi-partition path: load each partition into its own temp table, atomically copy all temp
+     * tables into the final table, then delete temp tables.
+     */
+    private void submitMultiPartitionLoad(
+            final long checkpointId,
+            final TableId finalTableId,
+            final List<List<PendingFileRecoverable>> partitions)
+            throws ExecutionException, InterruptedException {
+
+        final List<TableId> tempTableIds = new ArrayList<>(partitions.size());
+        final List<CompletableFuture<Void>> tempLoadFutures = new ArrayList<>(partitions.size());
+
+        for (int partitionIndex = 0; partitionIndex < partitions.size(); partitionIndex++) {
+            final List<PendingFileRecoverable> partitionFiles = partitions.get(partitionIndex);
+            final TableId tempTableId =
+                    TableId.of(
+                            tempProject,
+                            tempDataset,
+                            String.format(
+                                    PARTITION_ID_FORMAT,
+                                    TEMP_TABLE_NAME_PREFIX,
+                                    jobIdHex,
+                                    uuid,
+                                    checkpointId,
+                                    partitionIndex));
+            final String tempLoadJobId =
+                    String.format(
+                            PARTITION_ID_FORMAT,
+                            TEMP_LOAD_JOB_ID_PREFIX,
+                            jobIdHex,
+                            uuid,
+                            checkpointId,
+                            partitionIndex);
+            final List<String> gcsUris = toGcsUris(partitionFiles);
+
+            LOG.info(
+                    "Loading partition {} ({} files) into temp table {}",
+                    partitionIndex,
+                    partitionFiles.size(),
+                    formatTableId(tempTableId));
+
+            final JobConfiguration tempLoadConfig =
+                    applyFormatOptions(LoadJobConfiguration.newBuilder(tempTableId, gcsUris))
+                            .setWriteDisposition(JobInfo.WriteDisposition.WRITE_TRUNCATE)
+                            .setCreateDisposition(JobInfo.CreateDisposition.CREATE_IF_NEEDED)
+                            .build();
+
+            tempTableIds.add(tempTableId);
+            tempLoadFutures.add(
+                    CompletableFuture.runAsync(
+                            () -> submitAndAwaitJob(tempLoadJobId, tempLoadConfig),
+                            executorService));
+        }
+
+        // Submit + wait on all temp loads concurrently. If any fails, surface its
+        // exception; the others continue running but their results are ignored — temp
+        // loads are idempotent on jobId, so a Flink retry will re-attach to any
+        // in-flight or already-completed BQ jobs without double-loading.
+        CompletableFuture.allOf(tempLoadFutures.toArray(new CompletableFuture[0])).get();
+
+        final String copyJobId =
+                String.format(
+                        CHECKPOINT_ID_FORMAT, COPY_JOB_ID_PREFIX, jobIdHex, uuid, checkpointId);
+        final JobConfiguration copyConfig =
+                CopyJobConfiguration.newBuilder(finalTableId, tempTableIds)
+                        .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+                        // Indirect mode requires the destination table to exist
+                        // (validateIndirect rejects enableTableCreation); enforce server-side.
+                        .setCreateDisposition(JobInfo.CreateDisposition.CREATE_NEVER)
+                        .build();
+        submitAndAwaitJob(copyJobId, copyConfig);
+
+        bestEffortCleanupTempTables(tempTableIds);
+    }
+
+    /**
+     * Apply load options shared by all load jobs (direct + temp-table).
+     *
+     * <p>{@code decimalTargetTypes}: Parquet/Avro decimal logical types map to multiple BQ types
+     * depending on (precision, scale). The default order [NUMERIC, BIGNUMERIC, STRING] picks
+     * NUMERIC for any decimal with precision ≤38, even when scale > 9, which mismatches a target
+     * BIGNUMERIC column. Prefer BIGNUMERIC first so the column type is preserved when source
+     * decimals have scale > 9.
+     */
+    private LoadJobConfiguration.Builder applyFormatOptions(
+            final LoadJobConfiguration.Builder builder) {
+        return builder.setFormatOptions(formatOptions)
+                .setDecimalTargetTypes(List.of("BIGNUMERIC", "NUMERIC", "STRING"));
+    }
+
+    private static List<String> toGcsUris(final List<PendingFileRecoverable> files) {
+        return files.stream()
+                .map(file -> file.getPath().toUri().toString())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -261,12 +451,12 @@ public class BigQueryLoadJobOperator
      * IDs.
      */
     private String generateJobId(final long checkpointId) {
-        return String.format("flink-bq-load_%s_%s_c%d", jobIdHex, uuid, checkpointId);
+        return String.format(
+                CHECKPOINT_ID_FORMAT, LOAD_JOB_ID_PREFIX, jobIdHex, uuid, checkpointId);
     }
 
     /** Delete GCS files after successful load. Best-effort, concurrent operation. */
-    private void bestEffortCleanupGcsFiles(
-            final List<InProgressFileWriter.PendingFileRecoverable> pendingFiles)
+    private void bestEffortCleanupGcsFiles(final List<PendingFileRecoverable> pendingFiles)
             throws ExecutionException, InterruptedException {
         final AtomicInteger cleaned = new AtomicInteger(0);
         final AtomicInteger failures = new AtomicInteger(0);
@@ -299,7 +489,7 @@ public class BigQueryLoadJobOperator
 
     private void deleteSingleFile(
             final FileSystem fs,
-            final InProgressFileWriter.PendingFileRecoverable file,
+            final PendingFileRecoverable file,
             final AtomicInteger cleaned,
             final AtomicInteger failures) {
         final Path filePath = file.getPath();
@@ -315,5 +505,58 @@ public class BigQueryLoadJobOperator
             LOG.warn("Error deleting file {}", filePath, e);
             failures.incrementAndGet();
         }
+    }
+
+    /** Delete temp tables after a successful COPY job. Best-effort, concurrent operation. */
+    private void bestEffortCleanupTempTables(final List<TableId> tempTableIds)
+            throws ExecutionException, InterruptedException {
+        final AtomicInteger cleaned = new AtomicInteger(0);
+        final AtomicInteger failures = new AtomicInteger(0);
+
+        try {
+            CompletableFuture.allOf(
+                            tempTableIds.stream()
+                                    .map(
+                                            tempTableId ->
+                                                    CompletableFuture.runAsync(
+                                                            () ->
+                                                                    deleteSingleTempTable(
+                                                                            tempTableId,
+                                                                            cleaned,
+                                                                            failures),
+                                                            executorService))
+                                    .toArray(CompletableFuture[]::new))
+                    .get(5, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            LOG.warn("Temp table cleanup timed out after 5 minutes; some tables may remain.");
+        }
+
+        LOG.info(
+                "Temp table cleanup: {}/{} tables deleted, {} failures",
+                cleaned.get(),
+                tempTableIds.size(),
+                failures.get());
+    }
+
+    private void deleteSingleTempTable(
+            final TableId tempTableId, final AtomicInteger cleaned, final AtomicInteger failures) {
+        try {
+            final boolean deleted = queryClient.deleteTable(tempTableId);
+            if (deleted) {
+                LOG.debug("Deleted temp table: {}", formatTableId(tempTableId));
+            } else {
+                LOG.warn(
+                        "Temp table {} not found for deletion (already cleaned up?)",
+                        formatTableId(tempTableId));
+            }
+            cleaned.incrementAndGet();
+        } catch (Exception e) {
+            LOG.warn("Error deleting temp table {}", formatTableId(tempTableId), e);
+            failures.incrementAndGet();
+        }
+    }
+
+    private static String formatTableId(final TableId tableId) {
+        return tableId.getProject() + "." + tableId.getDataset() + "." + tableId.getTable();
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -89,6 +89,8 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
         additionalOptions.add(BigQueryConnectorOptions.WRITE_MODE);
         additionalOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
+        additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
+        additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
 
         return additionalOptions;
     }
@@ -125,6 +127,8 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
         forwardOptions.add(BigQueryConnectorOptions.WRITE_MODE);
         forwardOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
+        forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
+        forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
 
         return forwardOptions;
     }
@@ -186,6 +190,8 @@ public class BigQueryDynamicTableFactory
                 configProvider.getCdcMaxStaleness().orElse(null),
                 null,
                 configProvider.getWriteMode(),
-                configProvider.getTempGcsPath().orElse(null));
+                configProvider.getTempGcsPath().orElse(null),
+                configProvider.getTempProject().orElse(null),
+                configProvider.getTempDataset().orElse(null));
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -75,6 +75,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -96,7 +98,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             String cdcMaxStaleness,
             CdcChangeTypeProvider<RowData> cdcChangeTypeProvider,
             WriteMode writeMode,
-            String tempGcsPath) {
+            String tempGcsPath,
+            String tempProject,
+            String tempDataset) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
         this.sinkConfig =
@@ -119,7 +123,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                                 ? RowDataCdcChangeTypeProvider.getInstance()
                                 : cdcChangeTypeProvider,
                         writeMode,
-                        tempGcsPath);
+                        tempGcsPath,
+                        tempProject,
+                        tempDataset);
     }
 
     @Override
@@ -184,7 +190,9 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.getCdcMaxStaleness(),
                 (CdcChangeTypeProvider<RowData>) sinkConfig.getCdcChangeTypeProvider(),
                 this.sinkConfig.getWriteMode(),
-                this.sinkConfig.getTempGcsPath());
+                this.sinkConfig.getTempGcsPath(),
+                this.sinkConfig.getTempProject(),
+                this.sinkConfig.getTempDataset());
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -317,4 +317,35 @@ public class BigQueryConnectorOptions {
                     .noDefaultValue()
                     .withDescription(
                             "GCS path for temporary files (required for INDIRECT write mode)");
+
+    /**
+     * [REQUIRED for INDIRECT mode] GCP project for temporary tables created during multi-partition
+     * loads. The dataset given by {@link #WRITE_TEMP_DATASET} must exist in this project.
+     */
+    public static final ConfigOption<String> WRITE_TEMP_PROJECT =
+            ConfigOptions.key("write.indirect.temp-bigquery-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "GCP project for temp tables created during multi-partition loads "
+                                    + "(required for INDIRECT write mode). The temp dataset must "
+                                    + "exist in this project.");
+
+    /**
+     * [REQUIRED for INDIRECT mode] Dataset for temporary tables created during multi-partition
+     * loads. Must already exist in the project given by {@link #WRITE_TEMP_PROJECT}. <br>
+     * Recommended: configure a default {@code tableExpirationMs} on this dataset (e.g. 24 h) so any
+     * temp tables left behind by failed jobs are auto-deleted by BigQuery.
+     */
+    public static final ConfigOption<String> WRITE_TEMP_DATASET =
+            ConfigOptions.key("write.indirect.temp-bigquery-dataset")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Dataset for temporary tables created during multi-partition loads "
+                                    + "(required for INDIRECT write mode). Must exist in the "
+                                    + "project given by write.indirect.temp-bigquery-project. "
+                                    + "Recommended: set a default tableExpirationMs on this "
+                                    + "dataset so BigQuery auto-deletes any temp tables left "
+                                    + "behind by failed jobs.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -135,6 +135,14 @@ public class BigQueryTableConfigurationProvider {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.TEMP_GCS_PATH));
     }
 
+    public Optional<String> getTempProject() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.WRITE_TEMP_PROJECT));
+    }
+
+    public Optional<String> getTempDataset() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.WRITE_TEMP_DATASET));
+    }
+
     public BigQueryReadOptions toBigQueryReadOptions() {
         return BigQueryReadOptions.builder()
                 .setSnapshotTimestampInMillis(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.AvroRows;
 import com.google.cloud.bigquery.storage.v1.AvroSchema;
@@ -295,6 +296,12 @@ public class StorageClientFaker {
             public Job waitForJob(Job job) throws InterruptedException {
                 throw new UnsupportedOperationException(
                         "waitForJob not implemented in FakeQueryDataClient");
+            }
+
+            @Override
+            public boolean deleteTable(TableId tableId) {
+                throw new UnsupportedOperationException(
+                        "deleteTable not implemented in FakeQueryDataClient");
             }
         }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
@@ -81,6 +81,8 @@ public class BigQueryIndirectSinkTest {
     private static final String PROJECT = "test-project";
     private static final String DATASET = "test-dataset";
     private static final String TABLE = "test-table";
+    private static final String TEMP_PROJECT = "test-temp-project";
+    private static final String TEMP_DATASET = "test-temp-dataset";
 
     private static final RowType ROW_TYPE =
             RowType.of(new BigIntType(), new VarCharType(VarCharType.MAX_LENGTH));
@@ -111,6 +113,8 @@ public class BigQueryIndirectSinkTest {
                 .writeMode(WriteMode.INDIRECT)
                 .connectOptions(opts)
                 .tempGcsPath(localPath())
+                .tempProject(TEMP_PROJECT)
+                .tempDataset(TEMP_DATASET)
                 .bulkWriterFactory(new DummyFactory())
                 .formatOptions(FormatOptions.parquet())
                 .build();
@@ -311,6 +315,8 @@ public class BigQueryIndirectSinkTest {
                         .writeMode(WriteMode.INDIRECT)
                         .connectOptions(opts)
                         .tempGcsPath(gcsRoot.toURI().toString())
+                        .tempProject(TEMP_PROJECT)
+                        .tempDataset(TEMP_DATASET)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(ROW_TYPE))
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -469,6 +475,11 @@ public class BigQueryIndirectSinkTest {
                 final String materializationProject,
                 final String materializationDataset,
                 final String billingProject) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deleteTable(final TableId tableId) {
             throw new UnsupportedOperationException();
         }
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -377,6 +377,8 @@ public class BigQuerySinkConfigTest {
     // ---------- INDIRECT Write Mode Tests ----------
 
     private static final String GCS_PATH = "gs://bucket/tmp";
+    private static final String TEMP_PROJECT = "temp_p";
+    private static final String TEMP_DATASET = "temp_d";
 
     private static BigQueryConnectOptions indirectConnectOptions() {
         return BigQueryConnectOptions.builder()
@@ -400,12 +402,16 @@ public class BigQuerySinkConfigTest {
                         .writeMode(WriteMode.INDIRECT)
                         .connectOptions(opts)
                         .tempGcsPath(GCS_PATH)
+                        .tempProject(TEMP_PROJECT)
+                        .tempDataset(TEMP_DATASET)
                         .bulkWriterFactory(factory)
                         .formatOptions(FormatOptions.parquet())
                         .build();
 
         assertSame(opts, config.getConnectOptions());
         assertEquals(GCS_PATH, config.getTempGcsPath());
+        assertEquals(TEMP_PROJECT, config.getTempProject());
+        assertEquals(TEMP_DATASET, config.getTempDataset());
         assertSame(factory, config.getBulkWriterFactory());
         assertEquals(FormatOptions.parquet(), config.getFormatOptions());
         assertEquals(WriteMode.INDIRECT, config.getWriteMode());
@@ -419,6 +425,8 @@ public class BigQuerySinkConfigTest {
                         .writeMode(WriteMode.INDIRECT)
                         .connectOptions(indirectConnectOptions())
                         .tempGcsPath(GCS_PATH)
+                        .tempProject(TEMP_PROJECT)
+                        .tempDataset(TEMP_DATASET)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -427,6 +435,8 @@ public class BigQuerySinkConfigTest {
                         .writeMode(WriteMode.INDIRECT)
                         .connectOptions(indirectConnectOptions())
                         .tempGcsPath(GCS_PATH)
+                        .tempProject(TEMP_PROJECT)
+                        .tempDataset(TEMP_DATASET)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -437,7 +447,73 @@ public class BigQuerySinkConfigTest {
     }
 
     @Test
-    public void buildIndirectNullTempGcsPathThrowsException() {
+    public void buildIndirectNullTempDatasetThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempDataset is required"));
+    }
+
+    @Test
+    public void buildIndirectEmptyTempDatasetThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset("")
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempDataset is required"));
+    }
+
+    @Test
+    public void buildIndirectNullTempProjectThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempDataset(TEMP_DATASET)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempProject is required"));
+    }
+
+    @Test
+    public void buildIndirectEmptyTempProjectThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempProject("")
+                                        .tempDataset(TEMP_DATASET)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("tempProject is required"));
+    }
+
+    @Test
+    public void buildIndirectNullGcsTempPathThrowsException() {
         IllegalArgumentException ex =
                 assertThrows(
                         IllegalArgumentException.class,
@@ -451,7 +527,7 @@ public class BigQuerySinkConfigTest {
     }
 
     @Test
-    public void buildIndirectEmptyTempGcsPathThrowsException() {
+    public void buildIndirectEmptyGcsTempPathThrowsException() {
         IllegalArgumentException ex =
                 assertThrows(
                         IllegalArgumentException.class,
@@ -475,6 +551,8 @@ public class BigQuerySinkConfigTest {
                                         .writeMode(WriteMode.INDIRECT)
                                         .connectOptions(indirectConnectOptions())
                                         .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
                                         .build());
         assertTrue(ex.getMessage().contains("bulkWriterFactory is required"));
     }
@@ -489,6 +567,8 @@ public class BigQuerySinkConfigTest {
                                         .writeMode(WriteMode.INDIRECT)
                                         .connectOptions(indirectConnectOptions())
                                         .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .build());
         assertTrue(ex.getMessage().contains("formatOptions is required"));
@@ -504,6 +584,8 @@ public class BigQuerySinkConfigTest {
                                         .writeMode(WriteMode.INDIRECT)
                                         .connectOptions(indirectConnectOptions())
                                         .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .formatOptions(FormatOptions.parquet())
                                         .enableCdc(true)
@@ -521,6 +603,8 @@ public class BigQuerySinkConfigTest {
                                         .writeMode(WriteMode.INDIRECT)
                                         .connectOptions(indirectConnectOptions())
                                         .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .formatOptions(FormatOptions.parquet())
                                         .enableTableCreation(true)

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperatorTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperatorTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.Collector;
 
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.CopyJobConfiguration;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
@@ -37,6 +38,7 @@ import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.LoadJobConfiguration;
 import com.google.cloud.bigquery.ParquetOptions;
 import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
@@ -51,12 +53,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +82,8 @@ public class BigQueryLoadJobOperatorTest {
     private static final String PROJECT = "p";
     private static final String DATASET = "d";
     private static final String TABLE = "t";
+    private static final String TEMP_PROJECT = "temp_p";
+    private static final String TEMP_DATASET = "temp_d";
 
     private static class TestPendingFile implements InProgressFileWriter.PendingFileRecoverable {
         private final Path path;
@@ -131,8 +138,18 @@ public class BigQueryLoadJobOperatorTest {
 
     private static final UUID FIXED_UUID = UUID.fromString("00000000-0000-0000-0000-0000abc12345");
     private static final String FIXED_JOB_ID_HEX = "fd72014d4c864993a2e5a9287b4a9c5d";
-    private static final String EXPECTED_LOAD_JOB_ID_C1 =
-            "flink-bq-load_" + FIXED_JOB_ID_HEX + "_" + FIXED_UUID + "_c1";
+    private static final String CHECKPOINT_SUFFIX_C1 =
+            "_" + FIXED_JOB_ID_HEX + "_" + FIXED_UUID + "_c1";
+    private static final String EXPECTED_LOAD_JOB_ID_C1 = "flink-bq-load" + CHECKPOINT_SUFFIX_C1;
+    private static final String EXPECTED_TEMP_LOAD_JOB_ID_C1_P0 =
+            "flink-bq-tmp-load" + CHECKPOINT_SUFFIX_C1 + "_p0";
+    private static final String EXPECTED_TEMP_LOAD_JOB_ID_C1_P1 =
+            "flink-bq-tmp-load" + CHECKPOINT_SUFFIX_C1 + "_p1";
+    private static final String EXPECTED_COPY_JOB_ID_C1 = "flink-bq-copy" + CHECKPOINT_SUFFIX_C1;
+    private static final TableId EXPECTED_TEMP_TABLE_ID_C1_P0 =
+            TableId.of(TEMP_PROJECT, TEMP_DATASET, "flink-bq-tmp" + CHECKPOINT_SUFFIX_C1 + "_p0");
+    private static final TableId EXPECTED_TEMP_TABLE_ID_C1_P1 =
+            TableId.of(TEMP_PROJECT, TEMP_DATASET, "flink-bq-tmp" + CHECKPOINT_SUFFIX_C1 + "_p1");
 
     private static final ParquetOptions EXPECTED_PARQUET_OPTIONS =
             ParquetOptions.newBuilder().setEnableListInference(true).build();
@@ -151,19 +168,23 @@ public class BigQueryLoadJobOperatorTest {
 
     /**
      * Recording fake {@link BigQueryServices.QueryDataClient}. Each test mutates the configurable
-     * fields (existingJob / submitJobResult / waitForJobBehavior) to script responses, and asserts
-     * against the recorded lists rather than verifying mock interactions.
+     * fields (existingJobLookup / submitJobResult / waitForJobBehavior) to script responses, and
+     * asserts against the recorded lists rather than verifying mock interactions.
      */
     private static class RecordingQueryDataClient implements BigQueryServices.QueryDataClient {
         // Recording.
         final List<SubmittedJob> submittedJobs = new ArrayList<>();
         final List<String> getJobLookups = new ArrayList<>();
         final List<Job> waitForJobCalls = new ArrayList<>();
+        final List<TableId> deleteTableCalls = new ArrayList<>();
 
         // Configurable behavior - defaults form a happy-path success.
-        Job existingJob = null;
+        // existingJobLookup is keyed by jobId so multi-partition tests can script different
+        // states for different temp-load / copy jobs in the same checkpoint.
+        Function<String, Job> existingJobLookup = id -> null;
         Job submitJobResult = mockSuccessJob();
         Function<Job, Job> waitForJobBehavior = j -> j;
+        Function<TableId, Boolean> deleteTableBehavior = id -> true;
 
         static final class SubmittedJob {
             final String project;
@@ -178,19 +199,19 @@ public class BigQueryLoadJobOperatorTest {
         }
 
         @Override
-        public Job submitJob(String project, String jobId, JobConfiguration config) {
+        public synchronized Job submitJob(String project, String jobId, JobConfiguration config) {
             submittedJobs.add(new SubmittedJob(project, jobId, config));
             return submitJobResult;
         }
 
         @Override
-        public Job getJob(String project, String jobId) {
+        public synchronized Job getJob(String project, String jobId) {
             getJobLookups.add(jobId);
-            return existingJob;
+            return existingJobLookup.apply(jobId);
         }
 
         @Override
-        public Job waitForJob(Job job) {
+        public synchronized Job waitForJob(Job job) {
             waitForJobCalls.add(job);
             return waitForJobBehavior.apply(job);
         }
@@ -250,6 +271,12 @@ public class BigQueryLoadJobOperatorTest {
                 String billingProject) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public synchronized boolean deleteTable(TableId tableId) {
+            deleteTableCalls.add(tableId);
+            return deleteTableBehavior.apply(tableId);
+        }
     }
 
     /** Minimal {@link BigQueryServices} that delegates to a given {@link QueryDataClient}. */
@@ -296,13 +323,30 @@ public class BigQueryLoadJobOperatorTest {
     /** Creates an opened operator with the given client and an explicit file system. */
     private static BigQueryLoadJobOperator createOpenOperator(
             final BigQueryServices.QueryDataClient client, final FileSystem fs) throws Exception {
+        return createOpenOperator(
+                client,
+                fs,
+                BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
+    }
+
+    /** Creates an opened operator with explicit load-job size limits. */
+    private static BigQueryLoadJobOperator createOpenOperator(
+            final BigQueryServices.QueryDataClient client,
+            final FileSystem fs,
+            final int maxFilesPerLoadJob,
+            final long maxBytesPerLoadJob) {
         final BigQueryLoadJobOperator operator =
                 new BigQueryLoadJobOperator(
                         testConnectOptions(client),
                         FIXED_UUID,
+                        TEMP_PROJECT,
+                        TEMP_DATASET,
                         () -> Executors.newCachedThreadPool(),
                         () -> fs,
-                        EXPECTED_PARQUET_OPTIONS);
+                        EXPECTED_PARQUET_OPTIONS,
+                        maxFilesPerLoadJob,
+                        maxBytesPerLoadJob);
         operator.setRuntimeContext(mockRuntimeContext());
         operator.open(null);
         return operator;
@@ -400,7 +444,7 @@ public class BigQueryLoadJobOperatorTest {
      * Recording {@link FileSystem} that captures the URIs passed to {@code delete} and lets tests
      * configure the return value or an exception. Inherits everything else from {@link
      * LocalFileSystem}. Wrapping the URI list in a synchronized list because cleanup runs in
-     * parallel via the cleanup executor.
+     * parallel via the executorService.
      */
     private static class RecordingFileSystem extends LocalFileSystem {
         final List<String> deleteCalls = Collections.synchronizedList(new ArrayList<>());
@@ -429,15 +473,19 @@ public class BigQueryLoadJobOperatorTest {
                 new BigQueryLoadJobOperator(
                         testConnectOptions(new RecordingQueryDataClient()),
                         FIXED_UUID,
+                        TEMP_PROJECT,
+                        TEMP_DATASET,
                         () -> {
                             supplierCalls.incrementAndGet();
                             return executorService;
                         },
                         RecordingFileSystem::new,
-                        EXPECTED_PARQUET_OPTIONS);
+                        EXPECTED_PARQUET_OPTIONS,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
         operator.setRuntimeContext(mockRuntimeContext());
 
-        // Construction alone must not create the executor.
+        // Construction alone must not create the executorService.
         assertEquals(0, supplierCalls.get());
 
         operator.open(null);
@@ -455,9 +503,13 @@ public class BigQueryLoadJobOperatorTest {
                 new BigQueryLoadJobOperator(
                         testConnectOptions(new RecordingQueryDataClient()),
                         FIXED_UUID,
+                        TEMP_PROJECT,
+                        TEMP_DATASET,
                         () -> executorService,
                         RecordingFileSystem::new,
-                        EXPECTED_PARQUET_OPTIONS);
+                        EXPECTED_PARQUET_OPTIONS,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
         operator.setRuntimeContext(mockRuntimeContext());
         operator.open(null);
         operator.close();
@@ -473,9 +525,13 @@ public class BigQueryLoadJobOperatorTest {
                 new BigQueryLoadJobOperator(
                         testConnectOptions(new RecordingQueryDataClient()),
                         FIXED_UUID,
+                        TEMP_PROJECT,
+                        TEMP_DATASET,
                         () -> executorService,
                         RecordingFileSystem::new,
-                        EXPECTED_PARQUET_OPTIONS);
+                        EXPECTED_PARQUET_OPTIONS,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
         operator.setRuntimeContext(mockRuntimeContext());
         operator.open(null);
         operator.close();
@@ -491,9 +547,13 @@ public class BigQueryLoadJobOperatorTest {
                 new BigQueryLoadJobOperator(
                         testConnectOptions(new RecordingQueryDataClient()),
                         FIXED_UUID,
+                        TEMP_PROJECT,
+                        TEMP_DATASET,
                         () -> executorService,
                         RecordingFileSystem::new,
-                        EXPECTED_PARQUET_OPTIONS);
+                        EXPECTED_PARQUET_OPTIONS,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB,
+                        BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
         operator.close();
         assertEquals(0, executorService.shutdownCount);
         assertEquals(0, executorService.shutdownNowCount);
@@ -797,27 +857,29 @@ public class BigQueryLoadJobOperatorTest {
     }
 
     // =========================================================================
-    // submitAndAwaitJob - existing job succeed/fail/running
+    // submitAndAwaitJob - existing load job succeed/fail/running
     // =========================================================================
 
     @Test
     public void testFlatMapExistingSuccessJobSkipsSubmission() throws Exception {
+        Job existingJob = mockSuccessJob();
         RecordingQueryDataClient client = new RecordingQueryDataClient();
-        client.existingJob = mockSuccessJob();
+        client.existingJobLookup = id -> existingJob;
 
         BigQueryLoadJobOperator operator = createOpenOperator(client);
         processCompleteCheckpoint(operator, 1L, "file:///tmp/test.parquet");
 
         assertEquals(0, client.submittedJobs.size());
-        assertEquals(List.of(client.existingJob), client.waitForJobCalls);
+        assertEquals(List.of(existingJob), client.waitForJobCalls);
 
         operator.close();
     }
 
     @Test
     public void testFlatMapExistingFailedJobThrows() throws Exception {
+        Job existingJob = mockFailedJob();
         RecordingQueryDataClient client = new RecordingQueryDataClient();
-        client.existingJob = mockFailedJob();
+        client.existingJobLookup = id -> existingJob;
 
         BigQueryLoadJobOperator operator = createOpenOperator(client);
 
@@ -828,7 +890,7 @@ public class BigQueryLoadJobOperatorTest {
         assertTrue(ex.getMessage().contains("failed:"));
 
         assertEquals(0, client.submittedJobs.size());
-        assertEquals(List.of(client.existingJob), client.waitForJobCalls);
+        assertEquals(List.of(existingJob), client.waitForJobCalls);
 
         operator.close();
     }
@@ -836,15 +898,16 @@ public class BigQueryLoadJobOperatorTest {
     @Test
     public void testFlatMapRunningJobSucceedsWaitsAndReturns() throws Exception {
         Job successJob = mockSuccessJob();
+        Job runningJob = mockRunningJob();
         RecordingQueryDataClient client = new RecordingQueryDataClient();
-        client.existingJob = mockRunningJob();
+        client.existingJobLookup = id -> runningJob;
         client.waitForJobBehavior = j -> successJob;
 
         BigQueryLoadJobOperator operator = createOpenOperator(client);
         processCompleteCheckpoint(operator, 1L, "file:///tmp/test.parquet");
 
         assertEquals(0, client.submittedJobs.size());
-        assertEquals(List.of(client.existingJob), client.waitForJobCalls);
+        assertEquals(List.of(runningJob), client.waitForJobCalls);
 
         operator.close();
     }
@@ -852,8 +915,9 @@ public class BigQueryLoadJobOperatorTest {
     @Test
     public void testFlatMapRunningJobFailsThrows() throws Exception {
         Job failedAfterWait = mockFailedJob();
+        Job runningJob = mockRunningJob();
         RecordingQueryDataClient client = new RecordingQueryDataClient();
-        client.existingJob = mockRunningJob();
+        client.existingJobLookup = id -> runningJob;
         client.waitForJobBehavior = j -> failedAfterWait;
 
         BigQueryLoadJobOperator operator = createOpenOperator(client);
@@ -865,7 +929,7 @@ public class BigQueryLoadJobOperatorTest {
         assertTrue(ex.getMessage().contains("failed:"));
 
         assertEquals(0, client.submittedJobs.size());
-        assertEquals(List.of(client.existingJob), client.waitForJobCalls);
+        assertEquals(List.of(runningJob), client.waitForJobCalls);
 
         operator.close();
     }
@@ -938,14 +1002,15 @@ public class BigQueryLoadJobOperatorTest {
     @Test
     public void flatMapIgnoresAlreadyDeletedFiles() throws Exception {
         // Models a re-run after a previous attempt already submitted the load job and cleaned
-        // up its files: existingJob short-circuits submission, and cleanup runs against a file
-        // that no longer exists (delete returns false). No exception.
+        // up its files: existingJobLookup short-circuits submission, and cleanup runs against a
+        // file that no longer exists (delete returns false). No exception.
 
         RecordingFileSystem fs = new RecordingFileSystem();
         fs.deleteResult = false;
 
+        Job existingJob = mockSuccessJob();
         RecordingQueryDataClient client = new RecordingQueryDataClient();
-        client.existingJob = mockSuccessJob();
+        client.existingJobLookup = id -> existingJob;
         BigQueryLoadJobOperator operator = createOpenOperator(client, fs);
 
         processCompleteCheckpoint(operator, 1L, "file:///tmp/part.parquet");
@@ -970,6 +1035,317 @@ public class BigQueryLoadJobOperatorTest {
         assertEquals(1, client.submittedJobs.size());
         assertSubmittedFormatOptions((LoadJobConfiguration) client.submittedJobs.get(0).config);
         assertEquals(List.of("file:///tmp/part.parquet"), new ArrayList<>(fs.deleteCalls));
+
+        operator.close();
+    }
+
+    // =========================================================================
+    // flatMap - multi-partition path
+    // =========================================================================
+
+    /**
+     * Creates an opened operator with {@code maxFilesPerLoadJob = 1}, so any checkpoint with 2+
+     * files forces a multi-partition split regardless of file size.
+     */
+    private static BigQueryLoadJobOperator createOpenOperatorForcingMultiPartition(
+            final BigQueryServices.QueryDataClient client) {
+        return createOpenOperator(
+                client,
+                new RecordingFileSystem(),
+                1,
+                BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
+    }
+
+    @Test
+    public void flatMapExceedingMaxFilesPerLoadJobSubmitsTempLoadsAndCopy() throws Exception {
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        RecordingFileSystem fs = new RecordingFileSystem();
+        // maxFilesPerLoadJob = 1 with 2 incoming files forces a multi-partition split.
+        BigQueryLoadJobOperator operator =
+                createOpenOperator(
+                        client, fs, 1, BigQueryLoadJobOperator.DEFAULT_MAX_BYTES_PER_LOAD_JOB);
+
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        assertTwoPartitionTempLoadsAndCopy(client, fs);
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapExceedingMaxBytesPerLoadJobSubmitsTempLoadsAndCopy() throws Exception {
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        RecordingFileSystem fs = new RecordingFileSystem();
+        // Each file is 100 bytes (see processCompleteCheckpoint) for a total of 200 bytes
+        // So the split is byte-driven, not number-of-files
+        BigQueryLoadJobOperator operator =
+                createOpenOperator(
+                        client, fs, BigQueryLoadJobOperator.DEFAULT_MAX_FILES_PER_LOAD_JOB, 150L);
+
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        assertTwoPartitionTempLoadsAndCopy(client, fs);
+
+        operator.close();
+    }
+
+    /**
+     * Verifies the multi-partition output for a 2-file checkpoint regardless of which limit (file
+     * count or byte size) triggered the split: 2 temp-load jobs + 1 copy job with correct IDs,
+     * destinations, and dispositions, plus cleanup of both temp tables and source files.
+     */
+    private static void assertTwoPartitionTempLoadsAndCopy(
+            RecordingQueryDataClient client, RecordingFileSystem fs) {
+        // 2 temp-load jobs + 1 copy job
+        assertEquals(3, client.submittedJobs.size());
+
+        // Copy is always last (must wait for all temp-loads); temp-loads run in parallel
+        // so their relative submission order between p0 and p1 is non-deterministic.
+        assertEquals(EXPECTED_COPY_JOB_ID_C1, client.submittedJobs.get(2).jobId);
+
+        Map<String, RecordingQueryDataClient.SubmittedJob> tempLoadsByJobId = new HashMap<>();
+        tempLoadsByJobId.put(client.submittedJobs.get(0).jobId, client.submittedJobs.get(0));
+        tempLoadsByJobId.put(client.submittedJobs.get(1).jobId, client.submittedJobs.get(1));
+        assertEquals(
+                Set.of(EXPECTED_TEMP_LOAD_JOB_ID_C1_P0, EXPECTED_TEMP_LOAD_JOB_ID_C1_P1),
+                tempLoadsByJobId.keySet());
+
+        LoadJobConfiguration tempLoad0 =
+                (LoadJobConfiguration) tempLoadsByJobId.get(EXPECTED_TEMP_LOAD_JOB_ID_C1_P0).config;
+        assertEquals(EXPECTED_TEMP_TABLE_ID_C1_P0, tempLoad0.getDestinationTable());
+        // Temp tables must land in the configured tempProject/tempDataset, not the destination.
+        assertEquals(TEMP_PROJECT, tempLoad0.getDestinationTable().getProject());
+        assertEquals(TEMP_DATASET, tempLoad0.getDestinationTable().getDataset());
+        assertEquals(JobInfo.WriteDisposition.WRITE_TRUNCATE, tempLoad0.getWriteDisposition());
+        assertEquals(JobInfo.CreateDisposition.CREATE_IF_NEEDED, tempLoad0.getCreateDisposition());
+        assertEquals(1, tempLoad0.getSourceUris().size());
+
+        LoadJobConfiguration tempLoad1 =
+                (LoadJobConfiguration) tempLoadsByJobId.get(EXPECTED_TEMP_LOAD_JOB_ID_C1_P1).config;
+        assertEquals(EXPECTED_TEMP_TABLE_ID_C1_P1, tempLoad1.getDestinationTable());
+        assertEquals(JobInfo.WriteDisposition.WRITE_TRUNCATE, tempLoad1.getWriteDisposition());
+        assertEquals(JobInfo.CreateDisposition.CREATE_IF_NEEDED, tempLoad1.getCreateDisposition());
+        assertEquals(1, tempLoad1.getSourceUris().size());
+
+        Set<String> allTempLoadUris = new HashSet<>(tempLoad0.getSourceUris());
+        allTempLoadUris.addAll(tempLoad1.getSourceUris());
+        assertEquals(Set.of("file:///tmp/a.parquet", "file:///tmp/b.parquet"), allTempLoadUris);
+
+        CopyJobConfiguration copy = (CopyJobConfiguration) client.submittedJobs.get(2).config;
+        assertEquals(JobInfo.WriteDisposition.WRITE_APPEND, copy.getWriteDisposition());
+        assertEquals(JobInfo.CreateDisposition.CREATE_NEVER, copy.getCreateDisposition());
+        assertEquals(TableId.of(PROJECT, DATASET, TABLE), copy.getDestinationTable());
+        assertEquals(
+                List.of(EXPECTED_TEMP_TABLE_ID_C1_P0, EXPECTED_TEMP_TABLE_ID_C1_P1),
+                copy.getSourceTables());
+
+        // Both temp tables deleted after the copy succeeded (order non-deterministic — parallel).
+        assertEquals(
+                Set.of(EXPECTED_TEMP_TABLE_ID_C1_P0, EXPECTED_TEMP_TABLE_ID_C1_P1),
+                new HashSet<>(client.deleteTableCalls));
+
+        // Both source files deleted after the copy succeeded (order non-deterministic — parallel).
+        assertEquals(
+                Set.of("file:///tmp/a.parquet", "file:///tmp/b.parquet"),
+                new HashSet<>(fs.deleteCalls));
+    }
+
+    @Test
+    public void flatMapMultiPartitionTempLoadFailureThrowsAndSkipsCopy() throws Exception {
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.submitJobResult = mockFailedJob();
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        ExecutionException ex =
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                processCompleteCheckpoint(
+                                        operator,
+                                        1L,
+                                        "file:///tmp/a.parquet",
+                                        "file:///tmp/b.parquet"));
+        assertTrue(ex.getCause() instanceof BigQueryConnectorException);
+        assertTrue(ex.getCause().getMessage().contains("tmp-load"));
+
+        // Both temp-loads attempted in parallel; copy never submitted; no deletes.
+        assertEquals(2, client.submittedJobs.size());
+        assertFalse(
+                client.submittedJobs.stream()
+                        .anyMatch(j -> j.jobId.equals(EXPECTED_COPY_JOB_ID_C1)));
+        assertTrue(client.deleteTableCalls.isEmpty());
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapMultiPartitionCopyFailureThrowsAndSkipsDelete() throws Exception {
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        Job successJob = mockSuccessJob();
+        Job failedJob = mockFailedJob();
+        // Temp loads (first 2 calls) succeed, copy job (3rd) fails.
+        AtomicInteger callIdx = new AtomicInteger(0);
+        client.waitForJobBehavior = j -> callIdx.getAndIncrement() < 2 ? successJob : failedJob;
+        client.submitJobResult = successJob;
+
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        BigQueryConnectorException ex =
+                assertThrows(
+                        BigQueryConnectorException.class,
+                        () ->
+                                processCompleteCheckpoint(
+                                        operator,
+                                        1L,
+                                        "file:///tmp/a.parquet",
+                                        "file:///tmp/b.parquet"));
+        assertTrue(ex.getMessage().contains("copy"));
+
+        // Two temp loads + one copy submitted; copy threw, so no deletes attempted.
+        assertEquals(3, client.submittedJobs.size());
+        assertTrue(client.deleteTableCalls.isEmpty());
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapMultiPartitionToleratesDeleteTableReturningFalse() throws Exception {
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.deleteTableBehavior = id -> false; // delete reports the table didn't exist
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        // Should not throw despite delete returning false.
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        assertEquals(3, client.submittedJobs.size());
+        assertEquals(2, client.deleteTableCalls.size());
+
+        operator.close();
+    }
+
+    // =========================================================================
+    // flatMap - multi-partition replay: existing temp-load / copy jobs across partitions.
+    // Single-partition tests already cover submitAndAwaitJob's existing/running/failed branches;
+    // these tests target coordination scenarios unique to the multi-partition path, where
+    // different jobs (per-partition temp-loads + copy) can be in different states on replay.
+    // =========================================================================
+
+    @Test
+    public void flatMapMultiPartitionResumesExistingTempLoadAndSubmitsMissingOne()
+            throws Exception {
+        // p0 temp-load was submitted on a prior attempt (now existing-success); p1 wasn't.
+        // Operator skips p0 submission, submits p1, then runs copy.
+        Job p0Existing = mockSuccessJob();
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.existingJobLookup =
+                id -> id.equals(EXPECTED_TEMP_LOAD_JOB_ID_C1_P0) ? p0Existing : null;
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        // Only p1 temp-load + copy submitted; p0 was reused.
+        assertEquals(2, client.submittedJobs.size());
+        Set<String> submittedIds = new HashSet<>();
+        for (RecordingQueryDataClient.SubmittedJob j : client.submittedJobs) {
+            submittedIds.add(j.jobId);
+        }
+        assertEquals(
+                Set.of(EXPECTED_TEMP_LOAD_JOB_ID_C1_P1, EXPECTED_COPY_JOB_ID_C1), submittedIds);
+
+        // Both temp tables still cleaned up.
+        assertEquals(
+                Set.of(EXPECTED_TEMP_TABLE_ID_C1_P0, EXPECTED_TEMP_TABLE_ID_C1_P1),
+                new HashSet<>(client.deleteTableCalls));
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapMultiPartitionAllTempLoadsExistingSubmitsOnlyCopy() throws Exception {
+        // Both temp-loads succeeded on a prior attempt; copy did not run.
+        Job tempSuccess = mockSuccessJob();
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.existingJobLookup =
+                id ->
+                        (id.equals(EXPECTED_TEMP_LOAD_JOB_ID_C1_P0)
+                                        || id.equals(EXPECTED_TEMP_LOAD_JOB_ID_C1_P1))
+                                ? tempSuccess
+                                : null;
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        // Only the copy was submitted.
+        assertEquals(1, client.submittedJobs.size());
+        assertEquals(EXPECTED_COPY_JOB_ID_C1, client.submittedJobs.get(0).jobId);
+
+        // Cleanup still runs for both temp tables.
+        assertEquals(
+                Set.of(EXPECTED_TEMP_TABLE_ID_C1_P0, EXPECTED_TEMP_TABLE_ID_C1_P1),
+                new HashSet<>(client.deleteTableCalls));
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapMultiPartitionEverythingExistingSubmitsNothingAndCleansUp()
+            throws Exception {
+        // Full replay after operator died with everything already submitted: both temp-loads
+        // and the copy are existing-success. Operator just waits on each and cleans up.
+        Job successJob = mockSuccessJob();
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.existingJobLookup = id -> successJob;
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        // No submissions at all.
+        assertEquals(0, client.submittedJobs.size());
+        // All three jobs (2 temp-loads + copy) were waited on.
+        assertEquals(3, client.waitForJobCalls.size());
+        // Both temp tables cleaned up.
+        assertEquals(
+                Set.of(EXPECTED_TEMP_TABLE_ID_C1_P0, EXPECTED_TEMP_TABLE_ID_C1_P1),
+                new HashSet<>(client.deleteTableCalls));
+
+        operator.close();
+    }
+
+    @Test
+    public void flatMapMultiPartitionExistingFailedTempLoadThrowsAndSkipsCopy() throws Exception {
+        // p0's prior temp-load attempt is recorded as failed in BQ; p1 succeeded.
+        // submitAndAwaitJob short-circuits to wait + throw on p0; copy never runs;
+        // no cleanup because we never reached it.
+        Job successJob = mockSuccessJob();
+        Job failedJob = mockFailedJob();
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        client.existingJobLookup =
+                id -> {
+                    if (id.equals(EXPECTED_TEMP_LOAD_JOB_ID_C1_P0)) {
+                        return failedJob;
+                    }
+                    if (id.equals(EXPECTED_TEMP_LOAD_JOB_ID_C1_P1)) {
+                        return successJob;
+                    }
+                    return null;
+                };
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+
+        ExecutionException ex =
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                processCompleteCheckpoint(
+                                        operator,
+                                        1L,
+                                        "file:///tmp/a.parquet",
+                                        "file:///tmp/b.parquet"));
+        assertTrue(ex.getCause() instanceof BigQueryConnectorException);
+        assertTrue(ex.getCause().getMessage().contains("failed:"));
+
+        // Nothing submitted (both temp-loads short-circuited via getJob); no copy; no deletes.
+        assertEquals(0, client.submittedJobs.size());
+        assertTrue(client.deleteTableCalls.isEmpty());
 
         operator.close();
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -75,6 +75,8 @@ public class BigQueryDynamicTableSinkTest {
                     null,
                     null,
                     WriteMode.STORAGE_WRITE_API,
+                    null,
+                    null,
                     null);
 
     @RegisterExtension
@@ -156,7 +158,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        "gs://bucket/tmp");
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        "temp_d");
 
         SinkV2Provider provider =
                 (SinkV2Provider)
@@ -167,7 +171,7 @@ public class BigQueryDynamicTableSinkTest {
     }
 
     @Test
-    public void testSinkRuntimeProviderIndirectModeNullTempGcsPathThrows() {
+    public void testSinkRuntimeProviderIndirectModeNullGcsTempPathThrows() {
         BigQueryDynamicTableSink indirectSink =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -187,7 +191,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        null);
+                        null,
+                        "temp_p",
+                        "temp_d");
 
         assertThatThrownBy(
                         () ->
@@ -195,6 +201,72 @@ public class BigQueryDynamicTableSinkTest {
                                         Mockito.mock(DynamicTableSink.Context.class)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("tempGcsPath is required");
+    }
+
+    @Test
+    public void testSinkRuntimeProviderIndirectModeNullTempDatasetThrows() {
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        false,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        null);
+
+        assertThatThrownBy(
+                        () ->
+                                indirectSink.getSinkRuntimeProvider(
+                                        Mockito.mock(DynamicTableSink.Context.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tempDataset is required");
+    }
+
+    @Test
+    public void testSinkRuntimeProviderIndirectModeNullTempProjectThrows() {
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        false,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp",
+                        null,
+                        "temp_d");
+
+        assertThatThrownBy(
+                        () ->
+                                indirectSink.getSinkRuntimeProvider(
+                                        Mockito.mock(DynamicTableSink.Context.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tempProject is required");
     }
 
     @Test
@@ -218,7 +290,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        "gs://bucket/tmp");
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        "temp_d");
         assertEquals(indirectSink, indirectSink.copy());
     }
 
@@ -243,7 +317,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        "gs://bucket/tmp");
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        "temp_d");
         BigQueryDynamicTableSink direct =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -263,12 +339,14 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.STORAGE_WRITE_API,
-                        "gs://bucket/tmp");
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        "temp_d");
         assertNotEquals(indirect, direct);
     }
 
     @Test
-    public void testEqualsDiffersByTempGcsPath() {
+    public void testEqualsDiffersByGcsTempPath() {
         BigQueryDynamicTableSink a =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -288,7 +366,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        "gs://bucket/a");
+                        "gs://bucket/a",
+                        "temp_p",
+                        "temp_d");
         BigQueryDynamicTableSink b =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -308,7 +388,9 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.INDIRECT,
-                        "gs://bucket/b");
+                        "gs://bucket/b",
+                        "temp_p",
+                        "temp_d");
         assertNotEquals(a, b);
     }
 
@@ -333,6 +415,8 @@ public class BigQueryDynamicTableSinkTest {
                         "INTERVAL 10 MINUTE",
                         null,
                         WriteMode.STORAGE_WRITE_API,
+                        null,
+                        null,
                         null);
 
         BigQuerySinkConfig<RowData> obtainedSinkConfig = cdcTableSink.getSinkConfig();

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamResponse;
 import com.google.cloud.bigquery.storage.v1.FlushRowsResponse;
@@ -310,5 +311,13 @@ public interface BigQueryServices extends Serializable {
          * @throws InterruptedException if the wait is interrupted.
          */
         Job waitForJob(Job job) throws InterruptedException;
+
+        /**
+         * Delete a BigQuery table.
+         *
+         * @param tableId The table to delete.
+         * @return {@code true} if the table was deleted, {@code false} if it did not exist.
+         */
+        boolean deleteTable(TableId tableId);
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
@@ -591,6 +591,11 @@ public class BigQueryServicesImpl implements BigQueryServices {
         public Job waitForJob(Job job) throws InterruptedException {
             return job.waitFor();
         }
+
+        @Override
+        public boolean deleteTable(TableId tableId) {
+            return bigQuery.delete(tableId);
+        }
     }
 
     public static final String generateTraceId(String suffix) {

--- a/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/source/split/SplitDiscovererTest.java
+++ b/flink-connector-bigquery-common/src/test/java/com/google/cloud/flink/bigquery/source/split/SplitDiscovererTest.java
@@ -342,6 +342,11 @@ public class SplitDiscovererTest {
                 public com.google.cloud.bigquery.Job waitForJob(com.google.cloud.bigquery.Job job) {
                     throw new UnsupportedOperationException();
                 }
+
+                @Override
+                public boolean deleteTable(com.google.cloud.bigquery.TableId tableId) {
+                    throw new UnsupportedOperationException();
+                }
             };
         }
 


### PR DESCRIPTION
Partition each checkpoint's files when it exceeds BigQuery's per-load-job caps (10K source URIs or 15 TB), load each partition into a temp table, then atomically COPY all temp tables into the destination. Files are sorted by GCS path before partitioning so retries produce the same partition shape — without that, a retry could place a file into a different temp-table slot than the original attempt did, and since temp-load jobs are idempotent on jobId (not content) the COPY would double-count it.

Temp-load jobs for the partitions are submitted in parallel via the executor service; the COPY job still waits for all of them. Failures on any partition surface immediately while siblings keep running — those keep-running jobs aren't wasted because temp loads are idempotent on jobId, so a Flink retry re-attaches to any in-flight or completed BQ jobs without re-uploading.

Adds a required `write.indirect.temp-bigquery-dataset` option pointing at a separate dataset for temp tables. The recommendation is to set a default `tableExpirationMs` on that dataset so BigQuery itself cleans up any temp tables left behind by failed jobs.

---

This is (6/8) in the indirect-writes series:

- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/309
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/310
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/311
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/312
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/313
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/317
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/318
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/319
