### PR TITLE
Indirect writes (7/8): configurable job project

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-table-api-examples/src/main/java/com/google/cloud/flink/bigquery/examples/IndirectWriteExample.java
@@ -52,7 +52,9 @@ import org.slf4j.LoggerFactory;
  *       --temp-dataset {required; BigQuery dataset for temporary tables created during
  *       multi-partition loads. Must exist in --temp-project. Recommended: configure a default
  *       tableExpirationMs on this dataset so any temp tables left behind by failed jobs are
- *       auto-deleted by BigQuery.}
+ *       auto-deleted by BigQuery.} <br>
+ *       --job-project {required; GCP project under which BigQuery load and copy jobs are submitted
+ *       (i.e. where the jobs are listed and billed)}
  * </ul>
  *
  * <p>Requires the GCS Hadoop connector plugin ({@code flink-gs-fs-hadoop}) to be installed in the
@@ -65,7 +67,7 @@ public class IndirectWriteExample {
     public static void main(String[] args) {
         final ParameterTool params = ParameterTool.fromArgs(args);
 
-        if (params.getNumberOfParameters() < 6) {
+        if (params.getNumberOfParameters() < 7) {
             LOG.error(
                     "Missing parameters!\n"
                             + "Usage: IndirectWriteExample"
@@ -74,7 +76,8 @@ public class IndirectWriteExample {
                             + " --table <BigQuery table>"
                             + " --temp-gcs-path <GCS path for staging files>"
                             + " --temp-project <GCP project for temp tables>"
-                            + " --temp-dataset <BigQuery dataset for temp tables>");
+                            + " --temp-dataset <BigQuery dataset for temp tables>"
+                            + " --job-project <GCP project for BigQuery load/copy jobs>");
             return;
         }
 
@@ -84,6 +87,7 @@ public class IndirectWriteExample {
         String tempGcsPath = params.getRequired("temp-gcs-path");
         String tempProject = params.getRequired("temp-project");
         String tempDataset = params.getRequired("temp-dataset");
+        String jobProject = params.getRequired("job-project");
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
@@ -113,9 +117,16 @@ public class IndirectWriteExample {
                                 + "    'write.mode' = 'INDIRECT',"
                                 + "    'write.indirect.temp-gcs-path' = '%s',"
                                 + "    'write.indirect.temp-bigquery-project' = '%s',"
-                                + "    'write.indirect.temp-bigquery-dataset' = '%s'"
+                                + "    'write.indirect.temp-bigquery-dataset' = '%s',"
+                                + "    'write.indirect.bigquery-job-project' = '%s'"
                                 + ")",
-                        project, dataset, table, tempGcsPath, tempProject, tempDataset));
+                        project,
+                        dataset,
+                        table,
+                        tempGcsPath,
+                        tempProject,
+                        tempDataset,
+                        jobProject));
 
         String insertSql =
                 "INSERT INTO bigquery_sink VALUES"

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSink.java
@@ -86,6 +86,7 @@ final class BigQueryIndirectSink<IN>
     private final UUID uuid;
     private final String tempProject;
     private final String tempDataset;
+    private final String jobProject;
     private final Path gcsBasePath;
     private final FormatOptions formatOptions;
     private final FileSink<IN> fileSink;
@@ -100,14 +101,16 @@ final class BigQueryIndirectSink<IN>
         this.uuid = uuid;
         this.tempProject = config.getTempProject();
         this.tempDataset = config.getTempDataset();
+        this.jobProject = config.getJobProject();
         this.gcsBasePath = new Path(config.getTempGcsPath(), uuid.toString());
         this.formatOptions = config.getFormatOptions();
 
         LOG.info(
-                "Creating BigQueryIndirectSink: uuid={}, tempProject={}, tempDataset={}, gcsBasePath={}, table={}.{}.{}",
+                "Creating BigQueryIndirectSink: uuid={}, tempProject={}, tempDataset={}, jobProject={}, gcsBasePath={}, table={}.{}.{}",
                 uuid,
                 tempProject,
                 tempDataset,
+                jobProject,
                 gcsBasePath,
                 connectOptions.getProjectId(),
                 connectOptions.getDataset(),
@@ -168,6 +171,7 @@ final class BigQueryIndirectSink<IN>
                                 uuid,
                                 tempProject,
                                 tempDataset,
+                                jobProject,
                                 gcsBasePath,
                                 formatOptions))
                 .name("BigQueryLoadJobOperator")

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -47,6 +47,7 @@ public class BigQuerySink {
                     sinkConfig.getTempGcsPath(),
                     sinkConfig.getTempProject(),
                     sinkConfig.getTempDataset(),
+                    sinkConfig.getJobProject(),
                     sinkConfig.getBulkWriterFactory(),
                     sinkConfig.getFormatOptions(),
                     sinkConfig.isCdcEnabled(),

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -83,6 +83,7 @@ public class BigQuerySinkConfig<IN> {
     private final String tempGcsPath;
     private final String tempProject;
     private final String tempDataset;
+    private final String jobProject;
     private final BulkWriter.Factory<IN> bulkWriterFactory;
     private final FormatOptions formatOptions;
 
@@ -113,6 +114,7 @@ public class BigQuerySinkConfig<IN> {
                 tempGcsPath,
                 tempProject,
                 tempDataset,
+                jobProject,
                 bulkWriterFactory,
                 formatOptions);
     }
@@ -156,6 +158,7 @@ public class BigQuerySinkConfig<IN> {
                 && (Objects.equals(this.tempGcsPath, object.tempGcsPath))
                 && (Objects.equals(this.tempProject, object.tempProject))
                 && (Objects.equals(this.tempDataset, object.tempDataset))
+                && (Objects.equals(this.jobProject, object.jobProject))
                 && (Objects.equals(this.bulkWriterFactory, object.bulkWriterFactory))
                 && (Objects.equals(this.formatOptions, object.formatOptions)));
     }
@@ -181,6 +184,7 @@ public class BigQuerySinkConfig<IN> {
             String tempGcsPath,
             String tempProject,
             String tempDataset,
+            String jobProject,
             BulkWriter.Factory<IN> bulkWriterFactory,
             FormatOptions formatOptions) {
         this.connectOptions = connectOptions;
@@ -203,6 +207,7 @@ public class BigQuerySinkConfig<IN> {
         this.tempGcsPath = tempGcsPath;
         this.tempProject = tempProject;
         this.tempDataset = tempDataset;
+        this.jobProject = jobProject;
         this.bulkWriterFactory = bulkWriterFactory;
         this.formatOptions = formatOptions;
     }
@@ -287,6 +292,10 @@ public class BigQuerySinkConfig<IN> {
         return tempDataset;
     }
 
+    public String getJobProject() {
+        return jobProject;
+    }
+
     public BulkWriter.Factory<IN> getBulkWriterFactory() {
         return bulkWriterFactory;
     }
@@ -324,6 +333,7 @@ public class BigQuerySinkConfig<IN> {
         private String tempGcsPath;
         private String tempProject;
         private String tempDataset;
+        private String jobProject;
         private BulkWriter.Factory<IN> bulkWriterFactory;
         private FormatOptions formatOptions;
 
@@ -433,6 +443,11 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> jobProject(String jobProject) {
+            this.jobProject = jobProject;
+            return this;
+        }
+
         public Builder<IN> bulkWriterFactory(BulkWriter.Factory<IN> bulkWriterFactory) {
             this.bulkWriterFactory = bulkWriterFactory;
             return this;
@@ -449,6 +464,7 @@ public class BigQuerySinkConfig<IN> {
                         tempGcsPath,
                         tempProject,
                         tempDataset,
+                        jobProject,
                         bulkWriterFactory,
                         formatOptions,
                         cdcEnabled,
@@ -477,6 +493,7 @@ public class BigQuerySinkConfig<IN> {
                     tempGcsPath,
                     tempProject,
                     tempDataset,
+                    jobProject,
                     bulkWriterFactory,
                     formatOptions);
         }
@@ -505,7 +522,8 @@ public class BigQuerySinkConfig<IN> {
             WriteMode writeMode,
             String tempGcsPath,
             String tempProject,
-            String tempDataset) {
+            String tempDataset,
+            String jobProject) {
         boolean indirect = writeMode == WriteMode.INDIRECT;
         BulkWriter.Factory<RowData> bulkWriterFactory =
                 indirect ? RowDataParquetWriterFactory.create((RowType) logicalType) : null;
@@ -540,6 +558,7 @@ public class BigQuerySinkConfig<IN> {
                 tempGcsPath,
                 tempProject,
                 tempDataset,
+                jobProject,
                 bulkWriterFactory,
                 formatOptions);
     }
@@ -553,6 +572,7 @@ public class BigQuerySinkConfig<IN> {
             String tempGcsPath,
             String tempProject,
             String tempDataset,
+            String jobProject,
             BulkWriter.Factory<?> bulkWriterFactory,
             FormatOptions formatOptions,
             boolean cdcEnabled,
@@ -565,6 +585,9 @@ public class BigQuerySinkConfig<IN> {
         }
         if (tempDataset == null || tempDataset.isEmpty()) {
             throw new IllegalArgumentException("tempDataset is required for INDIRECT write mode");
+        }
+        if (jobProject == null || jobProject.isEmpty()) {
+            throw new IllegalArgumentException("jobProject is required for INDIRECT write mode");
         }
         if (bulkWriterFactory == null) {
             throw new IllegalArgumentException(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperator.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperator.java
@@ -99,6 +99,7 @@ public class BigQueryLoadJobOperator
     private final UUID uuid;
     private final String tempProject;
     private final String tempDataset;
+    private final String jobProject;
     private final SerializableSupplier<ExecutorService> executorServiceSupplier;
     private final SerializableSupplier<FileSystem> fileSystemSupplier;
     private final FormatOptions formatOptions;
@@ -118,6 +119,7 @@ public class BigQueryLoadJobOperator
             final UUID uuid,
             final String tempProject,
             final String tempDataset,
+            final String jobProject,
             final Path gcsBasePath,
             final FormatOptions formatOptions) {
         this(
@@ -125,6 +127,7 @@ public class BigQueryLoadJobOperator
                 uuid,
                 tempProject,
                 tempDataset,
+                jobProject,
                 () -> Executors.newFixedThreadPool(EXECUTOR_PARALLELISM, EXECUTOR_THREAD_FACTORY),
                 () -> {
                     try {
@@ -145,6 +148,7 @@ public class BigQueryLoadJobOperator
             final UUID uuid,
             final String tempProject,
             final String tempDataset,
+            final String jobProject,
             final SerializableSupplier<ExecutorService> executorServiceSupplier,
             final SerializableSupplier<FileSystem> fileSystemSupplier,
             final FormatOptions formatOptions,
@@ -154,6 +158,7 @@ public class BigQueryLoadJobOperator
         this.uuid = uuid;
         this.tempProject = tempProject;
         this.tempDataset = tempDataset;
+        this.jobProject = jobProject;
         this.executorServiceSupplier = executorServiceSupplier;
         this.fileSystemSupplier = fileSystemSupplier;
         this.formatOptions = formatOptions;
@@ -169,12 +174,13 @@ public class BigQueryLoadJobOperator
         this.executorService = executorServiceSupplier.get();
         this.fileSystem = fileSystemSupplier.get();
         LOG.info(
-                "BigQueryLoadJobOperator opened: jobId={}, uuid={}, table={}.{}.{}",
+                "BigQueryLoadJobOperator opened: jobId={}, uuid={}, table={}.{}.{}, jobProject={}",
                 jobIdHex,
                 uuid,
                 connectOptions.getProjectId(),
                 connectOptions.getDataset(),
-                connectOptions.getTable());
+                connectOptions.getTable(),
+                jobProject);
     }
 
     @Override
@@ -417,10 +423,10 @@ public class BigQueryLoadJobOperator
      */
     private void submitAndAwaitJob(final String jobId, final JobConfiguration config) {
         final Job job;
-        final Job maybeExistingJob = queryClient.getJob(connectOptions.getProjectId(), jobId);
+        final Job maybeExistingJob = queryClient.getJob(jobProject, jobId);
         if (maybeExistingJob == null) {
             LOG.info("Submitting job {}", jobId);
-            job = queryClient.submitJob(connectOptions.getProjectId(), jobId, config);
+            job = queryClient.submitJob(jobProject, jobId, config);
         } else {
             job = maybeExistingJob;
         }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -91,6 +91,7 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
         additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
         additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
+        additionalOptions.add(BigQueryConnectorOptions.WRITE_JOB_PROJECT);
 
         return additionalOptions;
     }
@@ -129,6 +130,7 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.TEMP_GCS_PATH);
         forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
         forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
+        forwardOptions.add(BigQueryConnectorOptions.WRITE_JOB_PROJECT);
 
         return forwardOptions;
     }
@@ -192,6 +194,7 @@ public class BigQueryDynamicTableFactory
                 configProvider.getWriteMode(),
                 configProvider.getTempGcsPath().orElse(null),
                 configProvider.getTempProject().orElse(null),
-                configProvider.getTempDataset().orElse(null));
+                configProvider.getTempDataset().orElse(null),
+                configProvider.getJobProject().orElse(null));
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -77,6 +77,7 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 
@@ -100,7 +101,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             WriteMode writeMode,
             String tempGcsPath,
             String tempProject,
-            String tempDataset) {
+            String tempDataset,
+            String jobProject) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
         this.sinkConfig =
@@ -125,7 +127,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         writeMode,
                         tempGcsPath,
                         tempProject,
-                        tempDataset);
+                        tempDataset,
+                        jobProject);
     }
 
     @Override
@@ -192,7 +195,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.getWriteMode(),
                 this.sinkConfig.getTempGcsPath(),
                 this.sinkConfig.getTempProject(),
-                this.sinkConfig.getTempDataset());
+                this.sinkConfig.getTempDataset(),
+                this.sinkConfig.getJobProject());
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -348,4 +348,16 @@ public class BigQueryConnectorOptions {
                                     + "Recommended: set a default tableExpirationMs on this "
                                     + "dataset so BigQuery auto-deletes any temp tables left "
                                     + "behind by failed jobs.");
+
+    /**
+     * [REQUIRED for INDIRECT mode] GCP project under which BigQuery load and copy jobs are
+     * submitted (i.e. where the jobs are listed and billed).
+     */
+    public static final ConfigOption<String> WRITE_JOB_PROJECT =
+            ConfigOptions.key("write.indirect.bigquery-job-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "GCP project under which BigQuery load and copy jobs are submitted "
+                                    + "(required for INDIRECT write mode).");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -143,6 +143,10 @@ public class BigQueryTableConfigurationProvider {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.WRITE_TEMP_DATASET));
     }
 
+    public Optional<String> getJobProject() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.WRITE_JOB_PROJECT));
+    }
+
     public BigQueryReadOptions toBigQueryReadOptions() {
         return BigQueryReadOptions.builder()
                 .setSnapshotTimestampInMillis(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryIndirectSinkTest.java
@@ -83,6 +83,7 @@ public class BigQueryIndirectSinkTest {
     private static final String TABLE = "test-table";
     private static final String TEMP_PROJECT = "test-temp-project";
     private static final String TEMP_DATASET = "test-temp-dataset";
+    private static final String JOB_PROJECT = "test-job-project";
 
     private static final RowType ROW_TYPE =
             RowType.of(new BigIntType(), new VarCharType(VarCharType.MAX_LENGTH));
@@ -115,6 +116,7 @@ public class BigQueryIndirectSinkTest {
                 .tempGcsPath(localPath())
                 .tempProject(TEMP_PROJECT)
                 .tempDataset(TEMP_DATASET)
+                .jobProject(JOB_PROJECT)
                 .bulkWriterFactory(new DummyFactory())
                 .formatOptions(FormatOptions.parquet())
                 .build();
@@ -317,6 +319,7 @@ public class BigQueryIndirectSinkTest {
                         .tempGcsPath(gcsRoot.toURI().toString())
                         .tempProject(TEMP_PROJECT)
                         .tempDataset(TEMP_DATASET)
+                        .jobProject(JOB_PROJECT)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(ROW_TYPE))
                         .formatOptions(FormatOptions.parquet())
                         .build();

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -379,6 +379,7 @@ public class BigQuerySinkConfigTest {
     private static final String GCS_PATH = "gs://bucket/tmp";
     private static final String TEMP_PROJECT = "temp_p";
     private static final String TEMP_DATASET = "temp_d";
+    private static final String JOB_PROJECT = "job_p";
 
     private static BigQueryConnectOptions indirectConnectOptions() {
         return BigQueryConnectOptions.builder()
@@ -404,6 +405,7 @@ public class BigQuerySinkConfigTest {
                         .tempGcsPath(GCS_PATH)
                         .tempProject(TEMP_PROJECT)
                         .tempDataset(TEMP_DATASET)
+                        .jobProject(JOB_PROJECT)
                         .bulkWriterFactory(factory)
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -412,6 +414,7 @@ public class BigQuerySinkConfigTest {
         assertEquals(GCS_PATH, config.getTempGcsPath());
         assertEquals(TEMP_PROJECT, config.getTempProject());
         assertEquals(TEMP_DATASET, config.getTempDataset());
+        assertEquals(JOB_PROJECT, config.getJobProject());
         assertSame(factory, config.getBulkWriterFactory());
         assertEquals(FormatOptions.parquet(), config.getFormatOptions());
         assertEquals(WriteMode.INDIRECT, config.getWriteMode());
@@ -427,6 +430,7 @@ public class BigQuerySinkConfigTest {
                         .tempGcsPath(GCS_PATH)
                         .tempProject(TEMP_PROJECT)
                         .tempDataset(TEMP_DATASET)
+                        .jobProject(JOB_PROJECT)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -437,6 +441,7 @@ public class BigQuerySinkConfigTest {
                         .tempGcsPath(GCS_PATH)
                         .tempProject(TEMP_PROJECT)
                         .tempDataset(TEMP_DATASET)
+                        .jobProject(JOB_PROJECT)
                         .bulkWriterFactory(RowDataParquetWriterFactory.create(rowType))
                         .formatOptions(FormatOptions.parquet())
                         .build();
@@ -542,6 +547,41 @@ public class BigQuerySinkConfigTest {
     }
 
     @Test
+    public void buildIndirectNullJobProjectThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("jobProject is required"));
+    }
+
+    @Test
+    public void buildIndirectEmptyJobProjectThrowsException() {
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                BigQuerySinkConfig.<String>newBuilder()
+                                        .writeMode(WriteMode.INDIRECT)
+                                        .connectOptions(indirectConnectOptions())
+                                        .tempGcsPath(GCS_PATH)
+                                        .tempProject(TEMP_PROJECT)
+                                        .tempDataset(TEMP_DATASET)
+                                        .jobProject("")
+                                        .bulkWriterFactory(dummyBulkWriterFactory())
+                                        .build());
+        assertTrue(ex.getMessage().contains("jobProject is required"));
+    }
+
+    @Test
     public void buildIndirectNullBulkWriterFactoryThrowsException() {
         IllegalArgumentException ex =
                 assertThrows(
@@ -553,6 +593,7 @@ public class BigQuerySinkConfigTest {
                                         .tempGcsPath(GCS_PATH)
                                         .tempProject(TEMP_PROJECT)
                                         .tempDataset(TEMP_DATASET)
+                                        .jobProject(JOB_PROJECT)
                                         .build());
         assertTrue(ex.getMessage().contains("bulkWriterFactory is required"));
     }
@@ -569,6 +610,7 @@ public class BigQuerySinkConfigTest {
                                         .tempGcsPath(GCS_PATH)
                                         .tempProject(TEMP_PROJECT)
                                         .tempDataset(TEMP_DATASET)
+                                        .jobProject(JOB_PROJECT)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .build());
         assertTrue(ex.getMessage().contains("formatOptions is required"));
@@ -586,6 +628,7 @@ public class BigQuerySinkConfigTest {
                                         .tempGcsPath(GCS_PATH)
                                         .tempProject(TEMP_PROJECT)
                                         .tempDataset(TEMP_DATASET)
+                                        .jobProject(JOB_PROJECT)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .formatOptions(FormatOptions.parquet())
                                         .enableCdc(true)
@@ -605,6 +648,7 @@ public class BigQuerySinkConfigTest {
                                         .tempGcsPath(GCS_PATH)
                                         .tempProject(TEMP_PROJECT)
                                         .tempDataset(TEMP_DATASET)
+                                        .jobProject(JOB_PROJECT)
                                         .bulkWriterFactory(dummyBulkWriterFactory())
                                         .formatOptions(FormatOptions.parquet())
                                         .enableTableCreation(true)

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperatorTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/indirect/BigQueryLoadJobOperatorTest.java
@@ -84,6 +84,7 @@ public class BigQueryLoadJobOperatorTest {
     private static final String TABLE = "t";
     private static final String TEMP_PROJECT = "temp_p";
     private static final String TEMP_DATASET = "temp_d";
+    private static final String JOB_PROJECT = "job_p";
 
     private static class TestPendingFile implements InProgressFileWriter.PendingFileRecoverable {
         private final Path path;
@@ -342,6 +343,7 @@ public class BigQueryLoadJobOperatorTest {
                         FIXED_UUID,
                         TEMP_PROJECT,
                         TEMP_DATASET,
+                        JOB_PROJECT,
                         () -> Executors.newCachedThreadPool(),
                         () -> fs,
                         EXPECTED_PARQUET_OPTIONS,
@@ -475,6 +477,7 @@ public class BigQueryLoadJobOperatorTest {
                         FIXED_UUID,
                         TEMP_PROJECT,
                         TEMP_DATASET,
+                        JOB_PROJECT,
                         () -> {
                             supplierCalls.incrementAndGet();
                             return executorService;
@@ -505,6 +508,7 @@ public class BigQueryLoadJobOperatorTest {
                         FIXED_UUID,
                         TEMP_PROJECT,
                         TEMP_DATASET,
+                        JOB_PROJECT,
                         () -> executorService,
                         RecordingFileSystem::new,
                         EXPECTED_PARQUET_OPTIONS,
@@ -527,6 +531,7 @@ public class BigQueryLoadJobOperatorTest {
                         FIXED_UUID,
                         TEMP_PROJECT,
                         TEMP_DATASET,
+                        JOB_PROJECT,
                         () -> executorService,
                         RecordingFileSystem::new,
                         EXPECTED_PARQUET_OPTIONS,
@@ -549,6 +554,7 @@ public class BigQueryLoadJobOperatorTest {
                         FIXED_UUID,
                         TEMP_PROJECT,
                         TEMP_DATASET,
+                        JOB_PROJECT,
                         () -> executorService,
                         RecordingFileSystem::new,
                         EXPECTED_PARQUET_OPTIONS,
@@ -616,7 +622,7 @@ public class BigQueryLoadJobOperatorTest {
 
         // Now both summaries + all files received - should have submitted
         assertEquals(1, client.submittedJobs.size());
-        assertEquals(PROJECT, client.submittedJobs.get(0).project);
+        assertEquals(JOB_PROJECT, client.submittedJobs.get(0).project);
         assertEquals(EXPECTED_LOAD_JOB_ID_C1, client.submittedJobs.get(0).jobId);
         // Order from the underlying HashSet isn't stable; compare as a set.
         assertEquals(
@@ -651,7 +657,7 @@ public class BigQueryLoadJobOperatorTest {
 
         // Now both summaries + all files received - should have submitted
         assertEquals(1, client.submittedJobs.size());
-        assertEquals(PROJECT, client.submittedJobs.get(0).project);
+        assertEquals(JOB_PROJECT, client.submittedJobs.get(0).project);
         assertEquals(EXPECTED_LOAD_JOB_ID_C1, client.submittedJobs.get(0).jobId);
         assertEquals(
                 Set.of("file:///tmp/f0.parquet", "file:///tmp/f1.parquet"),
@@ -827,13 +833,58 @@ public class BigQueryLoadJobOperatorTest {
         processCompleteCheckpoint(operator, 1L, "file:///tmp/test.parquet");
 
         assertEquals(1, client.submittedJobs.size());
-        assertEquals(PROJECT, client.submittedJobs.get(0).project);
+        assertEquals(JOB_PROJECT, client.submittedJobs.get(0).project);
         assertEquals(
                 JobInfo.CreateDisposition.CREATE_NEVER,
                 ((LoadJobConfiguration) client.submittedJobs.get(0).config).getCreateDisposition());
         assertSubmittedFormatOptions((LoadJobConfiguration) client.submittedJobs.get(0).config);
         // submitJob returns submitJobResult; that's what waitForJob receives.
         assertEquals(List.of(client.submitJobResult), client.waitForJobCalls);
+
+        operator.close();
+    }
+
+    @Test
+    public void singlePartitionLoadUsesJobProjectButDestinationProjectForTable() throws Exception {
+        // Cross-project semantics: the load job is created in JOB_PROJECT (where it's listed and
+        // billed), but the destination table is in the connect-options PROJECT. These can differ.
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        BigQueryLoadJobOperator operator = createOpenOperator(client);
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/test.parquet");
+
+        assertEquals(1, client.submittedJobs.size());
+        assertEquals(JOB_PROJECT, client.submittedJobs.get(0).project);
+        LoadJobConfiguration loadConfig = (LoadJobConfiguration) client.submittedJobs.get(0).config;
+        assertEquals(TableId.of(PROJECT, DATASET, TABLE), loadConfig.getDestinationTable());
+        // Recovery lookup also issued against JOB_PROJECT so jobId idempotence holds.
+        assertEquals(1, client.getJobLookups.size());
+
+        operator.close();
+    }
+
+    @Test
+    public void multiPartitionLoadUsesJobProjectForAllJobsAndCorrectDestinationProjects()
+            throws Exception {
+        // Cross-project semantics on the multi-partition path: every submitted job (2 temp loads
+        // + 1 copy) runs in JOB_PROJECT, but temp tables land in TEMP_PROJECT and the final
+        // table in PROJECT.
+        RecordingQueryDataClient client = new RecordingQueryDataClient();
+        BigQueryLoadJobOperator operator = createOpenOperatorForcingMultiPartition(client);
+        processCompleteCheckpoint(operator, 1L, "file:///tmp/a.parquet", "file:///tmp/b.parquet");
+
+        assertEquals(3, client.submittedJobs.size());
+        for (RecordingQueryDataClient.SubmittedJob job : client.submittedJobs) {
+            assertEquals(JOB_PROJECT, job.project);
+            if (job.config instanceof LoadJobConfiguration) {
+                assertEquals(
+                        TEMP_PROJECT,
+                        ((LoadJobConfiguration) job.config).getDestinationTable().getProject());
+            } else {
+                assertEquals(
+                        PROJECT,
+                        ((CopyJobConfiguration) job.config).getDestinationTable().getProject());
+            }
+        }
 
         operator.close();
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -77,6 +77,7 @@ public class BigQueryDynamicTableSinkTest {
                     WriteMode.STORAGE_WRITE_API,
                     null,
                     null,
+                    null,
                     null);
 
     @RegisterExtension
@@ -160,7 +161,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/tmp",
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        "job_p");
 
         SinkV2Provider provider =
                 (SinkV2Provider)
@@ -193,7 +195,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         null,
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        "job_p");
 
         assertThatThrownBy(
                         () ->
@@ -226,7 +229,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/tmp",
                         "temp_p",
-                        null);
+                        null,
+                        "job_p");
 
         assertThatThrownBy(
                         () ->
@@ -259,7 +263,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/tmp",
                         null,
-                        "temp_d");
+                        "temp_d",
+                        "job_p");
 
         assertThatThrownBy(
                         () ->
@@ -267,6 +272,40 @@ public class BigQueryDynamicTableSinkTest {
                                         Mockito.mock(DynamicTableSink.Context.class)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("tempProject is required");
+    }
+
+    @Test
+    public void testSinkRuntimeProviderIndirectModeNullJobProjectThrows() {
+        BigQueryDynamicTableSink indirectSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        false,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        WriteMode.INDIRECT,
+                        "gs://bucket/tmp",
+                        "temp_p",
+                        "temp_d",
+                        null);
+
+        assertThatThrownBy(
+                        () ->
+                                indirectSink.getSinkRuntimeProvider(
+                                        Mockito.mock(DynamicTableSink.Context.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("jobProject is required");
     }
 
     @Test
@@ -292,7 +331,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/tmp",
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        "job_p");
         assertEquals(indirectSink, indirectSink.copy());
     }
 
@@ -319,7 +359,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/tmp",
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        null);
         BigQueryDynamicTableSink direct =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -339,9 +380,10 @@ public class BigQueryDynamicTableSinkTest {
                         null,
                         null,
                         WriteMode.STORAGE_WRITE_API,
-                        "gs://bucket/tmp",
-                        "temp_p",
-                        "temp_d");
+                        null,
+                        null,
+                        null,
+                        null);
         assertNotEquals(indirect, direct);
     }
 
@@ -368,7 +410,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/a",
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        null);
         BigQueryDynamicTableSink b =
                 new BigQueryDynamicTableSink(
                         StorageClientFaker.createConnectOptionsForWrite(null),
@@ -390,7 +433,8 @@ public class BigQueryDynamicTableSinkTest {
                         WriteMode.INDIRECT,
                         "gs://bucket/b",
                         "temp_p",
-                        "temp_d");
+                        "temp_d",
+                        null);
         assertNotEquals(a, b);
     }
 
@@ -415,6 +459,7 @@ public class BigQueryDynamicTableSinkTest {
                         "INTERVAL 10 MINUTE",
                         null,
                         WriteMode.STORAGE_WRITE_API,
+                        null,
                         null,
                         null,
                         null);


### PR DESCRIPTION
Adds an optional `write.indirect.bigquery-job-project` (SQL) / `jobProject` (DataStream) configuration that controls which GCP project BigQuery load and copy jobs are submitted under — i.e. where they show up in the BigQuery job list and which project gets billed for the slot usage. Defaults to the destination project (existing behaviour). The destination table and the temp tables are unaffected by this option.

This decouples job billing from the destination table, useful when the team that runs the Flink job and the team that owns the destination table sit in different GCP projects with separate quota and cost allocation.

---

This is (7/8) in the indirect-writes series:

- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/309
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/310
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/311
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/312
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/313
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/317
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/318
- https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/319
