### PR TITLE
Null-check unsupported function definitions in BigQueryRestriction.convert

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
@@ -25,8 +25,6 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 
-import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -104,6 +102,14 @@ public class BigQueryRestriction {
      * BETWEEN will be converted to (GT_EQ AND LT_EQ), the NOT_BETWEEN will be converted to (LT_EQ
      * OR GT_EQ), the IN will be converted to OR, so we do not add the conversion here
      *
+     * <p>Expressions whose top-level {@link FunctionDefinition} is not in the supported {@link
+     * #FILTERS} map (e.g. {@code COALESCE}, {@code CASE}, {@code IF}, {@code CAST}) return {@link
+     * Optional#empty()}. The caller ({@code BigQueryDynamicTableSource.applyFilters}) treats an
+     * empty result as "rejected by BigQuery" and leaves the predicate as a remaining Flink Calc
+     * filter, which is also why a sub-expression of {@code NOT} that is unsupported must short-
+     * circuit to empty rather than throw: the {@code NOT} case recurses through {@code convert} and
+     * any unmapped child function would otherwise crash job planning.
+     *
      * @param flinkExpression the Flink expression
      * @return An {@link Optional} potentially containing the resolved row restriction for BigQuery.
      */
@@ -114,6 +120,11 @@ public class BigQueryRestriction {
 
         CallExpression call = (CallExpression) flinkExpression;
         Operation op = FILTERS.get(call.getFunctionDefinition());
+        if (op == null) {
+            // Need to check first of op is null, otherwise will get npe trying to call ordinal on
+            // null. If unknown we try to apply filter Flink side
+            return Optional.empty();
+        }
         switch (op) {
             case IS_NULL:
                 return onlyChildAs(call, FieldReferenceExpression.class)
@@ -158,10 +169,8 @@ public class BigQueryRestriction {
                 return convertLike(call);
 
             default:
-                throw new BigQueryConnectorException(
-                        String.format(
-                                "The provided Flink expression is not supported %s.",
-                                call.getFunctionName()));
+                // Defensive check if there exists something FILTERS we don't explicitly handle
+                return Optional.empty();
         }
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.types.DataType;
 
@@ -110,6 +111,71 @@ public class BigQueryRestrictionTest {
                 "(date_field = '2025-01-01')");
     }
 
+    @Test
+    public void testUnsupportedTopLevelFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "coalesce",
+                                BuiltInFunctionDefinitions.COALESCE,
+                                DataTypes.BOOLEAN(),
+                                field,
+                                fallback));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testNotOfUnsupportedFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+        CallExpression coalesceCall =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        field,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "not",
+                                BuiltInFunctionDefinitions.NOT,
+                                DataTypes.BOOLEAN(),
+                                coalesceCall));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testAndOfSupportedAndUnsupportedReturnsEmpty() {
+        FieldReferenceExpression city = createField("city", DataTypes.STRING());
+        ValueLiteralExpression toronto = createLiteral("Toronto", DataTypes.STRING().notNull());
+        FieldReferenceExpression flag = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        CallExpression supportedSide = createEqualsCallExpression(city, toronto);
+        CallExpression unsupportedSide =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        flag,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createAndCallExpression(supportedSide, unsupportedSide));
+
+        // The whole AND collapses to empty (mixed pushability is not partially expressible as a
+        // single row restriction); applyFilters then leaves the AND as a remaining Flink filter.
+        assertThat(result).isEmpty();
+    }
+
     private FieldReferenceExpression createField(String name, DataType type) {
         return new FieldReferenceExpression(name, type, 0, 0);
     }
@@ -120,12 +186,27 @@ public class BigQueryRestrictionTest {
 
     private CallExpression createEqualsCallExpression(
             ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "equals", BuiltInFunctionDefinitions.EQUALS, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createAndCallExpression(
+            ResolvedExpression left, ResolvedExpression right) {
+        return createCallExpression(
+                "and", BuiltInFunctionDefinitions.AND, DataTypes.BOOLEAN(), left, right);
+    }
+
+    private CallExpression createCallExpression(
+            String name,
+            FunctionDefinition functionDefinition,
+            DataType outputDataType,
+            ResolvedExpression... children) {
         return new CallExpression(
                 false,
-                FunctionIdentifier.of("equals"),
-                BuiltInFunctionDefinitions.EQUALS,
-                Arrays.asList(left, right),
-                DataTypes.BOOLEAN());
+                FunctionIdentifier.of(name),
+                functionDefinition,
+                Arrays.asList(children),
+                outputDataType);
     }
 
     private void assertTemporalConversion(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 
-import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -105,6 +103,14 @@ public class BigQueryRestriction {
      * BETWEEN will be converted to (GT_EQ AND LT_EQ), the NOT_BETWEEN will be converted to (LT_EQ
      * OR GT_EQ), the IN will be converted to OR, so we do not add the conversion here
      *
+     * <p>Expressions whose top-level {@link FunctionDefinition} is not in the supported {@link
+     * #FILTERS} map (e.g. {@code COALESCE}, {@code CASE}, {@code IF}, {@code CAST}) return {@link
+     * Optional#empty()}. The caller ({@code BigQueryDynamicTableSource.applyFilters}) treats an
+     * empty result as "rejected by BigQuery" and leaves the predicate as a remaining Flink Calc
+     * filter, which is also why a sub-expression of {@code NOT} that is unsupported must short-
+     * circuit to empty rather than throw: the {@code NOT} case recurses through {@code convert} and
+     * any unmapped child function would otherwise crash job planning.
+     *
      * @param flinkExpression the Flink expression
      * @return An {@link Optional} potentially containing the resolved row restriction for BigQuery.
      */
@@ -115,6 +121,11 @@ public class BigQueryRestriction {
 
         CallExpression call = (CallExpression) flinkExpression;
         Operation op = FILTERS.get(call.getFunctionDefinition());
+        if (op == null) {
+            // Need to check first of op is null, otherwise will get npe trying to call ordinal on
+            // null. If unknown we try to apply filter Flink side
+            return Optional.empty();
+        }
         switch (op) {
             case IS_NULL:
                 return onlyChildColumnPath(call).map(field -> field + " IS NULL");
@@ -155,10 +166,8 @@ public class BigQueryRestriction {
                 return convertLike(call);
 
             default:
-                throw new BigQueryConnectorException(
-                        String.format(
-                                "The provided Flink expression is not supported %s.",
-                                call.getFunctionName()));
+                // Defensive check if there exists something FILTERS we don't explicitly handle
+                return Optional.empty();
         }
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
@@ -289,6 +289,71 @@ public class BigQueryRestrictionTest {
         assertThat(result).hasValue("city IS NULL");
     }
 
+    @Test
+    public void testUnsupportedTopLevelFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "coalesce",
+                                BuiltInFunctionDefinitions.COALESCE,
+                                DataTypes.BOOLEAN(),
+                                field,
+                                fallback));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testNotOfUnsupportedFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+        CallExpression coalesceCall =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        field,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "not",
+                                BuiltInFunctionDefinitions.NOT,
+                                DataTypes.BOOLEAN(),
+                                coalesceCall));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testAndOfSupportedAndUnsupportedReturnsEmpty() {
+        FieldReferenceExpression city = createField("city", DataTypes.STRING());
+        ValueLiteralExpression toronto = createLiteral("Toronto", DataTypes.STRING().notNull());
+        FieldReferenceExpression flag = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        CallExpression supportedSide = createEqualsCallExpression(city, toronto);
+        CallExpression unsupportedSide =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        flag,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createAndCallExpression(supportedSide, unsupportedSide));
+
+        // The whole AND collapses to empty (mixed pushability is not partially expressible as a
+        // single row restriction); applyFilters then leaves the AND as a remaining Flink filter.
+        assertThat(result).isEmpty();
+    }
+
     private FieldReferenceExpression createField(String name, DataType type) {
         return new FieldReferenceExpression(name, type, 0, 0);
     }


### PR DESCRIPTION
# Context
BigQueryRestriction.convert looks up the call's FunctionDefinition in the FILTERS map and then does switch (op) without a null check. Any function definition not in the map (e.g. COALESCE, CASE, IF, CAST) unboxes a null Operation and throws NullPointerException during job planning.

I believe the original intention was for this to be caught by the `default` case, but as the switch calls `ordinal()` on null, the NPE is thrown before it ever gets there.

# Fixes

- By adding a null check before the other cases this prevents the hitting of an NPE on unknown operation
- Instead of throwing exception on default, we just follow the correct pattern of returning Optional.empty() which indicates to the caller that this filter needs to be handled on the Flink side. NOTE, this default case is defensive and never hit in practice.