### PR TITLE
Changed applyFilters so only filters rejected by BQ are left as remaining

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -170,7 +170,10 @@ public class BigQueryDynamicTableSource
                 translatedFilters.getOrDefault(true, new ArrayList<>()).stream()
                         .map(t -> t.f2)
                         .collect(Collectors.toList()),
-                filters);
+                // we now only add Calc filter node for filters not accepted by BQ
+                translatedFilters.getOrDefault(false, new ArrayList<>()).stream()
+                        .map(t -> t.f2)
+                        .collect(Collectors.toList()));
     }
 
     @VisibleForTesting

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -23,8 +23,16 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -151,6 +159,36 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testApplyFiltersReturnsOnlyUntranslatedFiltersForCalcNode() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(), SCHEMA.toPhysicalRowDataType());
+        ResolvedExpression translatableFilter =
+                createCallExpression(
+                        "greaterThan",
+                        BuiltInFunctionDefinitions.GREATER_THAN,
+                        createField("aaa", DataTypes.INT().notNull()),
+                        createLiteral(10, DataTypes.INT().notNull()));
+        ResolvedExpression untranslatableFilter =
+                createCallExpression(
+                        "equals",
+                        BuiltInFunctionDefinitions.EQUALS,
+                        createUnaryCallExpression(
+                                "upper",
+                                BuiltInFunctionDefinitions.UPPER,
+                                createField("bbb", DataTypes.STRING().notNull()),
+                                DataTypes.STRING().notNull()),
+                        createLiteral("ABC", DataTypes.STRING().notNull()));
+
+        SupportsFilterPushDown.Result result =
+                source.applyFilters(Arrays.asList(translatableFilter, untranslatableFilter));
+
+        assertThat(result.getAcceptedFilters()).containsExactly(translatableFilter);
+        assertThat(result.getRemainingFilters()).containsExactly(untranslatableFilter);
+        assertThat(source.getReadOptions().getRowRestriction()).isEqualTo("(aaa > 10)");
+    }
+
+    @Test
     public void testBigQuerySinkProperties() throws IOException {
         Map<String, String> properties = getRequiredOptions();
         Integer sinkParallelism = 5;
@@ -239,6 +277,40 @@ public class BigQueryDynamicTableFactoryTest {
                                 .setCredentialsOptions(CredentialsOptions.builder().build())
                                 .build())
                 .build();
+    }
+
+    private FieldReferenceExpression createField(String name, DataType type) {
+        return new FieldReferenceExpression(name, type, 0, 0);
+    }
+
+    private <T> ValueLiteralExpression createLiteral(T value, DataType type) {
+        return new ValueLiteralExpression(value, type);
+    }
+
+    private CallExpression createUnaryCallExpression(
+            String functionName,
+            FunctionDefinition functionDefinition,
+            ResolvedExpression child,
+            DataType outputDataType) {
+        return new CallExpression(
+                false,
+                FunctionIdentifier.of(functionName),
+                functionDefinition,
+                Collections.singletonList(child),
+                outputDataType);
+    }
+
+    private CallExpression createCallExpression(
+            String functionName,
+            FunctionDefinition functionDefinition,
+            ResolvedExpression left,
+            ResolvedExpression right) {
+        return new CallExpression(
+                false,
+                FunctionIdentifier.of(functionName),
+                functionDefinition,
+                Arrays.asList(left, right),
+                DataTypes.BOOLEAN());
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSource.java
@@ -173,7 +173,10 @@ public class BigQueryDynamicTableSource
                 translatedFilters.getOrDefault(true, new ArrayList<>()).stream()
                         .map(t -> t.f2)
                         .collect(Collectors.toList()),
-                filters);
+                // we now only add Calc filter node for filters not accepted by BQ
+                translatedFilters.getOrDefault(false, new ArrayList<>()).stream()
+                        .map(t -> t.f2)
+                        .collect(Collectors.toList()));
     }
 
     @VisibleForTesting

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -28,8 +28,16 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -181,6 +189,36 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testApplyFiltersReturnsOnlyUntranslatedFiltersForCalcNode() throws IOException {
+        BigQueryDynamicTableSource source =
+                new BigQueryDynamicTableSource(
+                        getConnectorOptions(), SCHEMA.toPhysicalRowDataType(), null);
+        ResolvedExpression translatableFilter =
+                createCallExpression(
+                        "greaterThan",
+                        BuiltInFunctionDefinitions.GREATER_THAN,
+                        createField("aaa", DataTypes.INT().notNull()),
+                        createLiteral(10, DataTypes.INT().notNull()));
+        ResolvedExpression untranslatableFilter =
+                createCallExpression(
+                        "equals",
+                        BuiltInFunctionDefinitions.EQUALS,
+                        createUnaryCallExpression(
+                                "upper",
+                                BuiltInFunctionDefinitions.UPPER,
+                                createField("bbb", DataTypes.STRING().notNull()),
+                                DataTypes.STRING().notNull()),
+                        createLiteral("ABC", DataTypes.STRING().notNull()));
+
+        SupportsFilterPushDown.Result result =
+                source.applyFilters(Arrays.asList(translatableFilter, untranslatableFilter));
+
+        assertThat(result.getAcceptedFilters()).containsExactly(translatableFilter);
+        assertThat(result.getRemainingFilters()).containsExactly(untranslatableFilter);
+        assertThat(source.getReadOptions().getRowRestriction()).isEqualTo("(aaa > 10)");
+    }
+
+    @Test
     public void testBigQuerySinkProperties() throws IOException {
         Map<String, String> properties = getRequiredOptions();
         Integer sinkParallelism = 5;
@@ -269,6 +307,40 @@ public class BigQueryDynamicTableFactoryTest {
                                 .setCredentialsOptions(CredentialsOptions.builder().build())
                                 .build())
                 .build();
+    }
+
+    private FieldReferenceExpression createField(String name, DataType type) {
+        return new FieldReferenceExpression(name, type, 0, 0);
+    }
+
+    private <T> ValueLiteralExpression createLiteral(T value, DataType type) {
+        return new ValueLiteralExpression(value, type);
+    }
+
+    private CallExpression createUnaryCallExpression(
+            String functionName,
+            FunctionDefinition functionDefinition,
+            ResolvedExpression child,
+            DataType outputDataType) {
+        return new CallExpression(
+                false,
+                FunctionIdentifier.of(functionName),
+                functionDefinition,
+                Collections.singletonList(child),
+                outputDataType);
+    }
+
+    private CallExpression createCallExpression(
+            String functionName,
+            FunctionDefinition functionDefinition,
+            ResolvedExpression left,
+            ResolvedExpression right) {
+        return new CallExpression(
+                false,
+                FunctionIdentifier.of(functionName),
+                functionDefinition,
+                Arrays.asList(left, right),
+                DataTypes.BOOLEAN());
     }
 
     @Test


### PR DESCRIPTION
# Current

The BQ connector will attempt to 'push-down' all viable filters from the Flink query into the BQ read session's row-restrictions (as defined in BigQueryRestriction.java). But instead of only having those filters that are rejected from the row-restriction being utilized to create a in Flink Calc node filter, it will reapply all the filters (pushed-down or not) as an added redundancy.

This PR removes that redundant filtering and has it so only rejected filters are used in the Calc node within the Flink plan.

# Precedent + Question

This pattern we are adopting here follows more closely with what is done in Apache Beam SQL BigQueryTable (DIRECT_READ mode) and spark-bigquery 2.4 (data-source v1). We do however see your existing pattern in spark-bigquery 3.x (dsv2) so are curious to hear your original design rationale about having your rejected filters handled like this.