### PR TITLE
Support nested fields in row-restrictions

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
@@ -20,6 +20,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.NestedFieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
@@ -116,14 +117,10 @@ public class BigQueryRestriction {
         Operation op = FILTERS.get(call.getFunctionDefinition());
         switch (op) {
             case IS_NULL:
-                return onlyChildAs(call, FieldReferenceExpression.class)
-                        .map(FieldReferenceExpression::getName)
-                        .map(field -> field + " IS NULL");
+                return onlyChildColumnPath(call).map(field -> field + " IS NULL");
 
             case NOT_NULL:
-                return onlyChildAs(call, FieldReferenceExpression.class)
-                        .map(FieldReferenceExpression::getName)
-                        .map(field -> "NOT " + field + " IS NULL");
+                return onlyChildColumnPath(call).map(field -> "NOT " + field + " IS NULL");
 
             case LT:
                 return convertOperationPartsWithItsSymbol("<", call);
@@ -189,8 +186,9 @@ public class BigQueryRestriction {
         Expression left = args.get(0);
         Expression right = args.get(1);
 
-        if (left instanceof FieldReferenceExpression && right instanceof ValueLiteralExpression) {
-            String name = ((FieldReferenceExpression) left).getName();
+        Optional<String> leftPath = toColumnPath(left);
+        if (leftPath.isPresent() && right instanceof ValueLiteralExpression) {
+            String name = leftPath.get();
             return convertLiteral((ValueLiteralExpression) right)
                     .flatMap(
                             lit -> {
@@ -210,6 +208,34 @@ public class BigQueryRestriction {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Resolves a top-level or nested field reference to a BigQuery column path.
+     *
+     * <p>Nested field references are returned as dotted paths, e.g. {@code address.city}
+     */
+    private static Optional<String> toColumnPath(Expression expr) {
+        if (expr instanceof FieldReferenceExpression) {
+            return Optional.of(((FieldReferenceExpression) expr).getName());
+        }
+        if (expr instanceof NestedFieldReferenceExpression) {
+            return Optional.of(
+                    String.join(".", ((NestedFieldReferenceExpression) expr).getFieldNames()));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Ensures that expression only contains singular 'child', then attempt to get appropriate field
+     * reference path (nested or top-level).
+     */
+    private static Optional<String> onlyChildColumnPath(CallExpression call) {
+        List<ResolvedExpression> children = call.getResolvedChildren();
+        if (children.size() != 1) {
+            return Optional.empty();
+        }
+        return toColumnPath(children.get(0));
     }
 
     private static Optional<String> convertLogicExpressionWithOperandsSymbol(
@@ -268,13 +294,14 @@ public class BigQueryRestriction {
 
         Optional<Object> leftOption = Optional.empty();
         Optional<Object> rightOption = Optional.empty();
-        if (left instanceof FieldReferenceExpression && right instanceof ValueLiteralExpression) {
-            leftOption = Optional.of(((FieldReferenceExpression) left).getName());
+        Optional<String> leftPath = toColumnPath(left);
+        Optional<String> rightPath = toColumnPath(right);
+        if (leftPath.isPresent() && right instanceof ValueLiteralExpression) {
+            leftOption = Optional.of(leftPath.get());
             rightOption = convertLiteral((ValueLiteralExpression) right);
-        } else if (left instanceof ValueLiteralExpression
-                && right instanceof FieldReferenceExpression) {
+        } else if (left instanceof ValueLiteralExpression && rightPath.isPresent()) {
             leftOption = convertLiteral((ValueLiteralExpression) left);
-            rightOption = Optional.of(((FieldReferenceExpression) right).getName());
+            rightOption = Optional.of(rightPath.get());
         }
 
         if (leftOption.isPresent() && rightOption.isPresent()) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
@@ -19,9 +19,11 @@ package com.google.cloud.flink.bigquery.table.restrictions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.NestedFieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.types.DataType;
 
@@ -110,8 +112,190 @@ public class BigQueryRestrictionTest {
                 "(date_field = '2025-01-01')");
     }
 
+    @Test
+    public void testNestedFieldEqualsLiteral() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+        ValueLiteralExpression literal =
+                this.<String>createLiteral("Toronto", DataTypes.STRING().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(createEqualsCallExpression(field, literal));
+
+        assertThat(result).hasValue("(address.city = 'Toronto')");
+    }
+
+    @Test
+    public void testNestedFieldEqualsLiteralWithLiteralOnLeft() {
+        ValueLiteralExpression literal = createLiteral("Toronto", DataTypes.STRING().notNull());
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(createEqualsCallExpression(literal, field));
+
+        assertThat(result).hasValue("('Toronto' = address.city)");
+    }
+
+    @Test
+    public void testNestedFieldIsNull() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "isNull",
+                                BuiltInFunctionDefinitions.IS_NULL,
+                                DataTypes.BOOLEAN(),
+                                field));
+
+        assertThat(result).hasValue("address.city IS NULL");
+    }
+
+    @Test
+    public void testNestedFieldIsNotNull() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "isNotNull",
+                                BuiltInFunctionDefinitions.IS_NOT_NULL,
+                                DataTypes.BOOLEAN(),
+                                field));
+
+        assertThat(result).hasValue("NOT address.city IS NULL");
+    }
+
+    @Test
+    public void testNestedFieldGreaterThanLiteral() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "zip"}, new int[] {1, 1}, DataTypes.INT());
+        ValueLiteralExpression literal = createLiteral(10000, DataTypes.INT().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(createGreaterThanCallExpression(field, literal));
+
+        assertThat(result).hasValue("(address.zip > 10000)");
+    }
+
+    @Test
+    public void testNestedAnd() {
+        NestedFieldReferenceExpression city =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+        NestedFieldReferenceExpression zip =
+                createNestedField(
+                        new String[] {"address", "zip"}, new int[] {1, 1}, DataTypes.INT());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createAndCallExpression(
+                                createEqualsCallExpression(
+                                        city,
+                                        createLiteral("Toronto", DataTypes.STRING().notNull())),
+                                createGreaterThanCallExpression(
+                                        zip, createLiteral(10000, DataTypes.INT().notNull()))));
+
+        assertThat(result).hasValue("((address.city = 'Toronto') AND (address.zip > 10000))");
+    }
+
+    @Test
+    public void testNestedOr() {
+        NestedFieldReferenceExpression city =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+        NestedFieldReferenceExpression country =
+                createNestedField(
+                        new String[] {"address", "country"}, new int[] {1, 1}, DataTypes.STRING());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createOrCallExpression(
+                                createEqualsCallExpression(
+                                        city,
+                                        createLiteral("Toronto", DataTypes.STRING().notNull())),
+                                createEqualsCallExpression(
+                                        country,
+                                        createLiteral("CA", DataTypes.STRING().notNull()))));
+
+        assertThat(result).hasValue("((address.city = 'Toronto') OR (address.country = 'CA'))");
+    }
+
+    @Test
+    public void testMultiLevelNestedFieldEqualsLiteral() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"customer", "address", "city"},
+                        new int[] {3, 1, 0},
+                        DataTypes.STRING());
+        ValueLiteralExpression literal = createLiteral("Toronto", DataTypes.STRING().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(createEqualsCallExpression(field, literal));
+
+        assertThat(result).hasValue("(customer.address.city = 'Toronto')");
+    }
+
+    @Test
+    public void testNotNestedFieldEqualsLiteral() {
+        NestedFieldReferenceExpression field =
+                createNestedField(
+                        new String[] {"address", "city"}, new int[] {1, 0}, DataTypes.STRING());
+        ValueLiteralExpression literal = createLiteral("Toronto", DataTypes.STRING().notNull());
+        CallExpression equalsCall = createEqualsCallExpression(field, literal);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "not",
+                                BuiltInFunctionDefinitions.NOT,
+                                DataTypes.BOOLEAN(),
+                                equalsCall));
+
+        assertThat(result).hasValue("NOT (address.city = 'Toronto')");
+    }
+
+    @Test
+    public void testTopLevelFieldEqualsLiteral() {
+        FieldReferenceExpression field = createField("city", DataTypes.STRING());
+        ValueLiteralExpression literal = createLiteral("Toronto", DataTypes.STRING().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(createEqualsCallExpression(field, literal));
+
+        assertThat(result).hasValue("(city = 'Toronto')");
+    }
+
+    @Test
+    public void testTopLevelFieldIsNull() {
+        FieldReferenceExpression field = createField("city", DataTypes.STRING());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "isNull",
+                                BuiltInFunctionDefinitions.IS_NULL,
+                                DataTypes.BOOLEAN(),
+                                field));
+
+        assertThat(result).hasValue("city IS NULL");
+    }
+
     private FieldReferenceExpression createField(String name, DataType type) {
         return new FieldReferenceExpression(name, type, 0, 0);
+    }
+
+    private NestedFieldReferenceExpression createNestedField(
+            String[] fieldNames, int[] fieldIndices, DataType type) {
+        return new NestedFieldReferenceExpression(fieldNames, fieldIndices, type);
     }
 
     private <T> ValueLiteralExpression createLiteral(T value, DataType type) {
@@ -120,12 +304,49 @@ public class BigQueryRestrictionTest {
 
     private CallExpression createEqualsCallExpression(
             ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "equals", BuiltInFunctionDefinitions.EQUALS, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createGreaterThanCallExpression(
+            ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "greaterThan",
+                BuiltInFunctionDefinitions.GREATER_THAN,
+                DataTypes.BOOLEAN(),
+                left,
+                right);
+    }
+
+    private CallExpression createLikeCallExpression(
+            ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "like", BuiltInFunctionDefinitions.LIKE, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createAndCallExpression(
+            ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "and", BuiltInFunctionDefinitions.AND, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createOrCallExpression(
+            ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "or", BuiltInFunctionDefinitions.OR, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createCallExpression(
+            String name,
+            FunctionDefinition functionDefinition,
+            DataType outputDataType,
+            ResolvedExpression... children) {
         return new CallExpression(
                 false,
-                FunctionIdentifier.of("equals"),
-                BuiltInFunctionDefinitions.EQUALS,
-                Arrays.asList(left, right),
-                DataTypes.BOOLEAN());
+                FunctionIdentifier.of(name),
+                functionDefinition,
+                Arrays.asList(children),
+                outputDataType);
     }
 
     private void assertTemporalConversion(


### PR DESCRIPTION
Updated the BigQueryRestriction class to be able to handle NestedFieldReferenceExpression which are used for nested field references. This will allow for users to push-down filters that reference nested-columns.

Note this only effects Flink 2.1 because in Flink 1.17 there was no support for referencing nested fields in a filter (i.e no [NestedFieldReferenceExpression](https://cwiki.apache.org/confluence/display/FLINK/FLIP-356%3A+Support+Nested+Fields+Filter+Pushdown)) meaning that there would be no way to extract the referenced nested column for filtering.