### PR TITLE
Feat: Enable Flip-314 For BigQuery Connector

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/pom.xml
@@ -82,6 +82,14 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-force-shading</artifactId>
         </dependency>
+        <!-- FLIP-314 data-lineage interfaces (org.apache.flink.streaming.api.lineage.*) live in
+             flink-runtime. Scope 'provided': compiled against here, supplied by the Flink cluster
+             at runtime, and never bundled into the shaded connector jar. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils-junit</artifactId>

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/lineage/BigQueryLineageUtil.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/lineage/BigQueryLineageUtil.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Builds the FLIP-314 {@link LineageDataset} shared by the BigQuery source and sink.
@@ -74,6 +75,8 @@ public final class BigQueryLineageUtil {
      */
     public static SourceLineageVertex sourceVertexOf(
             BigQueryConnectOptions options, Boundedness boundedness) {
+        Objects.requireNonNull(options, "options must not be null");
+        Objects.requireNonNull(boundedness, "boundedness must not be null");
         List<LineageDataset> datasets = Collections.singletonList(datasetOf(options));
         return new SourceLineageVertex() {
             @Override
@@ -93,6 +96,7 @@ public final class BigQueryLineageUtil {
      * {@code options}.
      */
     public static LineageVertex sinkVertexOf(BigQueryConnectOptions options) {
+        Objects.requireNonNull(options, "options must not be null");
         List<LineageDataset> datasets = Collections.singletonList(datasetOf(options));
         return () -> datasets;
     }
@@ -103,9 +107,10 @@ public final class BigQueryLineageUtil {
      * DatasetConfigFacet} (so they survive the Table planner overriding {@code name()}).
      */
     private static LineageDataset datasetOf(BigQueryConnectOptions options) {
-        String project = options.getProjectId();
-        String dataset = options.getDataset();
-        String table = options.getTable();
+        String project =
+                Objects.requireNonNull(options.getProjectId(), "projectId must not be null");
+        String dataset = Objects.requireNonNull(options.getDataset(), "dataset must not be null");
+        String table = Objects.requireNonNull(options.getTable(), "table must not be null");
         String name = String.join(".", project, dataset, table);
 
         Map<String, String> config = new LinkedHashMap<>();

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/lineage/BigQueryLineageUtil.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/lineage/BigQueryLineageUtil.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the FLIP-314 {@link LineageDataset} shared by the BigQuery source and sink.
+ *
+ * <p>The dataset's {@code (namespace, name)} pair is {@code ("bigquery", "project.dataset.table")}:
+ * {@code namespace} identifies the storage system and {@code name} is the fully-qualified table.
+ * This is the identity a FLIP-314 {@link org.apache.flink.core.execution.JobStatusChangedListener}
+ * consumes to resolve the BigQuery table.
+ *
+ * <p>For DataStream jobs that pair is sufficient. For FlinkSQL/Table jobs it is <em>not</em>:
+ * Flink's Table planner wraps the connector-provided dataset in {@code TableLineageDatasetImpl},
+ * whose constructor <em>overrides</em> {@code name()} with the Flink object identifier ({@code
+ * catalog.database.table}) while <em>preserving</em> {@code namespace()} and {@code facets()}. The
+ * clobbered name (e.g. {@code my_catalog.my_database.my_table}) no longer reflects the real
+ * BigQuery table. To survive that, the real BigQuery coordinates are also published in a {@link
+ * DatasetConfigFacet}; a downstream consumer that finds the facet can recover {@code
+ * project.dataset.table} even when {@code name()} has been overridden.
+ */
+public final class BigQueryLineageUtil {
+
+    /** Lineage namespace for BigQuery datasets. */
+    public static final String NAMESPACE = "bigquery";
+
+    /** Facet key under which the BigQuery coordinates are published. */
+    public static final String CONFIG_FACET_NAME = "bigquery";
+
+    /** Config-facet key holding the GCP project id. */
+    public static final String CONFIG_PROJECT = "project";
+
+    /** Config-facet key holding the BigQuery dataset. */
+    public static final String CONFIG_DATASET = "dataset";
+
+    /** Config-facet key holding the BigQuery table. */
+    public static final String CONFIG_TABLE = "table";
+
+    private BigQueryLineageUtil() {}
+
+    /**
+     * The FLIP-314 lineage vertex for a BigQuery <em>source</em> reading the table addressed by
+     * {@code options}. Returns a {@link SourceLineageVertex} (not a plain {@link LineageVertex})
+     * because Flink's {@code LineageGraphUtils.processSource} hard-casts source vertices to that
+     * type, so a plain vertex would fail at graph-build time.
+     */
+    public static SourceLineageVertex sourceVertexOf(
+            BigQueryConnectOptions options, Boundedness boundedness) {
+        List<LineageDataset> datasets = Collections.singletonList(datasetOf(options));
+        return new SourceLineageVertex() {
+            @Override
+            public List<LineageDataset> datasets() {
+                return datasets;
+            }
+
+            @Override
+            public Boundedness boundedness() {
+                return boundedness;
+            }
+        };
+    }
+
+    /**
+     * The FLIP-314 lineage vertex for a BigQuery <em>sink</em> writing the table addressed by
+     * {@code options}.
+     */
+    public static LineageVertex sinkVertexOf(BigQueryConnectOptions options) {
+        List<LineageDataset> datasets = Collections.singletonList(datasetOf(options));
+        return () -> datasets;
+    }
+
+    /**
+     * The FLIP-314 lineage dataset for the BigQuery table addressed by {@code options}. The
+     * BigQuery coordinates are carried both in {@code name()} (for DataStream jobs) and in a {@link
+     * DatasetConfigFacet} (so they survive the Table planner overriding {@code name()}).
+     */
+    private static LineageDataset datasetOf(BigQueryConnectOptions options) {
+        String project = options.getProjectId();
+        String dataset = options.getDataset();
+        String table = options.getTable();
+        String name = String.join(".", project, dataset, table);
+
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put(CONFIG_PROJECT, project);
+        config.put(CONFIG_DATASET, dataset);
+        config.put(CONFIG_TABLE, table);
+        Map<String, LineageDatasetFacet> facets =
+                Collections.singletonMap(CONFIG_FACET_NAME, new BigQueryConfigFacet(config));
+
+        return new LineageDataset() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String namespace() {
+                return NAMESPACE;
+            }
+
+            @Override
+            public Map<String, LineageDatasetFacet> facets() {
+                return facets;
+            }
+        };
+    }
+
+    /** A {@link DatasetConfigFacet} carrying the BigQuery project/dataset/table coordinates. */
+    private static final class BigQueryConfigFacet implements DatasetConfigFacet {
+        private final Map<String, String> config;
+
+        BigQueryConfigFacet(Map<String, String> config) {
+            this.config = Collections.unmodifiableMap(config);
+        }
+
+        @Override
+        public Map<String, String> config() {
+            return config;
+        }
+
+        @Override
+        public String name() {
+            return CONFIG_FACET_NAME;
+        }
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -17,11 +17,14 @@
 package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.util.StringUtils;
 
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
+import com.google.cloud.flink.bigquery.lineage.BigQueryLineageUtil;
 import com.google.cloud.flink.bigquery.sink.client.BigQueryClientWithErrorHandling;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
@@ -35,7 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /** Base class for developing a BigQuery sink. */
-abstract class BigQueryBaseSink<IN> implements Sink<IN> {
+abstract class BigQueryBaseSink<IN> implements Sink<IN>, LineageVertexProvider {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -172,5 +175,17 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
             }
         }
         return DEFAULT_MAX_SINK_PARALLELISM;
+    }
+
+    /**
+     * Exposes this sink's BigQuery table as FLIP-314 lineage metadata, with the {@code (namespace,
+     * name)} pair {@code ("bigquery", "project.dataset.table")} a downstream {@link
+     * org.apache.flink.core.execution.JobStatusChangedListener} can consume. Both concrete sinks
+     * ({@code BigQueryDefaultSink}, {@code BigQueryExactlyOnceSink}) inherit this. See {@link
+     * BigQueryLineageUtil} for details.
+     */
+    @Override
+    public LineageVertex getLineageVertex() {
+        return BigQueryLineageUtil.sinkVertexOf(connectOptions);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/BigQuerySource.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/BigQuerySource.java
@@ -27,11 +27,14 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.utils.SchemaTransform;
+import com.google.cloud.flink.bigquery.lineage.BigQueryLineageUtil;
 import com.google.cloud.flink.bigquery.services.BigQueryServicesFactory;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
 import com.google.cloud.flink.bigquery.source.emitter.BigQueryRecordEmitter;
@@ -79,7 +82,8 @@ import java.util.function.Supplier;
 @PublicEvolving
 public abstract class BigQuerySource<OUT>
         implements Source<OUT, BigQuerySourceSplit, BigQuerySourceEnumState>,
-                ResultTypeQueryable<OUT> {
+                ResultTypeQueryable<OUT>,
+                LineageVertexProvider {
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySource.class);
 
     public abstract BigQueryDeserializationSchema<GenericRecord, OUT> getDeserializationSchema();
@@ -91,6 +95,19 @@ public abstract class BigQuerySource<OUT>
     @Override
     public Boundedness getBoundedness() {
         return getSourceBoundedness();
+    }
+
+    /**
+     * Exposes this source's BigQuery table as FLIP-314 lineage metadata, with the {@code
+     * (namespace, name)} pair {@code ("bigquery", "project.dataset.table")} a downstream {@link
+     * org.apache.flink.core.execution.JobStatusChangedListener} can consume. Implemented on the
+     * source (not the pipeline) so lineage is emitted for pure FlinkSQL jobs too. See {@link
+     * BigQueryLineageUtil} for details.
+     */
+    @Override
+    public LineageVertex getLineageVertex() {
+        return BigQueryLineageUtil.sourceVertexOf(
+                getReadOptions().getBigQueryConnectOptions(), getBoundedness());
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSinkTest.java
@@ -19,6 +19,9 @@ package com.google.cloud.flink.bigquery.sink;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
@@ -35,6 +38,8 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.cloud.flink.bigquery.RestartStrategyConfigUtils.fixedDelayRestartStrategyConfig;
 import static com.google.common.truth.Truth.assertThat;
@@ -302,6 +307,33 @@ public class BigQueryDefaultSinkTest {
         BigQueryDefaultSink<GenericRecord> sink = new BigQueryDefaultSink<>(sinkConfig);
         assertEquals("us", sink.region);
         assertEquals(512, sink.maxParallelism);
+    }
+
+    @Test
+    public void testGetLineageVertex() {
+        BigQuerySinkConfig<Object> sinkConfig =
+                BigQuerySinkConfig.<Object>newBuilder()
+                        .connectOptions(getConnectOptions(true))
+                        .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                        .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                        .streamExecutionEnvironment(env)
+                        .build();
+        BigQueryDefaultSink<Object> sink = new BigQueryDefaultSink<>(sinkConfig);
+
+        List<LineageDataset> datasets = sink.getLineageVertex().datasets();
+        assertThat(datasets).hasSize(1);
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.namespace()).isEqualTo("bigquery");
+        assertThat(dataset.name()).isEqualTo("project.dataset.table");
+
+        // The BigQuery coordinates are also published in a config facet so they survive the Table
+        // planner overriding name() with the Flink object identifier for FlinkSQL jobs.
+        LineageDatasetFacet facet = dataset.facets().get("bigquery");
+        assertThat(facet).isInstanceOf(DatasetConfigFacet.class);
+        Map<String, String> config = ((DatasetConfigFacet) facet).config();
+        assertThat(config).containsEntry("project", "project");
+        assertThat(config).containsEntry("dataset", "dataset");
+        assertThat(config).containsEntry("table", "table");
     }
 
     private static BigQueryConnectOptions getConnectOptions(boolean tableExists) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/BigQuerySourceTest.java
@@ -18,6 +18,9 @@ package com.google.cloud.flink.bigquery.source;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
 import com.google.cloud.flink.bigquery.source.config.BigQueryReadOptions;
@@ -25,6 +28,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -40,5 +45,28 @@ public class BigQuerySourceTest {
         TypeInformation<GenericRecord> expected =
                 new GenericRecordAvroTypeInfo(StorageClientFaker.SIMPLE_AVRO_SCHEMA);
         assertThat(source.getDeserializationSchema().getProducedType()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testGetLineageVertex() throws IOException {
+        BigQueryReadOptions readOptions =
+                StorageClientFaker.createReadOptions(
+                        10, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING);
+        BigQuerySource<GenericRecord> source = BigQuerySource.readAvros(readOptions);
+
+        List<LineageDataset> datasets = source.getLineageVertex().datasets();
+        assertThat(datasets).hasSize(1);
+        LineageDataset dataset = datasets.get(0);
+        assertThat(dataset.namespace()).isEqualTo("bigquery");
+        assertThat(dataset.name()).isEqualTo("project.dataset.table");
+
+        // The BigQuery coordinates are also published in a config facet so they survive the Table
+        // planner overriding name() with the Flink object identifier for FlinkSQL jobs.
+        LineageDatasetFacet facet = dataset.facets().get("bigquery");
+        assertThat(facet).isInstanceOf(DatasetConfigFacet.class);
+        Map<String, String> config = ((DatasetConfigFacet) facet).config();
+        assertThat(config).containsEntry("project", "project");
+        assertThat(config).containsEntry("dataset", "dataset");
+        assertThat(config).containsEntry("table", "table");
     }
 }


### PR DESCRIPTION
Emit FLIP-314 data lineage from the BigQuery source and sink (Flink 2.1)

## Summary

Makes the Flink 2.1 BigQuery connector publish FLIP-314 data lineage, so any registered JobStatusChangedListener can discover which BigQuery tables a job reads from and writes to — without parsing job code or configuration. The connector's source and sink now advertise their table as a lineage dataset; Flink assembles these into the job's LineageGraph at submission time and hands it to registered listeners, which can map each dataset to an entry in an external catalog.

Applies to both DataStream and pure FlinkSQL/Tab

## Changes 
| File | Change |
| --- | --- |
| `lineage/BigQueryLineageUtil.java` *(new)* | Single home for the connector's FLIP-314 mapping: builds the `LineageDataset` for a BigQuery table and the source/sink vertices. Holds the `namespace`/facet-key constants and the `project.dataset.table` naming. |
| `source/BigQuerySource.java` | Implements `LineageVertexProvider`; `getLineageVertex()` returns `BigQueryLineageUtil.sourceVertexOf(connectOptions, getBoundedness())`. |
| `sink/BigQueryBaseSink.java` | Implements `LineageVertexProvider`; `getLineageVertex()` returns `BigQueryLineageUtil.sinkVertexOf(connectOptions)`. Inherited by `BigQueryDefaultSink` and `BigQueryExactlyOnceSink`. |
| `pom.xml` | Adds `flink-runtime` at `provided` scope (the lineage interfaces live there; supplied by the cluster, never bundled into the shaded jar). |
| `source/BigQuerySourceTest.java`, `sink/BigQueryDefaultSinkTest.java` | Unit tests asserting namespace, name, and config-facet contents for both the source and sink paths. |

## How the mapping works
BigQueryLineageUtil.datasetOf(options) produces a LineageDataset with:
- namespace() = "bigquery" (identifies the storage system)                                                              
- name() = "project.dataset.table" (the fully-qu
- facets() = a DatasetConfigFacet under key "bigquery" carrying {project, dataset, table} as discrete keys.

The (namespace, name) pair is the identity a downstream listener uses to resolve the BigQuery table. Usually referred to as the FQN of a BigQuery asset. 

## A gotcha? The redundant config facet

```java
    private static final class BigQueryConfigFacet implements DatasetConfigFacet {
        private final Map<String, String> config;

        BigQueryConfigFacet(Map<String, String> config) {
            this.config = Collections.unmodifiableMap(config);
        }

        @Override
        public Map<String, String> config() {
            return config;
        }

        @Override
        public String name() {
            return CONFIG_FACET_NAME;
        }
    }
}
```
Note here the `name()` and `config()` are implemented differently. 

For DataStream jobs, (namespace, name) alone is sufficient. For FlinkSQL/Table jobs it is not: Flink's Table planner wraps the connector-provided dataset in TableLineageDatasetImpl, whose constructor overrides name() with the Flink object identifier (catalogatalog.my_database.my_table) while preservingnamespace() and facets(). The overwritten name no longer reflects the real BigQuery table. Publishing the true coordinates in a DatasetConfigFacet lets a downstream consumer recover project.dataset.table even after name() is overridden.

## How a downstream JobStatusChangedListener consumes this

End-to-end flow at job submission:

1. Flink calls getLineageVertex() on each sourceVertexProvider.
2. LineageGraphUtils assembles them into a LineageGraph — sources under sources(), sinks under sinks(), plus relations()
edges.
3. Flink fires a JobCreatedEvent (which extends JobStatusChangedEvent) exposing lineageGraph().
4. Each registered JobStatusChangedListener recetusChangedEvent). On a JobCreatedEvent, thelistener reads event.lineageGraph(), iterates sources()/sinks() → datasets(), and for each LineageDataset reads namespace()
+ name() (or recovers project.dataset.table from), then emits the source→sink lineage to anexternal catalog.

Listeners are registered via the execution.job-snfig (JobStatusChangedListenerFactory); noconnector-side change is needed to opt a job in.

Sketch of what a listener does with this:

```java
@Override
public void onEvent(JobStatusChangedEvent event) {
    if (event instanceof JobCreatedEvent created) {
        LineageGraph graph = created.lineageGrap
        for (SourceLineageVertex src : graph.sources()) {
            for (LineageDataset ds : src.dataset
                // ds.namespace() == "bigquery", ds.name() == "project.dataset.table",
                // or recover from ds.facets().get("bigquery") config facet
                emitCatalogNode(ds);
            }
        }
        graph.sinks().forEach(sink -> sink.datasets().forEach(this::emitCatalogNode));
        // relations() gives the source→sink edges
    }
}
```