### PR TITLE
Add timeout handling for buffered and default writer

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -84,7 +84,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     // Multiply 0.95 to keep a buffer from exceeding payload limits.
     private static final long MAX_APPEND_REQUEST_BYTES =
             (long) (StreamWriter.getApiMaxRequestBytes() * 0.95);
-    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 300L;
+    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 420L;
 
     // Number of bytes to be sent in the next append request.
     private long appendRequestSizeBytes;

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -84,6 +84,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     // Multiply 0.95 to keep a buffer from exceeding payload limits.
     private static final long MAX_APPEND_REQUEST_BYTES =
             (long) (StreamWriter.getApiMaxRequestBytes() * 0.95);
+    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 300L;
 
     // Number of bytes to be sent in the next append request.
     private long appendRequestSizeBytes;
@@ -182,6 +183,22 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
         }
         if (writeClient != null) {
             writeClient.close();
+        }
+    }
+
+    void resetStreamWriter() {
+        if (streamWriter != null) {
+            try {
+                streamWriter.close();
+            } catch (Exception e) {
+                logger.warn(
+                        String.format(
+                                "Error closing StreamWriter for stream %s in subtask %d",
+                                streamName, subtaskId),
+                        e);
+            } finally {
+                streamWriter = null;
+            }
         }
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -45,6 +45,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Writer implementation for {@link BigQueryBufferedSink}.
@@ -230,6 +232,8 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         if (StringUtils.isNullOrWhitespaceOnly(streamName)) {
             createWriteStream(WriteStream.Type.BUFFERED);
             createStreamWriter(false);
+        } else if (streamWriter == null) {
+            createStreamWriter(false);
         }
         ApiFuture<AppendRowsResponse> future = streamWriter.append(protoRows, streamOffset);
         postAppendOps(future, rowCount);
@@ -243,12 +247,16 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         long recordsAppended = appendInfo.getRecordsAppended();
         AppendRowsResponse response;
         try {
-            response = appendResponseFuture.get();
+            response =
+                    appendResponseFuture.get(
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (response.hasError()) {
+                resetStreamWriter();
                 logAndThrowFatalException(response.getError().getMessage());
             }
             long offset = response.getAppendResult().getOffset().getValue();
             if (offset != expectedOffset) {
+                resetStreamWriter();
                 logAndThrowFatalException(
                         String.format(
                                 "Inconsistent offset in BigQuery API response. Found %d, expected %d",
@@ -256,6 +264,12 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             }
             totalRecordsWritten += recordsAppended;
             numberOfRecordsBufferedByBigQuerySinceCheckpoint.inc(recordsAppended);
+        } catch (TimeoutException e) {
+            resetStreamWriter();
+            logAndThrowFatalException(
+                    String.format(
+                            "AppendRows request timed out after %d seconds waiting for response in subtask %d",
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
             if (e.getCause().getClass() == OffsetAlreadyExists.class) {
                 logger.info(
@@ -263,6 +277,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                         subtaskId);
                 return;
             }
+            resetStreamWriter();
             logAndThrowFatalException(e);
         }
     }
@@ -334,9 +349,13 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         try {
             // Get this future immediately to check whether append worked or not, inferring stream
             // is usable or not.
-            response = future.get();
+            response = future.get(DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             postAppendOps(ApiFutures.immediateFuture(response), rowCount);
+        } catch (TimeoutException e) {
+            resetStreamWriter();
+            discardStreamAndResendAppendRequest(e, protoRows);
         } catch (ExecutionException | InterruptedException e) {
+            resetStreamWriter();
             if (e.getCause().getClass() == OffsetAlreadyExists.class
                     || e.getCause().getClass() == OffsetOutOfRange.class
                     || e.getCause().getClass() == StreamFinalizedException.class

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -271,7 +271,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                             "AppendRows request timed out after %d seconds waiting for response in subtask %d",
                             DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
-            if (e.getCause().getClass() == OffsetAlreadyExists.class) {
+            if (e.getCause() instanceof OffsetAlreadyExists) {
                 logger.info(
                         "Ignoring OffsetAlreadyExists error in subtask {} as this can be due to faulty retries",
                         subtaskId);
@@ -356,10 +356,10 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             discardStreamAndResendAppendRequest(e, protoRows);
         } catch (ExecutionException | InterruptedException e) {
             resetStreamWriter();
-            if (e.getCause().getClass() == OffsetAlreadyExists.class
-                    || e.getCause().getClass() == OffsetOutOfRange.class
-                    || e.getCause().getClass() == StreamFinalizedException.class
-                    || e.getCause().getClass() == StreamNotFound.class) {
+            if (e.getCause() instanceof OffsetAlreadyExists
+                    || e.getCause() instanceof OffsetOutOfRange
+                    || e.getCause() instanceof StreamFinalizedException
+                    || e.getCause() instanceof StreamNotFound) {
                 discardStreamAndResendAppendRequest(e, protoRows);
                 return;
             }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -33,6 +33,8 @@ import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.protobuf.ByteString;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Writer implementation for {@link BigQueryDefaultSink}.
@@ -150,15 +152,25 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
         long recordsAppended = appendInfo.getRecordsAppended();
         AppendRowsResponse response;
         try {
-            response = appendResponseFuture.get();
+            response =
+                    appendResponseFuture.get(
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (response.hasError()) {
+                resetStreamWriter();
                 logAndThrowFatalException(response.getError().getMessage());
             }
             totalRecordsWritten += recordsAppended;
             // the request succeeded without errors (records are in BQ)
             numberOfRecordsWrittenToBigQuery.inc(recordsAppended);
             numberOfRecordsWrittenToBigQuerySinceCheckpoint.inc(recordsAppended);
+        } catch (TimeoutException e) {
+            resetStreamWriter();
+            logAndThrowFatalException(
+                    String.format(
+                            "AppendRows request timed out after %d seconds waiting for response in subtask %d",
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
+            resetStreamWriter();
             if (e.getCause() instanceof Exceptions.AppendSerializationError) {
                 Exceptions.AppendSerializationError appendSerializationError =
                         (Exceptions.AppendSerializationError) e.getCause();

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -598,6 +598,18 @@ public class BigQueryBufferedWriterTest {
                         ApiFutures.immediateFailedFuture(mock(OffsetOutOfRange.class)), 0L, 0L));
     }
 
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withInterruptedException() throws Exception {
+        BigQueryBufferedWriter<Object> bufferedWriter =
+                createBufferedWriter(
+                        null, 0L, 10L, 0L, 0L, FakeBigQuerySerializer.getEmptySerializer());
+        ApiFuture<AppendRowsResponse> futureMock = mock(ApiFuture.class);
+        Mockito.when(futureMock.get(Mockito.anyLong(), Mockito.any()))
+                .thenThrow(new InterruptedException("interrupted"));
+        bufferedWriter.validateAppendResponse(
+                new BigQueryDefaultWriter.AppendInfo(futureMock, 0L, 0L));
+    }
+
     @Test
     public void testFlush() {
         BigQueryBufferedWriter<Object> bufferedWriter =

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -56,6 +56,8 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1124,6 +1126,23 @@ public class BigQueryBufferedWriterTest {
         bufferedWriter.write(new Object(), null);
         assertEquals(0, bufferedWriter.getProtoRows().getSerializedRowsCount());
         assertTrue(bufferedWriter.getAppendResponseFuturesQueue().isEmpty());
+    }
+
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withTimeoutException() throws Exception {
+        BigQueryBufferedWriter<Object> bufferedWriter =
+                createBufferedWriter(
+                        null, 0L, 0L, 0L, 0L, FakeBigQuerySerializer.getEmptySerializer());
+        @SuppressWarnings("unchecked")
+        ApiFuture<AppendRowsResponse> mockFuture = Mockito.mock(ApiFuture.class);
+        Mockito.when(mockFuture.get(Mockito.anyLong(), Mockito.any(TimeUnit.class)))
+                .thenThrow(new TimeoutException("Timeout waiting for response"));
+        try {
+            bufferedWriter.validateAppendResponse(
+                    new BigQueryBufferedWriter.AppendInfo(mockFuture, 0L, 10L));
+        } finally {
+            assertNull(bufferedWriter.streamWriter);
+        }
     }
 
     private BigQueryBufferedWriter<Object> createBufferedWriter(

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.flink.bigquery.sink.writer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.StreamWriter;
@@ -39,6 +40,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -381,6 +385,22 @@ public class BigQueryDefaultWriterTest {
         defaultWriter.validateAppendResponse(
                 new BigQueryDefaultWriter.AppendInfo(
                         ApiFutures.immediateFailedFuture(new RuntimeException("foo")), -1L, 10L));
+    }
+
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withTimeoutException() throws Exception {
+        BigQueryDefaultWriter<Object> defaultWriter =
+                createDefaultWriter(FakeBigQuerySerializer.getEmptySerializer(), null);
+        @SuppressWarnings("unchecked")
+        ApiFuture<AppendRowsResponse> mockFuture = Mockito.mock(ApiFuture.class);
+        Mockito.when(mockFuture.get(Mockito.anyLong(), Mockito.any(TimeUnit.class)))
+                .thenThrow(new TimeoutException("Timeout waiting for response"));
+        try {
+            defaultWriter.validateAppendResponse(
+                    new BigQueryDefaultWriter.AppendInfo(mockFuture, -1L, 10L));
+        } finally {
+            assertNull(defaultWriter.streamWriter);
+        }
     }
 
     private BigQueryDefaultWriter<Object> createDefaultWriter(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -84,7 +84,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     // Multiply 0.95 to keep a buffer from exceeding payload limits.
     private static final long MAX_APPEND_REQUEST_BYTES =
             (long) (StreamWriter.getApiMaxRequestBytes() * 0.95);
-    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 300L;
+    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 420L;
 
     // Number of bytes to be sent in the next append request.
     private long appendRequestSizeBytes;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -84,6 +84,7 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     // Multiply 0.95 to keep a buffer from exceeding payload limits.
     private static final long MAX_APPEND_REQUEST_BYTES =
             (long) (StreamWriter.getApiMaxRequestBytes() * 0.95);
+    protected static final long DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS = 300L;
 
     // Number of bytes to be sent in the next append request.
     private long appendRequestSizeBytes;
@@ -182,6 +183,22 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
         }
         if (writeClient != null) {
             writeClient.close();
+        }
+    }
+
+    void resetStreamWriter() {
+        if (streamWriter != null) {
+            try {
+                streamWriter.close();
+            } catch (Exception e) {
+                logger.warn(
+                        String.format(
+                                "Error closing StreamWriter for stream %s in subtask %d",
+                                streamName, subtaskId),
+                        e);
+            } finally {
+                streamWriter = null;
+            }
         }
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -273,7 +273,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                             "AppendRows request timed out after %d seconds waiting for response in subtask %d",
                             DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
-            if (e.getCause().getClass() == OffsetAlreadyExists.class) {
+            if (e.getCause() instanceof OffsetAlreadyExists) {
                 logger.info(
                         "Ignoring OffsetAlreadyExists error in subtask {} as this can be due to faulty retries",
                         subtaskId);
@@ -358,10 +358,10 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             discardStreamAndResendAppendRequest(e, protoRows);
         } catch (ExecutionException | InterruptedException e) {
             resetStreamWriter();
-            if (e.getCause().getClass() == OffsetAlreadyExists.class
-                    || e.getCause().getClass() == OffsetOutOfRange.class
-                    || e.getCause().getClass() == StreamFinalizedException.class
-                    || e.getCause().getClass() == StreamNotFound.class) {
+            if (e.getCause() instanceof OffsetAlreadyExists
+                    || e.getCause() instanceof OffsetOutOfRange
+                    || e.getCause() instanceof StreamFinalizedException
+                    || e.getCause() instanceof StreamNotFound) {
                 discardStreamAndResendAppendRequest(e, protoRows);
                 return;
             }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -47,6 +47,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Writer implementation for {@link BigQueryBufferedSink}.
@@ -232,6 +234,8 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         if (StringUtils.isNullOrWhitespaceOnly(streamName)) {
             createWriteStream(WriteStream.Type.BUFFERED);
             createStreamWriter(false);
+        } else if (streamWriter == null) {
+            createStreamWriter(false);
         }
         ApiFuture<AppendRowsResponse> future = streamWriter.append(protoRows, streamOffset);
         postAppendOps(future, rowCount);
@@ -245,12 +249,16 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         long recordsAppended = appendInfo.getRecordsAppended();
         AppendRowsResponse response;
         try {
-            response = appendResponseFuture.get();
+            response =
+                    appendResponseFuture.get(
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (response.hasError()) {
+                resetStreamWriter();
                 logAndThrowFatalException(response.getError().getMessage());
             }
             long offset = response.getAppendResult().getOffset().getValue();
             if (offset != expectedOffset) {
+                resetStreamWriter();
                 logAndThrowFatalException(
                         String.format(
                                 "Inconsistent offset in BigQuery API response. Found %d, expected %d",
@@ -258,6 +266,12 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
             }
             totalRecordsWritten += recordsAppended;
             numberOfRecordsBufferedByBigQuerySinceCheckpoint.inc(recordsAppended);
+        } catch (TimeoutException e) {
+            resetStreamWriter();
+            logAndThrowFatalException(
+                    String.format(
+                            "AppendRows request timed out after %d seconds waiting for response in subtask %d",
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
             if (e.getCause().getClass() == OffsetAlreadyExists.class) {
                 logger.info(
@@ -265,6 +279,7 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                         subtaskId);
                 return;
             }
+            resetStreamWriter();
             logAndThrowFatalException(e);
         }
     }
@@ -336,9 +351,13 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
         try {
             // Get this future immediately to check whether append worked or not, inferring stream
             // is usable or not.
-            response = future.get();
+            response = future.get(DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             postAppendOps(ApiFutures.immediateFuture(response), rowCount);
+        } catch (TimeoutException e) {
+            resetStreamWriter();
+            discardStreamAndResendAppendRequest(e, protoRows);
         } catch (ExecutionException | InterruptedException e) {
+            resetStreamWriter();
             if (e.getCause().getClass() == OffsetAlreadyExists.class
                     || e.getCause().getClass() == OffsetOutOfRange.class
                     || e.getCause().getClass() == StreamFinalizedException.class

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -151,15 +151,26 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
         long recordsAppended = appendInfo.getRecordsAppended();
         AppendRowsResponse response;
         try {
-            response = appendResponseFuture.get();
+            response =
+                    appendResponseFuture.get(
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS,
+                            java.util.concurrent.TimeUnit.SECONDS);
             if (response.hasError()) {
+                resetStreamWriter();
                 logAndThrowFatalException(response.getError().getMessage());
             }
             totalRecordsWritten += recordsAppended;
             // the request succeeded without errors (records are in BQ)
             numberOfRecordsWrittenToBigQuery.inc(recordsAppended);
             numberOfRecordsWrittenToBigQuerySinceCheckpoint.inc(recordsAppended);
+        } catch (java.util.concurrent.TimeoutException e) {
+            resetStreamWriter();
+            logAndThrowFatalException(
+                    String.format(
+                            "AppendRows request timed out after %d seconds waiting for response in subtask %d",
+                            DEFAULT_APPEND_RESPONSE_TIMEOUT_SECONDS, subtaskId));
         } catch (ExecutionException | InterruptedException e) {
+            resetStreamWriter();
             if (e.getCause() instanceof Exceptions.AppendSerializationError) {
                 Exceptions.AppendSerializationError appendSerializationError =
                         (Exceptions.AppendSerializationError) e.getCause();

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -599,6 +599,18 @@ public class BigQueryBufferedWriterTest {
                         ApiFutures.immediateFailedFuture(mock(OffsetOutOfRange.class)), 0L, 0L));
     }
 
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withInterruptedException() throws Exception {
+        BigQueryBufferedWriter<Object> bufferedWriter =
+                createBufferedWriter(
+                        null, 0L, 10L, 0L, 0L, FakeBigQuerySerializer.getEmptySerializer());
+        ApiFuture<AppendRowsResponse> futureMock = mock(ApiFuture.class);
+        Mockito.when(futureMock.get(Mockito.anyLong(), Mockito.any()))
+                .thenThrow(new InterruptedException("interrupted"));
+        bufferedWriter.validateAppendResponse(
+                new BigQueryDefaultWriter.AppendInfo(futureMock, 0L, 0L));
+    }
+
     @Test
     public void testFlush() {
         BigQueryBufferedWriter<Object> bufferedWriter =

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -56,6 +56,8 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1125,6 +1127,23 @@ public class BigQueryBufferedWriterTest {
         bufferedWriter.write(new Object(), null);
         assertEquals(0, bufferedWriter.getProtoRows().getSerializedRowsCount());
         assertTrue(bufferedWriter.getAppendResponseFuturesQueue().isEmpty());
+    }
+
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withTimeoutException() throws Exception {
+        BigQueryBufferedWriter<Object> bufferedWriter =
+                createBufferedWriter(
+                        null, 0L, 0L, 0L, 0L, FakeBigQuerySerializer.getEmptySerializer());
+        @SuppressWarnings("unchecked")
+        ApiFuture<AppendRowsResponse> mockFuture = Mockito.mock(ApiFuture.class);
+        Mockito.when(mockFuture.get(Mockito.anyLong(), Mockito.any(TimeUnit.class)))
+                .thenThrow(new TimeoutException("Timeout waiting for response"));
+        try {
+            bufferedWriter.validateAppendResponse(
+                    new BigQueryBufferedWriter.AppendInfo(mockFuture, 0L, 10L));
+        } finally {
+            assertNull(bufferedWriter.streamWriter);
+        }
     }
 
     private BigQueryBufferedWriter<Object> createBufferedWriter(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.flink.bigquery.sink.writer;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.StreamWriter;
@@ -39,6 +40,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -383,6 +387,22 @@ public class BigQueryDefaultWriterTest {
         defaultWriter.validateAppendResponse(
                 new BigQueryDefaultWriter.AppendInfo(
                         ApiFutures.immediateFailedFuture(new RuntimeException("foo")), -1L, 10L));
+    }
+
+    @Test(expected = BigQueryConnectorException.class)
+    public void testValidateAppendResponse_withTimeoutException() throws Exception {
+        BigQueryDefaultWriter<Object> defaultWriter =
+                createDefaultWriter(FakeBigQuerySerializer.getEmptySerializer(), null);
+        @SuppressWarnings("unchecked")
+        ApiFuture<AppendRowsResponse> mockFuture = Mockito.mock(ApiFuture.class);
+        Mockito.when(mockFuture.get(Mockito.anyLong(), Mockito.any(TimeUnit.class)))
+                .thenThrow(new TimeoutException("Timeout waiting for response"));
+        try {
+            defaultWriter.validateAppendResponse(
+                    new BigQueryDefaultWriter.AppendInfo(mockFuture, -1L, 10L));
+        } finally {
+            assertNull(defaultWriter.streamWriter);
+        }
     }
 
     private BigQueryDefaultWriter<Object> createDefaultWriter(


### PR DESCRIPTION
When incoming data traffic pauses or is low-volume for >10 minutes, BigQuery's Storage Write API server closes the inactive gRPC stream. When new records arrive or Flink triggers a checkpoint, the connector attempts to validate pending write futures using an unbounded future.get() call. Because the underlying gRPC stream is dead or hung, future.get() blocks indefinitely until Flink's execution.checkpointing.timeout triggers an InterruptedException, failing the task.

This PR re-initialize StreamWriter on Connection Failure / Timeout: Catch TimeoutException and connection closed / gRPC UNAVAILABLE exceptions, close the stale streamWriter, and recreate a fresh streamWriter (createStreamWriter(...)).