### PR TITLE
feat: add support for BigQuery views, materialization, and billing configurations in Table API

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -82,6 +82,11 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
         additionalOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         additionalOptions.add(BigQueryConnectorOptions.REGION);
+        additionalOptions.add(BigQueryConnectorOptions.VIEWS_ENABLED);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_PROJECT);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS);
+        additionalOptions.add(BigQueryConnectorOptions.BILLING_PROJECT);
 
         return additionalOptions;
     }
@@ -111,6 +116,11 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         forwardOptions.add(BigQueryConnectorOptions.REGION);
         forwardOptions.add(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
+        forwardOptions.add(BigQueryConnectorOptions.VIEWS_ENABLED);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_PROJECT);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS);
+        forwardOptions.add(BigQueryConnectorOptions.BILLING_PROJECT);
 
         return forwardOptions;
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -133,6 +134,19 @@ public class BigQueryDynamicTableFactory
         BigQueryTableConfigurationProvider configProvider =
                 new BigQueryTableConfigurationProvider(helper.getOptions());
         helper.validate();
+
+        Boolean viewsEnabled = helper.getOptions().get(BigQueryConnectorOptions.VIEWS_ENABLED);
+        if (Boolean.TRUE.equals(viewsEnabled)) {
+            String materializationDataset =
+                    helper.getOptions().get(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+            if (materializationDataset == null || materializationDataset.trim().isEmpty()) {
+                throw new ValidationException(
+                        String.format(
+                                "Option '%s' must be set when '%s' is set to true.",
+                                BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(),
+                                BigQueryConnectorOptions.VIEWS_ENABLED.key()));
+            }
+        }
 
         if (configProvider.isTestModeEnabled()) {
             configProvider = configProvider.withTestingServices(testingServices);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -246,7 +246,9 @@ public class BigQueryConnectorOptions {
                     .noDefaultValue()
                     .withDescription("GCP project where the temporary table is materialized.");
 
-    /** [OPTIONAL, Read Configuration] BigQuery dataset where the temporary table is materialized. */
+    /**
+     * [OPTIONAL, Read Configuration] BigQuery dataset where the temporary table is materialized.
+     */
     public static final ConfigOption<String> MATERIALIZATION_DATASET =
             ConfigOptions.key("read.views.materialization-dataset")
                     .stringType()

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -229,4 +229,41 @@ public class BigQueryConnectorOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Fail if serializer cannot convert record to proto");
+
+    /**
+     * [OPTIONAL, Read Configuration] Boolean value indicating if reading BigQuery views is enabled.
+     */
+    public static final ConfigOption<Boolean> VIEWS_ENABLED =
+            ConfigOptions.key("read.views.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Specifies if reading BigQuery views is enabled.");
+
+    /** [OPTIONAL, Read Configuration] GCP project where the temporary table is materialized. */
+    public static final ConfigOption<String> MATERIALIZATION_PROJECT =
+            ConfigOptions.key("read.views.materialization-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("GCP project where the temporary table is materialized.");
+
+    /** [OPTIONAL, Read Configuration] BigQuery dataset where the temporary table is materialized. */
+    public static final ConfigOption<String> MATERIALIZATION_DATASET =
+            ConfigOptions.key("read.views.materialization-dataset")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("BigQuery dataset where the temporary table is materialized.");
+
+    /** [OPTIONAL, Read Configuration] Expiration hours for the materialized temporary table. */
+    public static final ConfigOption<Integer> MATERIALIZATION_EXPIRATION_HOURS =
+            ConfigOptions.key("read.views.materialization-expiration-hours")
+                    .intType()
+                    .defaultValue(24)
+                    .withDescription("Expiration hours for the materialized temporary table.");
+
+    /** [OPTIONAL, Read Configuration] GCP project under which the materialization job is billed. */
+    public static final ConfigOption<String> BILLING_PROJECT =
+            ConfigOptions.key("read.views.billing-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("GCP project under which the materialization job is billed.");
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
@@ -249,12 +249,14 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             return this;
         }
 
-        public BigQueryReadTableConfig.Builder materializationProject(String materializationProject) {
+        public BigQueryReadTableConfig.Builder materializationProject(
+                String materializationProject) {
             this.materializationProject = materializationProject;
             return this;
         }
 
-        public BigQueryReadTableConfig.Builder materializationDataset(String materializationDataset) {
+        public BigQueryReadTableConfig.Builder materializationDataset(
+                String materializationDataset) {
             this.materializationDataset = materializationDataset;
             return this;
         }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
@@ -32,6 +32,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
     private final String columnProjection;
     private final Integer maxStreamCount;
     private final Long snapshotTimestamp;
+    private final Boolean viewsEnabled;
+    private final String materializationProject;
+    private final String materializationDataset;
+    private final Integer materializationExpirationHours;
+    private final String billingProject;
 
     BigQueryReadTableConfig(
             String project,
@@ -46,7 +51,12 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             Integer maxStreamCount,
             String rowRestriction,
             Integer limit,
-            Long snapshotTimestamp) {
+            Long snapshotTimestamp,
+            Boolean viewsEnabled,
+            String materializationProject,
+            String materializationDataset,
+            Integer materializationExpirationHours,
+            String billingProject) {
         super(
                 project,
                 quotaProjectId,
@@ -62,6 +72,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
         this.limit = limit;
         this.maxStreamCount = maxStreamCount;
         this.snapshotTimestamp = snapshotTimestamp;
+        this.viewsEnabled = viewsEnabled;
+        this.materializationProject = materializationProject;
+        this.materializationDataset = materializationDataset;
+        this.materializationExpirationHours = materializationExpirationHours;
+        this.billingProject = billingProject;
     }
 
     public static BigQueryReadTableConfig.Builder newBuilder() {
@@ -91,6 +106,27 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             tableDescriptorBuilder.option(
                     BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP, this.snapshotTimestamp);
         }
+        if (this.viewsEnabled != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.VIEWS_ENABLED, this.viewsEnabled);
+        }
+        if (this.materializationProject != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_PROJECT, this.materializationProject);
+        }
+        if (this.materializationDataset != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_DATASET, this.materializationDataset);
+        }
+        if (this.materializationExpirationHours != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS,
+                    this.materializationExpirationHours);
+        }
+        if (this.billingProject != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.BILLING_PROJECT, this.billingProject);
+        }
         return tableDescriptorBuilder.build();
     }
 
@@ -103,6 +139,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
         private String columnProjection;
         private Integer maxStreamCount;
         private Long snapshotTimestamp;
+        private Boolean viewsEnabled;
+        private String materializationProject;
+        private String materializationDataset;
+        private Integer materializationExpirationHours;
+        private String billingProject;
 
         @Override
         public BigQueryReadTableConfig.Builder project(String project) {
@@ -203,6 +244,32 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             return this;
         }
 
+        public BigQueryReadTableConfig.Builder viewsEnabled(Boolean viewsEnabled) {
+            this.viewsEnabled = viewsEnabled;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationProject(String materializationProject) {
+            this.materializationProject = materializationProject;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationDataset(String materializationDataset) {
+            this.materializationDataset = materializationDataset;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationExpirationHours(
+                Integer materializationExpirationHours) {
+            this.materializationExpirationHours = materializationExpirationHours;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder billingProject(String billingProject) {
+            this.billingProject = billingProject;
+            return this;
+        }
+
         public BigQueryReadTableConfig build() {
             return new BigQueryReadTableConfig(
                     project,
@@ -217,7 +284,12 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
                     maxStreamCount,
                     rowRestriction,
                     limit,
-                    snapshotTimestamp);
+                    snapshotTimestamp,
+                    viewsEnabled,
+                    materializationProject,
+                    materializationDataset,
+                    materializationExpirationHours,
+                    billingProject);
         }
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -129,6 +129,14 @@ public class BigQueryTableConfigurationProvider {
                                 .setQuotaProjectId(
                                         config.get(BigQueryConnectorOptions.QUOTA_PROJECT_ID))
                                 .build())
+                .setViewsEnabled(config.get(BigQueryConnectorOptions.VIEWS_ENABLED))
+                .setMaterializedTableExpirationHours(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS))
+                .setMaterializationProject(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_PROJECT))
+                .setMaterializationDataset(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_DATASET))
+                .setBillingProject(config.get(BigQueryConnectorOptions.BILLING_PROJECT))
                 .build();
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -114,6 +114,39 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testBigQueryReadPropertiesWithViews() throws IOException {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put(BigQueryConnectorOptions.VIEWS_ENABLED.key(), "true");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_PROJECT.key(), "temp-project");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(), "temp_dataset");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS.key(), "6");
+        properties.put(BigQueryConnectorOptions.BILLING_PROJECT.key(), "billing-project");
+
+        DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, properties);
+
+        BigQueryReadOptions readOptions =
+                BigQueryReadOptions.builder()
+                        .setBigQueryConnectOptions(
+                                BigQueryConnectOptions.builder()
+                                        .setDataset("dataset")
+                                        .setProjectId("project")
+                                        .setTable("table")
+                                        .setCredentialsOptions(CredentialsOptions.builder().build())
+                                        .setViewsEnabled(true)
+                                        .setMaterializationProject("temp-project")
+                                        .setMaterializationDataset("temp_dataset")
+                                        .setMaterializedTableExpirationHours(6)
+                                        .setBillingProject("billing-project")
+                                        .build())
+                        .build();
+
+        BigQueryDynamicTableSource expected =
+                new BigQueryDynamicTableSource(readOptions, SCHEMA.toPhysicalRowDataType());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void testDefaultColumnNamesAreAllDdlColumns() throws IOException {
         DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.table;
 
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
@@ -144,6 +145,22 @@ public class BigQueryDynamicTableFactoryTest {
                 new BigQueryDynamicTableSource(readOptions, SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testBigQueryReadPropertiesWithViewsMissingDataset() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put(BigQueryConnectorOptions.VIEWS_ENABLED.key(), "true");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_PROJECT.key(), "temp-project");
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSource(SCHEMA, properties))
+                .isInstanceOf(ValidationException.class)
+                .getCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Option '%s' must be set when '%s' is set to true.",
+                                BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(),
+                                BigQueryConnectorOptions.VIEWS_ENABLED.key()));
     }
 
     @Test

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery-integration-test/src/main/java/com/google/cloud/flink/bigquery/integration/BigQueryIntegrationTest.java
@@ -717,6 +717,10 @@ public class BigQueryIntegrationTest {
                         .dataset(sourceDatasetName)
                         .table(sourceTableName)
                         .testMode(false)
+                        .viewsEnabled(true)
+                        .materializationProject(matProject)
+                        .materializationDataset(matDataset)
+                        .billingProject(billProject)
                         .build();
 
         // Register the Source Table

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -92,6 +92,11 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
         additionalOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
         additionalOptions.add(BigQueryConnectorOptions.WRITE_JOB_PROJECT);
+        additionalOptions.add(BigQueryConnectorOptions.VIEWS_ENABLED);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_PROJECT);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+        additionalOptions.add(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS);
+        additionalOptions.add(BigQueryConnectorOptions.BILLING_PROJECT);
 
         return additionalOptions;
     }
@@ -131,6 +136,11 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_PROJECT);
         forwardOptions.add(BigQueryConnectorOptions.WRITE_TEMP_DATASET);
         forwardOptions.add(BigQueryConnectorOptions.WRITE_JOB_PROJECT);
+        forwardOptions.add(BigQueryConnectorOptions.VIEWS_ENABLED);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_PROJECT);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+        forwardOptions.add(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS);
+        forwardOptions.add(BigQueryConnectorOptions.BILLING_PROJECT);
 
         return forwardOptions;
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -153,6 +154,19 @@ public class BigQueryDynamicTableFactory
         BigQueryTableConfigurationProvider configProvider =
                 new BigQueryTableConfigurationProvider(helper.getOptions());
         helper.validate();
+
+        Boolean viewsEnabled = helper.getOptions().get(BigQueryConnectorOptions.VIEWS_ENABLED);
+        if (Boolean.TRUE.equals(viewsEnabled)) {
+            String materializationDataset =
+                    helper.getOptions().get(BigQueryConnectorOptions.MATERIALIZATION_DATASET);
+            if (materializationDataset == null || materializationDataset.trim().isEmpty()) {
+                throw new ValidationException(
+                        String.format(
+                                "Option '%s' must be set when '%s' is set to true.",
+                                BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(),
+                                BigQueryConnectorOptions.VIEWS_ENABLED.key()));
+            }
+        }
 
         if (configProvider.isTestModeEnabled()) {
             configProvider = configProvider.withTestingServices(testingServices);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -360,4 +360,43 @@ public class BigQueryConnectorOptions {
                     .withDescription(
                             "GCP project under which BigQuery load and copy jobs are submitted "
                                     + "(required for INDIRECT write mode).");
+
+    /**
+     * [OPTIONAL, Read Configuration] Boolean value indicating if reading BigQuery views is enabled.
+     */
+    public static final ConfigOption<Boolean> VIEWS_ENABLED =
+            ConfigOptions.key("read.views.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Specifies if reading BigQuery views is enabled.");
+
+    /** [OPTIONAL, Read Configuration] GCP project where the temporary table is materialized. */
+    public static final ConfigOption<String> MATERIALIZATION_PROJECT =
+            ConfigOptions.key("read.views.materialization-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("GCP project where the temporary table is materialized.");
+
+    /**
+     * [OPTIONAL, Read Configuration] BigQuery dataset where the temporary table is materialized.
+     */
+    public static final ConfigOption<String> MATERIALIZATION_DATASET =
+            ConfigOptions.key("read.views.materialization-dataset")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("BigQuery dataset where the temporary table is materialized.");
+
+    /** [OPTIONAL, Read Configuration] Expiration hours for the materialized temporary table. */
+    public static final ConfigOption<Integer> MATERIALIZATION_EXPIRATION_HOURS =
+            ConfigOptions.key("read.views.materialization-expiration-hours")
+                    .intType()
+                    .defaultValue(24)
+                    .withDescription("Expiration hours for the materialized temporary table.");
+
+    /** [OPTIONAL, Read Configuration] GCP project under which the materialization job is billed. */
+    public static final ConfigOption<String> BILLING_PROJECT =
+            ConfigOptions.key("read.views.billing-project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("GCP project under which the materialization job is billed.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryReadTableConfig.java
@@ -32,6 +32,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
     private final String columnProjection;
     private final Integer maxStreamCount;
     private final Long snapshotTimestamp;
+    private final Boolean viewsEnabled;
+    private final String materializationProject;
+    private final String materializationDataset;
+    private final Integer materializationExpirationHours;
+    private final String billingProject;
 
     BigQueryReadTableConfig(
             String project,
@@ -46,7 +51,12 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             Integer maxStreamCount,
             String rowRestriction,
             Integer limit,
-            Long snapshotTimestamp) {
+            Long snapshotTimestamp,
+            Boolean viewsEnabled,
+            String materializationProject,
+            String materializationDataset,
+            Integer materializationExpirationHours,
+            String billingProject) {
         super(
                 project,
                 quotaProjectId,
@@ -62,6 +72,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
         this.limit = limit;
         this.maxStreamCount = maxStreamCount;
         this.snapshotTimestamp = snapshotTimestamp;
+        this.viewsEnabled = viewsEnabled;
+        this.materializationProject = materializationProject;
+        this.materializationDataset = materializationDataset;
+        this.materializationExpirationHours = materializationExpirationHours;
+        this.billingProject = billingProject;
     }
 
     public static BigQueryReadTableConfig.Builder newBuilder() {
@@ -91,6 +106,27 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             tableDescriptorBuilder.option(
                     BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP, this.snapshotTimestamp);
         }
+        if (this.viewsEnabled != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.VIEWS_ENABLED, this.viewsEnabled);
+        }
+        if (this.materializationProject != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_PROJECT, this.materializationProject);
+        }
+        if (this.materializationDataset != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_DATASET, this.materializationDataset);
+        }
+        if (this.materializationExpirationHours != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS,
+                    this.materializationExpirationHours);
+        }
+        if (this.billingProject != null) {
+            tableDescriptorBuilder.option(
+                    BigQueryConnectorOptions.BILLING_PROJECT, this.billingProject);
+        }
         return tableDescriptorBuilder.build();
     }
 
@@ -103,6 +139,11 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
         private String columnProjection;
         private Integer maxStreamCount;
         private Long snapshotTimestamp;
+        private Boolean viewsEnabled;
+        private String materializationProject;
+        private String materializationDataset;
+        private Integer materializationExpirationHours;
+        private String billingProject;
 
         @Override
         public BigQueryReadTableConfig.Builder project(String project) {
@@ -203,6 +244,34 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
             return this;
         }
 
+        public BigQueryReadTableConfig.Builder viewsEnabled(Boolean viewsEnabled) {
+            this.viewsEnabled = viewsEnabled;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationProject(
+                String materializationProject) {
+            this.materializationProject = materializationProject;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationDataset(
+                String materializationDataset) {
+            this.materializationDataset = materializationDataset;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder materializationExpirationHours(
+                Integer materializationExpirationHours) {
+            this.materializationExpirationHours = materializationExpirationHours;
+            return this;
+        }
+
+        public BigQueryReadTableConfig.Builder billingProject(String billingProject) {
+            this.billingProject = billingProject;
+            return this;
+        }
+
         public BigQueryReadTableConfig build() {
             return new BigQueryReadTableConfig(
                     project,
@@ -217,7 +286,12 @@ public class BigQueryReadTableConfig extends BigQueryTableConfig {
                     maxStreamCount,
                     rowRestriction,
                     limit,
-                    snapshotTimestamp);
+                    snapshotTimestamp,
+                    viewsEnabled,
+                    materializationProject,
+                    materializationDataset,
+                    materializationExpirationHours,
+                    billingProject);
         }
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -180,6 +180,14 @@ public class BigQueryTableConfigurationProvider {
                                 .setQuotaProjectId(
                                         config.get(BigQueryConnectorOptions.QUOTA_PROJECT_ID))
                                 .build())
+                .setViewsEnabled(config.get(BigQueryConnectorOptions.VIEWS_ENABLED))
+                .setMaterializedTableExpirationHours(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS))
+                .setMaterializationProject(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_PROJECT))
+                .setMaterializationDataset(
+                        config.get(BigQueryConnectorOptions.MATERIALIZATION_DATASET))
+                .setBillingProject(config.get(BigQueryConnectorOptions.BILLING_PROJECT))
                 .build();
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -121,6 +121,39 @@ public class BigQueryDynamicTableFactoryTest {
     }
 
     @Test
+    public void testBigQueryReadPropertiesWithViews() throws IOException {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put(BigQueryConnectorOptions.VIEWS_ENABLED.key(), "true");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_PROJECT.key(), "temp-project");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(), "temp_dataset");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_EXPIRATION_HOURS.key(), "6");
+        properties.put(BigQueryConnectorOptions.BILLING_PROJECT.key(), "billing-project");
+
+        DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, properties);
+
+        BigQueryReadOptions readOptions =
+                BigQueryReadOptions.builder()
+                        .setBigQueryConnectOptions(
+                                BigQueryConnectOptions.builder()
+                                        .setDataset("dataset")
+                                        .setProjectId("project")
+                                        .setTable("table")
+                                        .setCredentialsOptions(CredentialsOptions.builder().build())
+                                        .setViewsEnabled(true)
+                                        .setMaterializationProject("temp-project")
+                                        .setMaterializationDataset("temp_dataset")
+                                        .setMaterializedTableExpirationHours(6)
+                                        .setBillingProject("billing-project")
+                                        .build())
+                        .build();
+
+        BigQueryDynamicTableSource expected =
+                new BigQueryDynamicTableSource(readOptions, SCHEMA.toPhysicalRowDataType(), null);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void testDefaultColumnNamesAreAllDdlColumns() throws IOException {
         DynamicTableSource actual = FactoryMocks.createTableSource(SCHEMA, getRequiredOptions());
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
@@ -151,6 +152,22 @@ public class BigQueryDynamicTableFactoryTest {
                 new BigQueryDynamicTableSource(readOptions, SCHEMA.toPhysicalRowDataType(), null);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testBigQueryReadPropertiesWithViewsMissingDataset() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put(BigQueryConnectorOptions.VIEWS_ENABLED.key(), "true");
+        properties.put(BigQueryConnectorOptions.MATERIALIZATION_PROJECT.key(), "temp-project");
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSource(SCHEMA, properties))
+                .isInstanceOf(ValidationException.class)
+                .getCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Option '%s' must be set when '%s' is set to true.",
+                                BigQueryConnectorOptions.MATERIALIZATION_DATASET.key(),
+                                BigQueryConnectorOptions.VIEWS_ENABLED.key()));
     }
 
     @Test


### PR DESCRIPTION
This PR adds comprehensive support for querying BigQuery Views and configuring materialization and billing parameters within the Flink Table API connector. These features are implemented across both the flink-1.17 and flink-2.1 connector modules.

